### PR TITLE
Release/v1.0.6

### DIFF
--- a/backend/Dockerfile.celery
+++ b/backend/Dockerfile.celery
@@ -63,5 +63,7 @@ RUN if [ -f .gitmodules ]; then \
     git submodule update --init --recursive plugin/official || true; \
     fi
 
-# Celery 실행
-CMD ["/opt/micromamba/envs/snakemake/bin/python", "-m", "celery", "-A", "app.main.celery", "worker", "-n", "worker@%h", "--loglevel=info", "-E", "-Q", "workflow_task,plugin_task"]
+# Celery 실행 (shell form for env var substitution; default concurrency=12)
+CMD /opt/micromamba/envs/snakemake/bin/python -m celery -A app.main.celery worker \
+    -n worker@%h --loglevel=info -E -Q workflow_task,plugin_task \
+    -c ${CELERY_WORKER_CONCURRENCY:-12}

--- a/backend/Dockerfile.celery.prod
+++ b/backend/Dockerfile.celery.prod
@@ -63,5 +63,7 @@ RUN if [ -f .gitmodules ]; then \
     git submodule update --init --recursive plugin/official || true; \
     fi
 
-# Celery 실행 (Micromamba cellcraft-test env 내 python 사용)
-CMD ["/opt/micromamba/envs/cellcraft-test/bin/python", "-m", "celery", "-A", "app.main.celery", "worker", "-n", "worker@%h", "--loglevel=info", "-E", "-Q", "workflow_task,plugin_task"]
+# Celery 실행 (shell form for env var substitution; default concurrency=12)
+CMD /opt/micromamba/envs/cellcraft-test/bin/python -m celery -A app.main.celery worker \
+    -n worker@%h --loglevel=info -E -Q workflow_task,plugin_task \
+    -c ${CELERY_WORKER_CONCURRENCY:-12}

--- a/backend/Dockerfile.cpu.celery
+++ b/backend/Dockerfile.cpu.celery
@@ -93,5 +93,7 @@ COPY . .
 # Note: Git submodules are managed on the host and mounted via volumes
 # This ensures proper branch synchronization between host and container
 
-# Celery 실행
-CMD ["/opt/micromamba/envs/snakemake/bin/python", "-m", "celery", "-A", "app.main.celery", "worker", "-n", "worker@%h", "--loglevel=info", "-E", "-Q", "workflow_task,plugin_task"]
+# Celery 실행 (shell form for env var substitution; default concurrency=12)
+CMD /opt/micromamba/envs/snakemake/bin/python -m celery -A app.main.celery worker \
+    -n worker@%h --loglevel=info -E -Q workflow_task,plugin_task \
+    -c ${CELERY_WORKER_CONCURRENCY:-12}

--- a/backend/Dockerfile.dev.celery
+++ b/backend/Dockerfile.dev.celery
@@ -45,5 +45,7 @@ RUN if [ -f .gitmodules ]; then \
     git submodule update --init --recursive plugin/official || true; \
     fi
 
-# Celery 실행
-CMD ["/opt/micromamba/envs/snakemake/bin/python", "-m", "celery", "-A", "app.main.celery", "worker", "-n", "worker@%h", "--loglevel=info", "-E", "-Q", "workflow_task,plugin_task"]
+# Celery 실행 (shell form for env var substitution; default concurrency=12)
+CMD /opt/micromamba/envs/snakemake/bin/python -m celery -A app.main.celery worker \
+    -n worker@%h --loglevel=info -E -Q workflow_task,plugin_task \
+    -c ${CELERY_WORKER_CONCURRENCY:-12}

--- a/backend/Dockerfile.gpu.celery
+++ b/backend/Dockerfile.gpu.celery
@@ -85,5 +85,7 @@ COPY . .
 # Note: Git submodules are managed on the host and mounted via volumes
 # This ensures proper branch synchronization between host and container
 
-# Celery 실행
-CMD ["/opt/micromamba/envs/snakemake/bin/python", "-m", "celery", "-A", "app.main.celery", "worker", "-n", "worker@%h", "--loglevel=info", "-E", "-Q", "workflow_task,plugin_task"]
+# Celery 실행 (shell form for env var substitution; default concurrency=12)
+CMD /opt/micromamba/envs/snakemake/bin/python -m celery -A app.main.celery worker \
+    -n worker@%h --loglevel=info -E -Q workflow_task,plugin_task \
+    -c ${CELERY_WORKER_CONCURRENCY:-12}

--- a/backend/app/common/config.py
+++ b/backend/app/common/config.py
@@ -109,8 +109,10 @@ class Settings(BaseSettings):
     # File Upload Validation Configuration
     # ==============================================================================
 
-    # Maximum file size: 10GB for H5AD files (large scRNA-seq datasets)
-    MAX_UPLOAD_SIZE: int = 10 * 1024 * 1024 * 1024  # 10GB in bytes
+    # Maximum file size: 5GB for H5AD files (large scRNA-seq datasets)
+    # Note: sc.read_h5ad() loads entire file into memory during compression,
+    # so peak memory ≈ 1.0-1.3x file size. 5GB keeps peak under ~6.5GB.
+    MAX_UPLOAD_SIZE: int = 5 * 1024 * 1024 * 1024  # 5GB in bytes
 
     # Allowed file extensions for upload
     ALLOWED_EXTENSIONS: set = {".h5ad", ".csv", ".json", ".txt"}

--- a/backend/app/common/config.py
+++ b/backend/app/common/config.py
@@ -109,8 +109,8 @@ class Settings(BaseSettings):
     # File Upload Validation Configuration
     # ==============================================================================
 
-    # Maximum file size: 500MB for H5AD files (bioinformatics datasets can be large)
-    MAX_UPLOAD_SIZE: int = 500 * 1024 * 1024  # 500MB in bytes
+    # Maximum file size: 10GB for H5AD files (large scRNA-seq datasets)
+    MAX_UPLOAD_SIZE: int = 10 * 1024 * 1024 * 1024  # 10GB in bytes
 
     # Allowed file extensions for upload
     ALLOWED_EXTENSIONS: set = {".h5ad", ".csv", ".json", ".txt"}
@@ -125,6 +125,10 @@ class Settings(BaseSettings):
     # This prevents loading entire files into memory during upload
     # Memory usage: ~1MB per upload instead of up to 500MB
     UPLOAD_CHUNK_SIZE: int = 1024 * 1024  # 1MB in bytes
+
+    # H5AD Compression Configuration
+    H5AD_COMPRESSION_ENABLED: bool = True
+    H5AD_COMPRESSION_MIN_SIZE: int = 1 * 1024 * 1024  # 1MB
 
     # ==============================================================================
     # Security Configuration (OWASP Top 10 Compliance)
@@ -185,3 +189,7 @@ ENABLE_ANOMALY_DETECTION = settings.ENABLE_ANOMALY_DETECTION
 ANOMALY_PATH_TRAVERSAL_THRESHOLD = settings.ANOMALY_PATH_TRAVERSAL_THRESHOLD
 ANOMALY_FILE_SPOOFING_THRESHOLD = settings.ANOMALY_FILE_SPOOFING_THRESHOLD
 ANOMALY_USER_EVENTS_THRESHOLD = settings.ANOMALY_USER_EVENTS_THRESHOLD
+
+# Export H5AD compression configuration
+H5AD_COMPRESSION_ENABLED = settings.H5AD_COMPRESSION_ENABLED
+H5AD_COMPRESSION_MIN_SIZE = settings.H5AD_COMPRESSION_MIN_SIZE

--- a/backend/app/common/config.py
+++ b/backend/app/common/config.py
@@ -68,6 +68,11 @@ class Settings(BaseSettings):
             f"{values.get('POSTGRES_DB')}"
         )
 
+    # Redis Configuration
+    REDIS_URL: str = "redis://redis:6379/0"
+    DATATABLE_DF_CACHE_TTL: int = 3600  # 1 hour
+    PLUGIN_LIST_CACHE_TTL: int = 120    # 2 minutes
+
     # Celery configuration with proper defaults
     CELERY_BROKER_URL: str = "amqp://guest:guest@rabbitmq:5672//"
     CELERY_RESULT_BACKEND: Optional[str] = None

--- a/backend/app/common/config.py
+++ b/backend/app/common/config.py
@@ -73,6 +73,14 @@ class Settings(BaseSettings):
     DATATABLE_DF_CACHE_TTL: int = 3600  # 1 hour
     PLUGIN_LIST_CACHE_TTL: int = 120    # 2 minutes
 
+    # Resource Queue Configuration
+    RESOURCE_CPU_TOTAL: int = 0            # 0 = auto-detect (os.cpu_count()), positive = manual override
+    RESOURCE_GPU_TOTAL: int = 0            # 0 = auto-detect (GPU_COUNT env or GPUtil), positive = manual override
+    RESOURCE_DEFAULT_CPU_SLOTS: int = 4    # Default CPU slots per task (TENET baseline)
+    RESOURCE_DEFAULT_GPU_SLOTS: int = 1    # Default GPU slots per task (FastTENET baseline)
+    RESOURCE_POLL_INTERVAL: int = 10       # Retry interval when resources unavailable (seconds)
+    CELERY_WORKER_CONCURRENCY: int = 0     # 0 = auto-calculate (cpu_total // default_cpu_slots), positive = manual override
+
     # Celery configuration with proper defaults
     CELERY_BROKER_URL: str = "amqp://guest:guest@rabbitmq:5672//"
     CELERY_RESULT_BACKEND: Optional[str] = None

--- a/backend/app/common/utils/celery_utils.py
+++ b/backend/app/common/utils/celery_utils.py
@@ -1,43 +1,27 @@
 from celery import current_app as current_celery_app
 from celery.result import AsyncResult
-from celery.signals import celeryd_after_setup
-from kombu import Queue, Exchange
-import threading
-import GPUtil
-import psutil
-import time
+from celery.signals import worker_ready
+import logging
 
 from app.common.config import settings
 
-# 자원 사용량 제한 설정
-CPU_USAGE_LIMIT = 85  # CPU 사용량 제한
-MEMORY_USAGE_LIMIT = 90  # 메모리 사용량 제한
-GPU_USAGE_LIMIT = 90  # GPU 사용량 제한
+logger = logging.getLogger(__name__)
 
-def check_system_usage():
-    """ CPU, 메모리 및 GPU 사용량 확인 후 Celery Task 큐 컨트롤 """
-    while True:
-        cpu_usage = psutil.cpu_percent(interval=1)
-        memory_usage = psutil.virtual_memory().percent
-        gpus = GPUtil.getGPUs()
-        gpu_usage = max((gpu.load * 100 for gpu in gpus), default=0)
 
-        celery_app = current_celery_app
+@worker_ready.connect
+def on_worker_ready(sender, **kwargs):
+    """Initialize resource totals and clean up stale allocations on worker startup."""
+    from app.common.utils.resource_manager import (
+        initialize_resource_totals, cleanup_stale_resources
+    )
+    result = initialize_resource_totals()
+    cleanup_stale_resources()
+    logger.info(
+        f"Worker ready — resources initialized: "
+        f"CPU={result['cpu_total']}, GPU={result['gpu_total']}, "
+        f"concurrency={result['worker_concurrency']}"
+    )
 
-        print(f"💡 시스템 리소스 체크: CPU {cpu_usage}%, 메모리 {memory_usage}%, GPU {gpu_usage}%")
-
-        if cpu_usage >= CPU_USAGE_LIMIT or memory_usage >= MEMORY_USAGE_LIMIT or gpu_usage >= GPU_USAGE_LIMIT:
-            print(f"⚠️ 리소스 초과! (CPU: {cpu_usage}%, Memory: {memory_usage}%, GPU: {gpu_usage}%) → 큐 대기 중...")
-            # celery_app.control.pause_consumer("workflow_task")  # 특정 Task Queue 중지
-            celery_app.control.cancel_consumer("workflow_task")  # 특정 Task Queue 중지
-            celery_app.control.cancel_consumer("plugin_task")  # 플러그인 Task Queue 중지
-        else:
-            print(f"✅ 정상 상태 (CPU: {cpu_usage}%, Memory: {memory_usage}%, GPU: {gpu_usage}%) → 큐 실행 중...")
-            # celery_app.control.resume_consumer("workflow_task")  # 특정 Task Queue 다시 실행
-            celery_app.control.add_consumer("workflow_task")  # 특정 Task Queue 다시 실행
-            celery_app.control.add_consumer("plugin_task")  # 플러그인 Task Queue 다시 실행
-
-        time.sleep(5)  # 5초마다 상태 체크
 
 def create_celery():
     celery_app = current_celery_app
@@ -53,16 +37,20 @@ def create_celery():
     celery_app.conf.update(worker_send_task_events=True)
     celery_app.conf.update(worker_prefetch_multiplier=1)
 
-    # 긴 작업을 위한 타임아웃 설정 추가
+    # broker_transport_options 설정
+    # - visibility_timeout: acks_late=False이므로 실질적 영향 없음. 방어적으로 유지.
+    # - confirm_publish: 메시지 발행 확인 활성화
+    # - confirm_timeout: 발행 확인 타임아웃
     celery_app.conf.update(broker_transport_options={
-        'visibility_timeout': 259200,  # 긴 작업을 위한 visibility timeout 설정 (72시간)
-        'confirm_publish': True,  # 메시지 발행 확인 활성화
-        'confirm_timeout': 60.0  # 메시지 발행 확인을 위한 타임아웃 설정 (초 단위)
+        'visibility_timeout': 259200,
+        'confirm_publish': True,
+        'confirm_timeout': 10.0
     })
 
-    # Task Time Limits 설정 (72시간 제한, 소프트 타임아웃 71시간 56분)
-    celery_app.conf.update(task_time_limit=259200)  # 작업 시간 제한 (72시간)
-    celery_app.conf.update(task_soft_time_limit=258960)  # 소프트 타임아웃 설정 (71시간 56분)
+    # Task Time Limits 비활성화 — GRN inference 작업은 데이터셋에 따라 수일~수주 소요 가능
+    # None = 무제한. 작업 중단은 사용자가 UI에서 revoke로 수행.
+    celery_app.conf.update(task_time_limit=None)
+    celery_app.conf.update(task_soft_time_limit=None)
 
     # Celery 설정에서 ampq 연결 끊김 방지를 위한 연결 관련 옵션 조정
     celery_app.conf.update(
@@ -73,18 +61,11 @@ def create_celery():
         broker_connection_retry_delay=1,  # 재시도 간격 (초 단위)
         broker_connection_retry_jitter=False,  # 재시도 간격 랜덤화 비활성화
     )
-    celery_app.conf.broker_transport_options = {'confirm_publish': True, 'confirm_timeout': 10.0}
 
-    # 라우팅 설정 활성화 (큐별 라우팅을 위해 필요)
-    # celery_app.conf.task_routes = None  # 기본 설정으로 돌아감
-
-    # 작업자(worker) 동시성 제한 설정 수정
+    # 작업자(worker) 동시성 제한 설정
     celery_app.conf.update(
         task_reject_on_worker_lost=True  # 워커 손실 시 작업 거부
     )
-
-    # monitoring_thread = threading.Thread(target=check_system_usage, daemon=True)
-    # monitoring_thread.start()
 
     return celery_app
 

--- a/backend/app/common/utils/datatable_cache.py
+++ b/backend/app/common/utils/datatable_cache.py
@@ -1,0 +1,59 @@
+"""
+DataTable DataFrame caching via Redis.
+
+Caches the parsed DataFrame (obs + UMAP/PCA) from load_tab_file()
+so that page/sort/filter changes don't re-read the entire h5ad file.
+
+Cache key includes file mtime for automatic invalidation on file changes.
+Pickle is used for serialization — safe because only trusted internal
+DataFrames are serialized, never external/user-supplied data.
+"""
+import os
+import pickle
+import logging
+from typing import Optional
+
+import pandas as pd
+
+from app.common.utils.redis_cache import cache_get_bytes, cache_set_bytes, cache_delete_pattern
+from app.common.config import settings
+
+logger = logging.getLogger(__name__)
+
+MAX_CACHEABLE_SIZE_MB = 200
+
+
+def _make_key(filepath: str) -> str:
+    mtime = os.path.getmtime(filepath)
+    return f"datatable:df:{filepath}:{mtime}"
+
+
+def get_cached_dataframe(filepath: str) -> Optional[pd.DataFrame]:
+    key = _make_key(filepath)
+    data = cache_get_bytes(key)
+    if data is None:
+        return None
+    try:
+        return pickle.loads(data)
+    except Exception as e:
+        logger.warning(f"DataFrame unpickle failed for {key}: {e}")
+        return None
+
+
+def set_cached_dataframe(filepath: str, df: pd.DataFrame) -> bool:
+    size_mb = df.memory_usage(deep=True).sum() / (1024 * 1024)
+    if size_mb > MAX_CACHEABLE_SIZE_MB:
+        logger.info(f"DataFrame too large to cache: {size_mb:.0f}MB > {MAX_CACHEABLE_SIZE_MB}MB")
+        return False
+
+    key = _make_key(filepath)
+    try:
+        data = pickle.dumps(df, protocol=pickle.HIGHEST_PROTOCOL)
+        return cache_set_bytes(key, data, settings.DATATABLE_DF_CACHE_TTL)
+    except Exception as e:
+        logger.warning(f"DataFrame pickle/cache failed for {key}: {e}")
+        return False
+
+
+def invalidate_datatable(filepath: str) -> int:
+    return cache_delete_pattern(f"datatable:df:{filepath}:*")

--- a/backend/app/common/utils/datatable_cache.py
+++ b/backend/app/common/utils/datatable_cache.py
@@ -7,6 +7,9 @@ so that page/sort/filter changes don't re-read the entire h5ad file.
 Cache key includes file mtime for automatic invalidation on file changes.
 Pickle is used for serialization — safe because only trusted internal
 DataFrames are serialized, never external/user-supplied data.
+
+SECURITY: Never store user-supplied or externally-sourced objects in this cache.
+pickle.loads() can execute arbitrary code — only cache internally-generated DataFrames.
 """
 import os
 import pickle

--- a/backend/app/common/utils/datatable_utils.py
+++ b/backend/app/common/utils/datatable_utils.py
@@ -1,9 +1,10 @@
 import pandas as pd
-from typing import Dict, List
+from typing import Dict, List, Optional
 from pydantic import BaseModel
 
 class DataTableBase(BaseModel):
     file_name: str
+    source: Optional[str] = None  # "user" | "shared"
 
 class Sort(BaseModel):
     field: str

--- a/backend/app/common/utils/file_path_resolver.py
+++ b/backend/app/common/utils/file_path_resolver.py
@@ -1,0 +1,31 @@
+import os
+from fastapi import HTTPException
+from app.common.utils.file_security import validate_file_path
+
+SHARED_DIR = './tutorials'
+
+
+def resolve_data_file_path(filename: str, username: str, source: str = None) -> str:
+    """사용자 파일 또는 공용(tutorials) 파일의 경로를 반환한다.
+
+    Args:
+        filename: 파일명
+        username: 현재 사용자 이름
+        source: "user" | "shared" | None (None은 "user"로 취급)
+
+    Returns:
+        검증된 파일 경로 문자열
+
+    Raises:
+        HTTPException: source 값이 유효하지 않거나 경로 순회 공격이 감지된 경우
+    """
+    if source == "shared":
+        folder_path = SHARED_DIR
+    elif source == "user" or source is None:
+        folder_path = f"./user/{username}/data"
+    else:
+        raise HTTPException(status_code=400, detail=f"Invalid file source: {source}")
+
+    file_path = os.path.join(folder_path, filename)
+    validate_file_path(folder_path, file_path)
+    return file_path

--- a/backend/app/common/utils/h5ad_compression.py
+++ b/backend/app/common/utils/h5ad_compression.py
@@ -2,6 +2,11 @@
 
 Compresses uploaded H5AD files using HDF5 internal gzip compression.
 sc.read_h5ad() transparently decompresses, so no downstream code changes needed.
+
+Memory safety: sc.read_h5ad() loads the entire file into memory (~1.0-1.3x file size
+for uncompressed files, ~2-4x for already-compressed files). To prevent OOM,
+already-compressed files are detected via h5py metadata and skipped — they would
+not benefit from re-compression anyway.
 """
 
 import gc
@@ -11,6 +16,7 @@ import shutil
 import tempfile
 from typing import Tuple
 
+import h5py
 import scanpy as sc
 
 logger = logging.getLogger(__name__)
@@ -19,6 +25,30 @@ logger = logging.getLogger(__name__)
 # Some H5AD files (e.g., from older pipelines) have '_index' in raw.var or obs,
 # which causes write_h5ad() to raise ValueError.
 _ANNDATA_RESERVED_COLUMNS = {"_index"}
+
+
+def _is_already_compressed(file_path: str) -> bool:
+    """Check if the main X dataset in an H5AD file already has HDF5 compression.
+
+    Uses h5py to read only file metadata (no data loaded into memory).
+    Returns True if compression is detected, False otherwise.
+    On any error, returns False to allow the normal compression path.
+    """
+    try:
+        with h5py.File(file_path, "r") as f:
+            if "X" not in f:
+                return False
+            x = f["X"]
+            # Dense X: stored as a single Dataset
+            if isinstance(x, h5py.Dataset):
+                return x.compression is not None
+            # Sparse X (CSR/CSC): stored as a Group with 'data' dataset
+            if isinstance(x, h5py.Group) and "data" in x:
+                return x["data"].compression is not None
+        return False
+    except Exception as e:
+        logger.debug("Could not check compression for %s: %s", file_path, e)
+        return False
 
 
 def _fix_reserved_columns(adata) -> None:
@@ -78,6 +108,16 @@ def compress_h5ad_file(
         )
         return False, original_size
 
+    # Skip already-compressed files to avoid OOM: sc.read_h5ad() would decompress
+    # the entire dataset into memory (~2-4x file size), and re-compression would
+    # produce a similar-sized file anyway.
+    if _is_already_compressed(file_path):
+        logger.info(
+            "Skipping already-compressed H5AD file: %s (%d bytes)",
+            file_path, original_size,
+        )
+        return False, original_size
+
     tmp_fd = None
     tmp_path = None
     adata = None
@@ -127,10 +167,5 @@ def compress_h5ad_file(
         if tmp_path is not None and os.path.exists(tmp_path):
             try:
                 os.remove(tmp_path)
-            except OSError:
-                pass
-        if tmp_fd is not None:
-            try:
-                os.close(tmp_fd)
             except OSError:
                 pass

--- a/backend/app/common/utils/h5ad_compression.py
+++ b/backend/app/common/utils/h5ad_compression.py
@@ -1,0 +1,136 @@
+"""H5AD file compression utility.
+
+Compresses uploaded H5AD files using HDF5 internal gzip compression.
+sc.read_h5ad() transparently decompresses, so no downstream code changes needed.
+"""
+
+import gc
+import logging
+import os
+import shutil
+import tempfile
+from typing import Tuple
+
+import scanpy as sc
+
+logger = logging.getLogger(__name__)
+
+# anndata 0.8.0 reserves '_index' as a column name.
+# Some H5AD files (e.g., from older pipelines) have '_index' in raw.var or obs,
+# which causes write_h5ad() to raise ValueError.
+_ANNDATA_RESERVED_COLUMNS = {"_index"}
+
+
+def _fix_reserved_columns(adata) -> None:
+    """Rename reserved column names in-place so write_h5ad() succeeds."""
+    for attr_name in ("obs", "var"):
+        df = getattr(adata, attr_name, None)
+        if df is not None:
+            conflicts = _ANNDATA_RESERVED_COLUMNS & set(df.columns)
+            if conflicts:
+                rename_map = {c: f"{c}_original" for c in conflicts}
+                df.rename(columns=rename_map, inplace=True)
+                logger.info("Renamed reserved columns in %s: %s", attr_name, rename_map)
+
+    # raw.var is accessed via adata.raw.var (Raw object)
+    if adata.raw is not None:
+        raw_var = adata.raw.var
+        conflicts = _ANNDATA_RESERVED_COLUMNS & set(raw_var.columns)
+        if conflicts:
+            rename_map = {c: f"{c}_original" for c in conflicts}
+            raw_var_fixed = raw_var.rename(columns=rename_map)
+            # Reconstruct raw with fixed var (Raw is immutable, so recreate)
+            import anndata
+            adata._raw = anndata.Raw(
+                adata,
+                X=adata.raw.X,
+                var=raw_var_fixed,
+                varm=adata.raw.varm if hasattr(adata.raw, "varm") else None,
+            )
+            logger.info("Renamed reserved columns in raw.var: %s", rename_map)
+
+
+def compress_h5ad_file(
+    file_path: str,
+    min_size_bytes: int = 1 * 1024 * 1024,
+    compression: str = "gzip",
+) -> Tuple[bool, int]:
+    """Compress an H5AD file in-place using HDF5 internal compression.
+
+    Args:
+        file_path: Absolute path to the .h5ad file.
+        min_size_bytes: Skip compression if file is smaller than this (default 1MB).
+        compression: HDF5 compression algorithm (default 'gzip').
+
+    Returns:
+        (compressed, final_size): Whether compression was applied, and the final file size in bytes.
+    """
+    if not file_path.lower().endswith(".h5ad"):
+        logger.debug("Skipping non-H5AD file: %s", file_path)
+        return False, os.path.getsize(file_path)
+
+    original_size = os.path.getsize(file_path)
+
+    if original_size < min_size_bytes:
+        logger.debug(
+            "Skipping compression for %s (size %d < min %d)",
+            file_path, original_size, min_size_bytes,
+        )
+        return False, original_size
+
+    tmp_fd = None
+    tmp_path = None
+    adata = None
+
+    try:
+        # Create temp file in same directory to ensure same filesystem (atomic move)
+        dir_name = os.path.dirname(file_path)
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".h5ad.tmp", dir=dir_name)
+        os.close(tmp_fd)
+        tmp_fd = None
+
+        adata = sc.read_h5ad(file_path)
+        _fix_reserved_columns(adata)
+        adata.write_h5ad(tmp_path, compression=compression)
+
+        compressed_size = os.path.getsize(tmp_path)
+
+        if compressed_size < original_size:
+            shutil.move(tmp_path, file_path)
+            tmp_path = None  # Moved successfully, don't clean up
+            savings_pct = (1 - compressed_size / original_size) * 100
+            logger.info(
+                "Compressed %s: %d -> %d bytes (%.1f%% reduction)",
+                file_path, original_size, compressed_size, savings_pct,
+            )
+            return True, compressed_size
+        else:
+            logger.info(
+                "Compression not beneficial for %s (%d >= %d), keeping original",
+                file_path, compressed_size, original_size,
+            )
+            return False, original_size
+
+    except Exception:
+        logger.warning(
+            "Failed to compress %s, keeping original file",
+            file_path, exc_info=True,
+        )
+        return False, original_size
+
+    finally:
+        if adata is not None:
+            del adata
+        gc.collect()
+
+        # Clean up temp file if it still exists
+        if tmp_path is not None and os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass

--- a/backend/app/common/utils/h5ad_metadata_cache.py
+++ b/backend/app/common/utils/h5ad_metadata_cache.py
@@ -1,0 +1,69 @@
+"""
+h5ad metadata in-process cache using cachetools.TTLCache.
+
+Caches lightweight metadata (column names, cluster lists) to avoid
+re-reading entire h5ad files via scanpy.read_h5ad() on every request.
+
+Design decisions:
+- In-process TTLCache (not Redis) because cached data is <1KB per entry,
+  backend runs a single Uvicorn worker, and Celery never calls these endpoints.
+- Cache key includes file mtime for automatic invalidation on file changes.
+- Thread lock guards concurrent access from async endpoint threads.
+- Explicit invalidate_file() called on file deletion for immediate purge.
+"""
+
+import os
+import threading
+from typing import Optional, Dict, Any, List
+
+from cachetools import TTLCache
+
+_lock = threading.Lock()
+_columns_cache: TTLCache = TTLCache(maxsize=500, ttl=86400)  # 24h
+_clusters_cache: TTLCache = TTLCache(maxsize=500, ttl=86400)
+
+
+def _make_columns_key(filepath: str) -> str:
+    mtime = os.path.getmtime(filepath)
+    return f"{filepath}:{mtime}"
+
+
+def _make_clusters_key(filepath: str, anno_column: str) -> str:
+    mtime = os.path.getmtime(filepath)
+    return f"{filepath}:{anno_column}:{mtime}"
+
+
+def get_cached_columns(filepath: str) -> Optional[Dict[str, Any]]:
+    key = _make_columns_key(filepath)
+    with _lock:
+        return _columns_cache.get(key)
+
+
+def set_cached_columns(filepath: str, data: Dict[str, Any]) -> None:
+    key = _make_columns_key(filepath)
+    with _lock:
+        _columns_cache[key] = data
+
+
+def get_cached_clusters(filepath: str, anno_column: str) -> Optional[List[str]]:
+    key = _make_clusters_key(filepath, anno_column)
+    with _lock:
+        return _clusters_cache.get(key)
+
+
+def set_cached_clusters(filepath: str, anno_column: str, data: List[str]) -> None:
+    key = _make_clusters_key(filepath, anno_column)
+    with _lock:
+        _clusters_cache[key] = data
+
+
+def invalidate_file(filepath: str) -> int:
+    """Remove all cache entries for the given file path."""
+    count = 0
+    with _lock:
+        for cache in (_columns_cache, _clusters_cache):
+            keys_to_del = [k for k in cache if k.startswith(filepath + ":")]
+            for k in keys_to_del:
+                del cache[k]
+                count += 1
+    return count

--- a/backend/app/common/utils/h5ad_utils.py
+++ b/backend/app/common/utils/h5ad_utils.py
@@ -57,23 +57,23 @@ def organize_column_dtypes(data_frame):
             df[column] = df[column].astype('category')
     return df
 
-def get_annotation_columns(data_frame):
+def get_annotation_columns(data_frame, organized=False):
     '''
     유저가 tenet을 돌리고 싶은 부분을 선택할 때에 다양한 annotation을 기준으로
-    선택하고 싶을 수 있습니다. 범주형 데이터는 모두 그런 annotation이 될 수 
+    선택하고 싶을 수 있습니다. 범주형 데이터는 모두 그런 annotation이 될 수
     있다고 가정하고 모든 범주형 column의 이름을 추출합니다.
     '''
-    df = organize_column_dtypes(data_frame.copy())
+    df = data_frame if organized else organize_column_dtypes(data_frame.copy())
     return list(df.columns[np.where(np.char.startswith(list(map(str,df.dtypes)), 'category'))[0]])
 
-def get_pseudotime_columns(data_frame):
+def get_pseudotime_columns(data_frame, organized=False):
     '''
     유저가 다양한 방식으로 pseudotime을 구하고 pseudotime 값을 저장한 column 개수가
     여러 개인 상황을 가정했습니다. pseudotime 데이터는 연속형으로 나오기 때문에 연속형
     데이터인 column은 모두 pseudotime에 관련된 데이터일 수 있다고 가정하고 모든 연속형
     column의 이름을 추출합니다.
     '''
-    df = organize_column_dtypes(data_frame.copy())
+    df = data_frame if organized else organize_column_dtypes(data_frame.copy())
     numeric_columns = df.select_dtypes(include=['float', 'int']).columns
     return list(numeric_columns)
 

--- a/backend/app/common/utils/plugin_cache.py
+++ b/backend/app/common/utils/plugin_cache.py
@@ -1,0 +1,54 @@
+"""
+Plugin list caching via Redis.
+
+Caches the /plugin/list response per user so that repeated modal opens
+(Algorithm, Visualization) don't re-query the database and Docker daemon.
+
+Uses JSON serialization — plugin list data is plain dicts/strings.
+On Redis failure, operations silently return None / skip,
+allowing the application to fall back to the original query path.
+"""
+import json
+import logging
+from typing import Optional
+
+from app.common.utils.redis_cache import cache_get_bytes, cache_set_bytes, cache_delete_pattern
+from app.common.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _make_key(user_id: int) -> str:
+    return f"plugin:list:{user_id}"
+
+
+def get_cached_plugin_list(user_id: int) -> Optional[dict]:
+    """Get cached plugin list response for a user. Returns None on miss or error."""
+    data = cache_get_bytes(_make_key(user_id))
+    if data is None:
+        return None
+    try:
+        return json.loads(data)
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        logger.warning(f"Plugin cache JSON decode failed for user {user_id}: {e}")
+        return None
+
+
+def set_cached_plugin_list(user_id: int, data: dict) -> bool:
+    """Cache plugin list response for a user."""
+    try:
+        payload = json.dumps(data, default=str).encode("utf-8")
+        return cache_set_bytes(_make_key(user_id), payload, settings.PLUGIN_LIST_CACHE_TTL)
+    except (TypeError, ValueError) as e:
+        logger.warning(f"Plugin cache JSON encode failed for user {user_id}: {e}")
+        return False
+
+
+def invalidate_plugin_cache_for_user(user_id: int) -> int:
+    """Invalidate cached plugin list for a specific user."""
+    return cache_delete_pattern(f"plugin:list:{user_id}")
+
+
+def invalidate_all_plugin_cache() -> int:
+    """Invalidate cached plugin list for all users."""
+    return cache_delete_pattern("plugin:list:*")

--- a/backend/app/common/utils/redis_cache.py
+++ b/backend/app/common/utils/redis_cache.py
@@ -1,0 +1,66 @@
+"""
+Redis cache layer with graceful fallback.
+
+On Redis failure, operations silently return None (get) or skip (set),
+allowing the application to fall back to the original data loading path.
+"""
+import logging
+from typing import Optional
+
+import redis
+
+from app.common.config import settings
+
+logger = logging.getLogger(__name__)
+
+_pool: Optional[redis.ConnectionPool] = None
+
+
+def _get_pool() -> redis.ConnectionPool:
+    global _pool
+    if _pool is None:
+        _pool = redis.ConnectionPool.from_url(
+            settings.REDIS_URL,
+            max_connections=20,
+            decode_responses=False,
+        )
+    return _pool
+
+
+def get_redis_client() -> redis.Redis:
+    return redis.Redis(connection_pool=_get_pool())
+
+
+def cache_get_bytes(key: str) -> Optional[bytes]:
+    """Get binary data from cache (for DataFrame serialization)."""
+    try:
+        client = get_redis_client()
+        return client.get(key)
+    except redis.RedisError as e:
+        logger.warning(f"Redis cache_get_bytes failed for {key}: {e}")
+        return None
+
+
+def cache_set_bytes(key: str, value: bytes, ttl: int) -> bool:
+    """Set binary data in cache with TTL."""
+    try:
+        client = get_redis_client()
+        client.setex(key, ttl, value)
+        return True
+    except redis.RedisError as e:
+        logger.warning(f"Redis cache_set_bytes failed for {key}: {e}")
+        return False
+
+
+def cache_delete_pattern(pattern: str) -> int:
+    """Delete all keys matching a pattern using SCAN (non-blocking)."""
+    try:
+        client = get_redis_client()
+        count = 0
+        for key in client.scan_iter(match=pattern, count=100):
+            client.delete(key)
+            count += 1
+        return count
+    except redis.RedisError as e:
+        logger.warning(f"Redis cache_delete_pattern failed for {pattern}: {e}")
+        return 0

--- a/backend/app/common/utils/resource_manager.py
+++ b/backend/app/common/utils/resource_manager.py
@@ -268,6 +268,12 @@ def get_resource_status() -> Optional[dict]:
     """
     Return comprehensive resource status for the monitoring API.
     Returns None on Redis failure (caller should return HTTP 503).
+
+    Includes:
+    - cpu/gpu slot allocation from Redis semaphore
+    - host memory via psutil (~1ms)
+    - GPU device details via GPUtil (optional)
+    - running task list from Redis
     """
     try:
         client = get_redis_client()
@@ -275,6 +281,38 @@ def get_resource_status() -> Optional[dict]:
         gpu_total = int(client.get("resource:gpu:total") or 0)
         cpu_used = int(client.get("resource:cpu:used") or 0)
         gpu_used = int(client.get("resource:gpu:used") or 0)
+
+        # Host memory via psutil
+        memory_info = None
+        try:
+            import psutil
+            vm = psutil.virtual_memory()
+            memory_info = {
+                'total_bytes': vm.total,
+                'used_bytes': vm.used,
+                'available_bytes': vm.available,
+                'percent': vm.percent,
+            }
+        except Exception:
+            pass
+
+        # GPU device details (only when GPUs are present)
+        gpu_devices = []
+        if gpu_total > 0:
+            try:
+                import GPUtil
+                for gpu in GPUtil.getGPUs():
+                    gpu_devices.append({
+                        'id': gpu.id,
+                        'name': gpu.name,
+                        'load_percent': round(gpu.load * 100, 1),
+                        'memory_total_bytes': int(gpu.memoryTotal * 1024 * 1024),
+                        'memory_used_bytes': int(gpu.memoryUsed * 1024 * 1024),
+                        'memory_free_bytes': int(gpu.memoryFree * 1024 * 1024),
+                        'temperature_c': gpu.temperature,
+                    })
+            except Exception:
+                pass
 
         # Collect running task allocations
         tasks = []
@@ -308,6 +346,8 @@ def get_resource_status() -> Optional[dict]:
                 'used': gpu_used,
                 'available': max(0, gpu_total - gpu_used),
             },
+            'memory': memory_info,
+            'gpu_devices': gpu_devices,
             'tasks': tasks,
         }
 

--- a/backend/app/common/utils/resource_manager.py
+++ b/backend/app/common/utils/resource_manager.py
@@ -1,0 +1,316 @@
+"""
+Redis-based resource semaphore for Celery task queue gating.
+
+Uses Lua scripts for atomic check-and-increment operations to prevent
+race conditions. On Redis failure, all operations fall back to ungated
+execution (acquire returns True, release is a no-op).
+
+Redis key schema:
+  resource:cpu:total   - Total CPU slots
+  resource:gpu:total   - Total GPU slots
+  resource:cpu:used    - Currently used CPU slots
+  resource:gpu:used    - Currently used GPU slots
+  resource:task:{id}   - Per-task allocation hash (type, slots, plugin_name, started_at)
+"""
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+import redis
+
+from app.common.config import settings
+from app.common.utils.redis_cache import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lua scripts for atomic Redis operations
+# ---------------------------------------------------------------------------
+
+# Atomically check available capacity and increment used counter.
+# Returns 1 on success (slots acquired), 0 on failure (insufficient capacity).
+_LUA_ACQUIRE = """
+local total_key = KEYS[1]
+local used_key  = KEYS[2]
+local task_key  = KEYS[3]
+local requested = tonumber(ARGV[1])
+local rtype     = ARGV[2]
+local plugin    = ARGV[3]
+local started   = ARGV[4]
+
+local total = tonumber(redis.call('GET', total_key) or 0)
+local used  = tonumber(redis.call('GET', used_key) or 0)
+
+if used + requested <= total then
+    redis.call('INCRBY', used_key, requested)
+    redis.call('HSET', task_key,
+        'type', rtype,
+        'slots', requested,
+        'plugin_name', plugin,
+        'started_at', started)
+    return 1
+end
+return 0
+"""
+
+# Atomically decrement used counter and delete task key.
+# Ensures used never goes below 0.
+_LUA_RELEASE = """
+local used_key = KEYS[1]
+local task_key = KEYS[2]
+local slots    = tonumber(ARGV[1])
+
+local used = tonumber(redis.call('GET', used_key) or 0)
+local new_used = used - slots
+if new_used < 0 then
+    new_used = 0
+end
+redis.call('SET', used_key, new_used)
+redis.call('DEL', task_key)
+return new_used
+"""
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection helpers
+# ---------------------------------------------------------------------------
+
+def detect_cpu_count() -> int:
+    """Detect total CPU slots. Uses config override if set, else os.cpu_count()."""
+    if settings.RESOURCE_CPU_TOTAL > 0:
+        return settings.RESOURCE_CPU_TOTAL
+    count = os.cpu_count()
+    return count if count else 4  # fallback
+
+
+def detect_gpu_count() -> int:
+    """Detect total GPU devices. Priority: config > GPU_COUNT env > GPUtil > 0."""
+    if settings.RESOURCE_GPU_TOTAL > 0:
+        return settings.RESOURCE_GPU_TOTAL
+    env_val = os.environ.get('GPU_COUNT')
+    if env_val is not None:
+        try:
+            return int(env_val)
+        except (ValueError, TypeError):
+            pass
+    try:
+        import GPUtil
+        return len(GPUtil.getGPUs())
+    except Exception:
+        pass
+    return 0
+
+
+def detect_worker_concurrency(cpu_total: int) -> int:
+    """Calculate optimal worker concurrency from CPU total and default slot size."""
+    if settings.CELERY_WORKER_CONCURRENCY > 0:
+        return settings.CELERY_WORKER_CONCURRENCY
+    return max(1, cpu_total // settings.RESOURCE_DEFAULT_CPU_SLOTS)
+
+
+# ---------------------------------------------------------------------------
+# Core resource operations
+# ---------------------------------------------------------------------------
+
+def acquire_slots(resource_type: str, slots: int, task_id: str,
+                  plugin_name: str = '') -> bool:
+    """
+    Atomically acquire resource slots for a task.
+
+    Returns True if slots were acquired, False if insufficient capacity.
+    On Redis failure, returns True (graceful fallback — ungated execution).
+    """
+    try:
+        client = get_redis_client()
+        total_key = f"resource:{resource_type}:total"
+        used_key = f"resource:{resource_type}:used"
+        task_key = f"resource:task:{task_id}"
+        started = datetime.now(timezone.utc).isoformat()
+
+        result = client.eval(
+            _LUA_ACQUIRE, 3,
+            total_key, used_key, task_key,
+            slots, resource_type, plugin_name, started,
+        )
+        acquired = int(result) == 1
+        if acquired:
+            logger.info(
+                f"Resource acquired: task={task_id} type={resource_type} "
+                f"slots={slots} plugin={plugin_name}"
+            )
+        else:
+            logger.info(
+                f"Resource unavailable: task={task_id} type={resource_type} "
+                f"slots={slots} — will retry"
+            )
+        return acquired
+
+    except redis.RedisError as e:
+        logger.warning(
+            f"Redis error in acquire_slots for task {task_id}: {e}. "
+            "Falling back to ungated execution."
+        )
+        return True
+
+
+def release_slots(resource_type: str, slots: int, task_id: str) -> None:
+    """
+    Atomically release resource slots for a task.
+    Safe to call multiple times — Lua script prevents negative counters.
+    """
+    try:
+        client = get_redis_client()
+        used_key = f"resource:{resource_type}:used"
+        task_key = f"resource:task:{task_id}"
+        client.eval(_LUA_RELEASE, 2, used_key, task_key, slots)
+        logger.info(
+            f"Resource released: task={task_id} type={resource_type} slots={slots}"
+        )
+    except redis.RedisError as e:
+        logger.warning(f"Redis error in release_slots for task {task_id}: {e}")
+
+
+def release_slots_by_task_id(task_id: str) -> bool:
+    """
+    Look up the task's allocation hash and release its slots.
+    Used as a safety net in after_return when kwargs may not be available.
+    Returns True if slots were released, False if no allocation found.
+    """
+    try:
+        client = get_redis_client()
+        task_key = f"resource:task:{task_id}"
+        info = client.hgetall(task_key)
+        if not info:
+            return False
+
+        resource_type = info.get(b'type', info.get('type', b'cpu'))
+        slots = info.get(b'slots', info.get('slots', b'0'))
+        # Decode bytes if needed
+        if isinstance(resource_type, bytes):
+            resource_type = resource_type.decode()
+        if isinstance(slots, bytes):
+            slots = slots.decode()
+
+        release_slots(resource_type, int(slots), task_id)
+        return True
+
+    except redis.RedisError as e:
+        logger.warning(f"Redis error in release_slots_by_task_id for {task_id}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Initialization (called on worker_ready)
+# ---------------------------------------------------------------------------
+
+def initialize_resource_totals() -> dict:
+    """
+    Detect system resources and write totals to Redis.
+    Called once on worker startup via worker_ready signal.
+    Returns dict with detected values for logging.
+    """
+    cpu_total = detect_cpu_count()
+    gpu_total = detect_gpu_count()
+    concurrency = detect_worker_concurrency(cpu_total)
+
+    cpu_source = "config" if settings.RESOURCE_CPU_TOTAL > 0 else "auto"
+    gpu_source = (
+        "config" if settings.RESOURCE_GPU_TOTAL > 0
+        else ("env:GPU_COUNT" if os.environ.get('GPU_COUNT') else "auto")
+    )
+
+    try:
+        client = get_redis_client()
+        client.set("resource:cpu:total", cpu_total)
+        client.set("resource:gpu:total", gpu_total)
+        logger.info(
+            f"Resource detection: CPU={cpu_total} ({cpu_source}), "
+            f"GPU={gpu_total} ({gpu_source}), "
+            f"Worker concurrency={concurrency}"
+        )
+    except redis.RedisError as e:
+        logger.warning(f"Redis error in initialize_resource_totals: {e}")
+
+    return {
+        'cpu_total': cpu_total,
+        'gpu_total': gpu_total,
+        'worker_concurrency': concurrency,
+    }
+
+
+def cleanup_stale_resources() -> None:
+    """
+    Reset used counters and remove stale task keys on worker startup.
+    Safe for single-worker architecture — assumes no other worker holds slots.
+    """
+    try:
+        client = get_redis_client()
+        # Reset used counters
+        client.set("resource:cpu:used", 0)
+        client.set("resource:gpu:used", 0)
+        # Remove stale task allocation keys
+        count = 0
+        for key in client.scan_iter(match="resource:task:*", count=100):
+            client.delete(key)
+            count += 1
+        if count > 0:
+            logger.info(f"Cleaned up {count} stale resource task key(s)")
+    except redis.RedisError as e:
+        logger.warning(f"Redis error in cleanup_stale_resources: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Monitoring API helper
+# ---------------------------------------------------------------------------
+
+def get_resource_status() -> Optional[dict]:
+    """
+    Return comprehensive resource status for the monitoring API.
+    Returns None on Redis failure (caller should return HTTP 503).
+    """
+    try:
+        client = get_redis_client()
+        cpu_total = int(client.get("resource:cpu:total") or 0)
+        gpu_total = int(client.get("resource:gpu:total") or 0)
+        cpu_used = int(client.get("resource:cpu:used") or 0)
+        gpu_used = int(client.get("resource:gpu:used") or 0)
+
+        # Collect running task allocations
+        tasks = []
+        for key in client.scan_iter(match="resource:task:*", count=100):
+            info = client.hgetall(key)
+            if not info:
+                continue
+            # Extract task_id from key pattern "resource:task:{task_id}"
+            key_str = key.decode() if isinstance(key, bytes) else key
+            task_id = key_str.replace("resource:task:", "", 1)
+
+            def _decode(val):
+                return val.decode() if isinstance(val, bytes) else val
+
+            tasks.append({
+                'task_id': task_id,
+                'resource_type': _decode(info.get(b'type', info.get('type', b''))),
+                'resource_slots': int(_decode(info.get(b'slots', info.get('slots', b'0')))),
+                'plugin_name': _decode(info.get(b'plugin_name', info.get('plugin_name', b''))),
+                'started_at': _decode(info.get(b'started_at', info.get('started_at', b''))),
+            })
+
+        return {
+            'cpu': {
+                'total': cpu_total,
+                'used': cpu_used,
+                'available': max(0, cpu_total - cpu_used),
+            },
+            'gpu': {
+                'total': gpu_total,
+                'used': gpu_used,
+                'available': max(0, gpu_total - gpu_used),
+            },
+            'tasks': tasks,
+        }
+
+    except redis.RedisError as e:
+        logger.warning(f"Redis error in get_resource_status: {e}")
+        return None

--- a/backend/app/common/utils/workflow_utils.py
+++ b/backend/app/common/utils/workflow_utils.py
@@ -98,14 +98,22 @@ def load_tab_file(file_path: str):
                     df = pd.concat([df, pca_df], axis=1)
                 # 둘 다 없는 경우 raw 데이터에서 처음 두 컬럼 사용
                 else:
+                    # sparse matrix인 경우 dense로 변환
+                    from scipy.sparse import issparse
                     # 데이터가 1차원인 경우 처리
                     if adata.X.shape[1] == 1:
+                        col_data = adata.X[:, 0]
+                        if issparse(col_data):
+                            col_data = col_data.toarray().ravel()
                         raw_df = pd.DataFrame({
-                            'X': adata.X[:, 0],
+                            'X': col_data,
                             'Y': np.zeros(adata.X.shape[0])  # Y값을 0으로 설정
                         }, index=adata.obs.index)
                     else:
-                        raw_df = pd.DataFrame(adata.X[:, :2], columns=['X', 'Y'], index=adata.obs.index)
+                        col_data = adata.X[:, :2]
+                        if issparse(col_data):
+                            col_data = col_data.toarray()
+                        raw_df = pd.DataFrame(col_data, columns=['X', 'Y'], index=adata.obs.index)
                     df = pd.concat([df, raw_df], axis=1)
 
                 logger.debug(f"Successfully loaded H5AD file with {df.shape[0]} observations")

--- a/backend/app/common/utils/workflow_utils.py
+++ b/backend/app/common/utils/workflow_utils.py
@@ -280,19 +280,63 @@ def extract_visualization_data(workflow_info, node_id):
     # "Visualization" 클래스를 가진 객체가 없을 경우 빈 딕셔너리 반환
     return {}
 
-def generate_user_input(selectedPluginInputOutput):
+def generate_user_input(selectedPluginInputOutput, username=None, file_sources=None):
+    """
+    플러그인 입출력 파라미터에서 사용자 입력 파일 매핑을 생성한다.
+
+    Args:
+        selectedPluginInputOutput: 플러그인 입출력 파라미터 배열
+        username: 유저명 (전체 경로 구성 시 사용)
+        file_sources: {파라미터키: "user"|"shared"} 매핑 (None이면 기존 동작)
+
+    Returns:
+        {"input.h5ad": "user/john/data/pbmc.h5ad"} 또는
+        {"input.h5ad": "tutorials/pbmc.h5ad"} 또는
+        {"input.h5ad": "pbmc.h5ad"} (하위 호환: username/file_sources 미제공 시)
+    """
     user_input = {}
 
-    # selectedPluginInputOutput에서 type이 "input"인 파라미터 추출 및 사용자 입력에 추가
     for parameter in selectedPluginInputOutput:
-        if parameter.get("type") == "inputFile" or parameter.get("type") == "optionalInputFile":
-            # 파라미터 이름 추출
+        if parameter.get("type") in ("inputFile", "optionalInputFile"):
             parameter_key = parameter.get("defaultValue")
-            
-            # 사용자 입력에 추가
-            user_input[parameter_key] = parameter.get("file_name")
-    
+            file_name = parameter.get("file_name")
+
+            if not file_name:
+                continue
+
+            # 하위 호환: username이 없으면 기존 동작 (파일명만 반환)
+            if username is None or file_sources is None:
+                user_input[parameter_key] = file_name
+            else:
+                source = file_sources.get(parameter_key, "user")
+                if source == "shared":
+                    user_input[parameter_key] = f"tutorials/{file_name}"
+                else:
+                    user_input[parameter_key] = f"user/{username}/data/{file_name}"
+
     return user_input
+
+
+def extract_file_sources(algorithm_data):
+    """Algorithm 노드에서 file_source 매핑 추출.
+
+    selectedPluginInputOutput 배열의 각 inputFile 파라미터에서
+    fileSource 필드를 읽어 {defaultValue: source} 매핑을 반환한다.
+
+    Args:
+        algorithm_data: algorithm dict (selectedPluginInputOutput 포함)
+
+    Returns:
+        {"input.h5ad": "shared", "geneList.txt": "user", ...}
+    """
+    sources = {}
+    input_output = algorithm_data.get('selectedPluginInputOutput', [])
+    for param in input_output:
+        if param.get('type') in ('inputFile', 'optionalInputFile'):
+            key = param.get('defaultValue')
+            source = param.get('fileSource', 'user')
+            sources[key] = source
+    return sources
 
 def generate_plugin_params(selectedPluginRules):
     plugin_params = {}

--- a/backend/app/database/schemas/file.py
+++ b/backend/app/database/schemas/file.py
@@ -19,6 +19,7 @@ class FileGet(FileBase):
 class FileFind(FileBase):
     file_name: str
     anno_column: Optional[str] = None
+    source: Optional[str] = None  # "user" | "shared"
 
 class FolderFind(FileBase):
     folder_name: str

--- a/backend/app/routes/celery_tasks.py
+++ b/backend/app/routes/celery_tasks.py
@@ -85,7 +85,7 @@ class MyTask(Task):
         if task_type == 'visualization':
             cache_key = kwargs.get('cache_key')
             cache_info = kwargs.get('cache_info')
-            
+
             if cache_key and cache_info:
                 try:
                     success = save_result_to_cache(
@@ -104,7 +104,14 @@ class MyTask(Task):
                     logger.error(f"Error caching visualization result for task {task_id}: {e}")
             else:
                 logger.debug(f"No cache information provided for visualization task {task_id}")
-        
+
+        if task_type == 'plugin_build':
+            try:
+                from app.common.utils.plugin_cache import invalidate_all_plugin_cache
+                invalidate_all_plugin_cache()
+            except Exception as e:
+                logger.warning(f"Plugin cache invalidation failed for task {task_id}: {e}")
+
         # 작업 완료 시 컨테이너 매니저에서 등록 해제
         container_manager.unregister_container(task_id)
 
@@ -115,6 +122,14 @@ class MyTask(Task):
         print(f'Task {task_id} failed at {end_time}, error: {exc}')
         user_id = kwargs.get('user_id')
         end_task(user_id, task_id, end_time, status='FAILURE')
+
+        task_type = kwargs.get('task_type')
+        if task_type == 'plugin_build':
+            try:
+                from app.common.utils.plugin_cache import invalidate_all_plugin_cache
+                invalidate_all_plugin_cache()
+            except Exception as e:
+                logger.warning(f"Plugin cache invalidation failed for task {task_id}: {e}")
 
         # 작업 실패 시 관련 컨테이너 정리
         try:
@@ -158,11 +173,19 @@ class MyTask(Task):
         end_time = datetime.now(timezone.utc)
         print(f'Task {task_id} revoked at {end_time}')
         print(f'Revoke details - terminated: {terminated}, signal: {signum}, expired: {expired}')
-        
+
         user_id = kwargs.get('user_id') if kwargs else None
         if user_id:
             end_task(user_id, task_id, end_time, status='REVOKED')
-        
+
+        task_type = kwargs.get('task_type') if kwargs else None
+        if task_type == 'plugin_build':
+            try:
+                from app.common.utils.plugin_cache import invalidate_all_plugin_cache
+                invalidate_all_plugin_cache()
+            except Exception as e:
+                logger.warning(f"Plugin cache invalidation failed for task {task_id}: {e}")
+
         # 작업 취소 시 관련 컨테이너 강제 정리
         try:
             print(f"Attempting to stop container for revoked task {task_id}")

--- a/backend/app/routes/celery_tasks.py
+++ b/backend/app/routes/celery_tasks.py
@@ -37,6 +37,9 @@ class MyTask(Task):
     Request = MyRequest  # Custom Request class 적용
 
     def before_start(self, task_id, args, kwargs):
+        # Skip DB recording on retries — task was already recorded on first attempt
+        if self.request.retries > 0:
+            return
         start_time = datetime.now(timezone.utc)
         print(f'Task {task_id} started at {start_time}')
         user_id = kwargs.get('user_id')
@@ -231,7 +234,15 @@ class MyTask(Task):
         print('----------------------------------------')
         print(f'Task {task_id} returned with status {status}, return value: {retval}')
         print('----------------------------------------')
-        
+
+        # Safety-net resource release for non-retry terminal states
+        if status != 'RETRY':
+            try:
+                from app.common.utils.resource_manager import release_slots_by_task_id
+                release_slots_by_task_id(task_id)
+            except Exception as e:
+                logger.warning(f"Safety-net resource release failed for task {task_id}: {e}")
+
         # 모든 작업 완료 후 컨테이너 정리 확인
         if status in ['SUCCESS', 'FAILURE', 'REVOKED']:
             try:
@@ -296,14 +307,26 @@ def wait_for_file_ready(file_path: str, timeout: int = 10, check_interval: float
 
 @shared_task(bind=True, base=MyTask, name="workflow_task:process_data_task")
 def process_data_task(self, username: str, snakefile_path: str, selected_plugin: str,
-                      targets: list, user_id: int, workflow_id: int, algorithm_id: int, plugin_name: str, task_type: str, **kwargs):
+                      targets: list, user_id: int, workflow_id: int, algorithm_id: int,
+                      plugin_name: str, task_type: str,
+                      resource_type: str = 'cpu', resource_slots: int = 4, **kwargs):
+    from app.common.utils.resource_manager import acquire_slots, release_slots
+    from app.common.config import settings as app_settings
+
+    task_id = self.request.id
+
+    # --- Resource gating: acquire slots or retry ---
+    acquired = acquire_slots(resource_type, resource_slots, task_id, plugin_name=plugin_name)
+    if not acquired:
+        raise self.retry(countdown=app_settings.RESOURCE_POLL_INTERVAL, max_retries=None)
+
     try:
-        task_id = self.request.id
         print(f'Processing data for user {username}...')
         print(f"Task ID: {task_id}")
         print(f"Targets: {targets}")
         print(f"Snakefile path: {snakefile_path}")
         print(f"Plugin name: {selected_plugin}")
+        print(f"Resource: {resource_type} x {resource_slots} slots")
 
         self.update_state(state="RUNNING", meta={"message": "Executing workflow..."})
 
@@ -331,7 +354,7 @@ def process_data_task(self, username: str, snakefile_path: str, selected_plugin:
 
         print('Data processing complete.')
         return {
-            "status": "Success", 
+            "status": "Success",
             "message": "Processing complete",
             "stdout": result.get("stdout", ""),
             "stderr": result.get("stderr", ""),
@@ -346,6 +369,9 @@ def process_data_task(self, username: str, snakefile_path: str, selected_plugin:
             error_message = f"Plugin execution failed: {error_message}. Please ensure the plugin is properly built and available."
         self.update_state(state="FAILURE", meta={"error": error_message})
         raise RuntimeError(error_message) from e
+    finally:
+        # Always release slots after execution (acquire succeeded at this point)
+        release_slots(resource_type, resource_slots, task_id)
 
 @shared_task(bind=True, base=MyTask, name="plugin_task:build_plugin_task")
 def build_plugin_task(self, plugin_name: str = None, user_id: int = None, workflow_id: int = None, algorithm_id: int = None, task_type: str = "plugin_build"):

--- a/backend/app/routes/celery_tasks.py
+++ b/backend/app/routes/celery_tasks.py
@@ -305,7 +305,7 @@ def wait_for_file_ready(file_path: str, timeout: int = 10, check_interval: float
     return file_exists
 
 
-@shared_task(bind=True, base=MyTask, name="workflow_task:process_data_task")
+@shared_task(bind=True, base=MyTask, name="workflow_task:process_data_task", max_retries=None)
 def process_data_task(self, username: str, snakefile_path: str, selected_plugin: str,
                       targets: list, user_id: int, workflow_id: int, algorithm_id: int,
                       plugin_name: str, task_type: str,
@@ -318,7 +318,7 @@ def process_data_task(self, username: str, snakefile_path: str, selected_plugin:
     # --- Resource gating: acquire slots or retry ---
     acquired = acquire_slots(resource_type, resource_slots, task_id, plugin_name=plugin_name)
     if not acquired:
-        raise self.retry(countdown=app_settings.RESOURCE_POLL_INTERVAL, max_retries=None)
+        raise self.retry(countdown=app_settings.RESOURCE_POLL_INTERVAL)
 
     try:
         print(f'Processing data for user {username}...')

--- a/backend/app/routes/endpoints/datatable.py
+++ b/backend/app/routes/endpoints/datatable.py
@@ -12,8 +12,15 @@ router = APIRouter()
 def load_data(vgt_info: DataTableEvent, current_user: str = Depends(dep.get_current_active_user)):
     try:
         from app.common.utils.file_path_resolver import resolve_data_file_path
-        PATH_DATATABLE_FILE = resolve_data_file_path(vgt_info.file_name, current_user.username, vgt_info.source)
-        df = load_tab_file(PATH_DATATABLE_FILE)
+        from app.common.utils.datatable_cache import get_cached_dataframe, set_cached_dataframe
+
+        file_path = resolve_data_file_path(vgt_info.file_name, current_user.username, vgt_info.source)
+
+        df = get_cached_dataframe(file_path)
+        if df is None:
+            df = load_tab_file(file_path)
+            set_cached_dataframe(file_path, df)
+
         remote_table = RemoteDataTable(df, vgt_info)
         data = remote_table.get_filtered_sorted_paginated_data()
         vgt_data = transform_df_to_vgt_format(data["df"])

--- a/backend/app/routes/endpoints/datatable.py
+++ b/backend/app/routes/endpoints/datatable.py
@@ -11,7 +11,8 @@ router = APIRouter()
 @router.post("/load_data")
 def load_data(vgt_info: DataTableEvent, current_user: str = Depends(dep.get_current_active_user)):
     try:
-        PATH_DATATABLE_FILE = f'./user/{current_user.username}/data/{vgt_info.file_name}'
+        from app.common.utils.file_path_resolver import resolve_data_file_path
+        PATH_DATATABLE_FILE = resolve_data_file_path(vgt_info.file_name, current_user.username, vgt_info.source)
         df = load_tab_file(PATH_DATATABLE_FILE)
         remote_table = RemoteDataTable(df, vgt_info)
         data = remote_table.get_filtered_sorted_paginated_data()

--- a/backend/app/routes/endpoints/files.py
+++ b/backend/app/routes/endpoints/files.py
@@ -154,7 +154,7 @@ def find_user_file(
 
 #User find File of folder
 @router.post("/folder")
-def find_user_file(
+def find_user_folder(
     *,
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
@@ -405,8 +405,22 @@ def read_user_file(
             return contents
         
 @router.get("/html/{filename}", response_class=HTMLResponse)
-async def read_html_file(filename: str):
-    with open(f'./tutorials/{filename}.html', "r") as f:
+async def read_html_file(
+    *,
+    current_user: models.User = Depends(dep.get_current_active_user),
+    filename: str,
+) -> Any:
+    from app.common.utils.file_security import validate_file_path
+
+    folder_path = './tutorials'
+    file_path = os.path.join(folder_path, f'{filename}.html')
+
+    validate_file_path(folder_path, file_path)
+
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    with open(file_path, "r") as f:
         html = f.read()
     return HTMLResponse(content=html)
 

--- a/backend/app/routes/endpoints/files.py
+++ b/backend/app/routes/endpoints/files.py
@@ -404,10 +404,59 @@ def read_user_file(
             contents = file.read()
             return contents
         
-@router.get("/html/{filename}", response_class=HTMLResponse)
-async def read_html_file(
+@router.get("/shared")
+def get_shared_files(
+    current_user: models.User = Depends(dep.get_current_active_user),
+) -> Any:
+    """tutorials/ 디렉토리의 데이터 파일 목록 반환 (html 제외)"""
+    SHARED_DIR = './tutorials'
+    DATA_EXTENSIONS = {'.h5ad', '.csv', '.txt', '.json'}
+    shared_files = []
+
+    if not os.path.isdir(SHARED_DIR):
+        return shared_files
+
+    for f in os.listdir(SHARED_DIR):
+        ext = os.path.splitext(f)[1].lower()
+        if ext in DATA_EXTENSIONS:
+            file_path = os.path.join(SHARED_DIR, f)
+            shared_files.append({
+                "file_name": f,
+                "file_size": str(os.path.getsize(file_path)),
+                "file_path": SHARED_DIR,
+                "folder": "tutorials",
+                "source": "shared",
+            })
+    return shared_files
+
+
+@router.post("/shared/find")
+def find_shared_file(
     *,
     current_user: models.User = Depends(dep.get_current_active_user),
+    fileInfo: FileFind,
+) -> Any:
+    """공용 파일 단건 조회 (InputFile.vue에서 사용)"""
+    from app.common.utils.file_security import validate_file_path
+
+    SHARED_DIR = './tutorials'
+    file_path = os.path.join(SHARED_DIR, fileInfo.file_name)
+    validate_file_path(SHARED_DIR, file_path)
+
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="Shared file not found")
+
+    return {
+        "file_name": fileInfo.file_name,
+        "file_size": str(os.path.getsize(file_path)),
+        "file_path": SHARED_DIR,
+        "folder": "tutorials",
+        "source": "shared",
+    }
+
+
+@router.get("/html/{filename}", response_class=HTMLResponse)
+async def read_html_file(
     filename: str,
 ) -> Any:
     from app.common.utils.file_security import validate_file_path

--- a/backend/app/routes/endpoints/files.py
+++ b/backend/app/routes/endpoints/files.py
@@ -17,6 +17,7 @@ from app.database.crud import crud_file
 from app.database import models
 from app.database.schemas.file import FileCreate, FileDelete, FileUpdate, FileFind, FolderFind, FileGet, FileResultFind
 from app.common.utils.h5ad_utils import organize_column_dtypes, get_annotation_columns, get_pseudotime_columns
+from app.common.utils.h5ad_metadata_cache import get_cached_columns, set_cached_columns, get_cached_clusters, set_cached_clusters, invalidate_file
 from app.common.utils.workflow_utils import load_tab_file
 
 router = APIRouter()
@@ -191,7 +192,10 @@ def delete_user_file(
         # 파일 존재 여부 확인 및 삭제
         if os.path.exists(file_path) and os.path.isfile(file_path):
             try:
-                os.remove(file_path)  # 실제 파일 삭제
+                from app.common.utils.datatable_cache import invalidate_datatable
+                invalidate_file(file_path)
+                invalidate_datatable(file_path)
+                os.remove(file_path)
             except Exception as e:
                 raise HTTPException(
                     status_code=500,
@@ -321,19 +325,24 @@ def h5ad_columns (
     if not os.path.isfile(input_filepath):
         raise HTTPException(status_code=404, detail="File not found")
 
-    # 메모리 누수 방지를 위해 adata를 명시적으로 해제
+    cached = get_cached_columns(input_filepath)
+    if cached is not None:
+        return cached
+
     adata = None
     try:
         adata = sc.read_h5ad(input_filepath)
-        adata.obs = organize_column_dtypes(adata.obs)
-        anno_columns = get_annotation_columns(adata.obs)
-        pseudo_columns = get_pseudotime_columns(adata.obs)
-        return {'anno_columns': anno_columns, 'pseudo_columns': pseudo_columns}
+        obs = organize_column_dtypes(adata.obs)
+        anno_columns = get_annotation_columns(obs, organized=True)
+        pseudo_columns = get_pseudotime_columns(obs, organized=True)
+        result = {'anno_columns': anno_columns, 'pseudo_columns': pseudo_columns}
+        set_cached_columns(input_filepath, result)
+        return result
     finally:
         if adata is not None:
             del adata
         gc.collect()
-    
+
 @router.post("/clusters")
 def h5ad_cluster (
     *,
@@ -357,13 +366,17 @@ def h5ad_cluster (
     if not os.path.isfile(input_filepath):
         raise HTTPException(status_code=404, detail="File not found")
 
-    # 메모리 누수 방지를 위해 adata를 명시적으로 해제
+    cached = get_cached_clusters(input_filepath, fileInfo.anno_column)
+    if cached is not None:
+        return {'clusters': cached}
+
     adata = None
     try:
         adata = sc.read_h5ad(input_filepath)
         adata.obs = organize_column_dtypes(adata.obs)
-        clusters = map(str, adata.obs[fileInfo.anno_column].value_counts().index)
-        return {'clusters': list(clusters)}
+        clusters = list(map(str, adata.obs[fileInfo.anno_column].value_counts().index))
+        set_cached_clusters(input_filepath, fileInfo.anno_column, clusters)
+        return {'clusters': clusters}
     finally:
         if adata is not None:
             del adata

--- a/backend/app/routes/endpoints/files.py
+++ b/backend/app/routes/endpoints/files.py
@@ -305,29 +305,34 @@ def h5ad_columns (
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileFind,
     ) -> Any:
-    user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-    if user_file:
-        folder_path = './user' + '/' + current_user.username
-        input_filename = fileInfo.file_name
-        input_filepath = f"{folder_path}/data/{input_filename}"
+    from app.common.utils.file_path_resolver import resolve_data_file_path
 
-        # 메모리 누수 방지를 위해 adata를 명시적으로 해제
-        adata = None
-        try:
-            adata = sc.read_h5ad(input_filepath)
-            adata.obs = organize_column_dtypes(adata.obs)
-            anno_columns = get_annotation_columns(adata.obs)
-            pseudo_columns = get_pseudotime_columns(adata.obs)
-            return {'anno_columns': anno_columns, 'pseudo_columns': pseudo_columns}
-        finally:
-            if adata is not None:
-                del adata
-            gc.collect()
-    else:
-        raise HTTPException(
+    # 공용 파일은 DB 소유권 검사 스킵
+    if fileInfo.source != "shared":
+        user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
+        if not user_file:
+            raise HTTPException(
                 status_code=400,
                 detail="this file not exists in your files",
-        )
+            )
+
+    input_filepath = resolve_data_file_path(fileInfo.file_name, current_user.username, fileInfo.source)
+
+    if not os.path.isfile(input_filepath):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # 메모리 누수 방지를 위해 adata를 명시적으로 해제
+    adata = None
+    try:
+        adata = sc.read_h5ad(input_filepath)
+        adata.obs = organize_column_dtypes(adata.obs)
+        anno_columns = get_annotation_columns(adata.obs)
+        pseudo_columns = get_pseudotime_columns(adata.obs)
+        return {'anno_columns': anno_columns, 'pseudo_columns': pseudo_columns}
+    finally:
+        if adata is not None:
+            del adata
+        gc.collect()
     
 @router.post("/clusters")
 def h5ad_cluster (
@@ -336,28 +341,33 @@ def h5ad_cluster (
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileFind,
     ) -> Any:
-    user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-    if user_file:
-        folder_path = './user' + '/' + current_user.username
-        input_filename = fileInfo.file_name
-        input_filepath = f"{folder_path}/data/{input_filename}"
+    from app.common.utils.file_path_resolver import resolve_data_file_path
 
-        # 메모리 누수 방지를 위해 adata를 명시적으로 해제
-        adata = None
-        try:
-            adata = sc.read_h5ad(input_filepath)
-            adata.obs = organize_column_dtypes(adata.obs)
-            clusters = map(str, adata.obs[fileInfo.anno_column].value_counts().index)
-            return {'clusters': list(clusters)}
-        finally:
-            if adata is not None:
-                del adata
-            gc.collect()
-    else:
-        raise HTTPException(
+    # 공용 파일은 DB 소유권 검사 스킵
+    if fileInfo.source != "shared":
+        user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
+        if not user_file:
+            raise HTTPException(
                 status_code=400,
                 detail="this file not exists in your files",
-        )
+            )
+
+    input_filepath = resolve_data_file_path(fileInfo.file_name, current_user.username, fileInfo.source)
+
+    if not os.path.isfile(input_filepath):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # 메모리 누수 방지를 위해 adata를 명시적으로 해제
+    adata = None
+    try:
+        adata = sc.read_h5ad(input_filepath)
+        adata.obs = organize_column_dtypes(adata.obs)
+        clusters = map(str, adata.obs[fileInfo.anno_column].value_counts().index)
+        return {'clusters': list(clusters)}
+    finally:
+        if adata is not None:
+            del adata
+        gc.collect()
     
 @router.get("/setup/check")
 def algorithm_setup_check (
@@ -525,14 +535,11 @@ async def download_data_file(
     *,
     current_user: models.User = Depends(dep.get_current_active_user),
     filename: str,
+    source: str = None,
     ) -> Any:
-    from app.common.utils.file_security import validate_file_path
+    from app.common.utils.file_path_resolver import resolve_data_file_path
 
-    folder_path = f'./user/{current_user.username}/data'
-    file_path = os.path.join(folder_path, filename)
-
-    # Security: Prevent path traversal
-    validate_file_path(folder_path, file_path)
+    file_path = resolve_data_file_path(filename, current_user.username, source)
 
     # 파일이 존재하는지 확인
     if not os.path.isfile(file_path):

--- a/backend/app/routes/endpoints/files.py
+++ b/backend/app/routes/endpoints/files.py
@@ -102,6 +102,18 @@ async def fileUpload(
                 detail=f"File upload failed: {str(e)}"
             )
 
+        # Compress H5AD files to reduce storage
+        if final_filename.lower().endswith('.h5ad'):
+            from app.common.utils.h5ad_compression import compress_h5ad_file
+            from app.common.config import H5AD_COMPRESSION_ENABLED, H5AD_COMPRESSION_MIN_SIZE
+
+            if H5AD_COMPRESSION_ENABLED:
+                _compressed, file_size = await asyncio.to_thread(
+                    compress_h5ad_file,
+                    file_path,
+                    min_size_bytes=H5AD_COMPRESSION_MIN_SIZE,
+                )
+
         # Create database record
         created_file = crud_file.create_file(
             db,

--- a/backend/app/routes/endpoints/files.py
+++ b/backend/app/routes/endpoints/files.py
@@ -1,5 +1,4 @@
 from typing import Any
-from venv import create
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, UploadFile, File
 from fastapi.responses import HTMLResponse, FileResponse
 from typing import List, Union

--- a/backend/app/routes/endpoints/plugin.py
+++ b/backend/app/routes/endpoints/plugin.py
@@ -18,6 +18,7 @@ from app.database.crud import crud_plugin
 from app.database import models
 from app.common.utils import plugin_utils
 from app.common.utils.plugin_utils import get_plugin_path, is_plugin_editable, ensure_local_plugins_dir
+from app.common.utils.plugin_cache import invalidate_all_plugin_cache
 from app.common.utils.github_registry_client import GitHubRegistryClient
 from app.routes.celery_tasks import build_plugin_task
 from celery.result import AsyncResult
@@ -254,6 +255,7 @@ async def upload_plugin(
             if backup_folder and os.path.exists(backup_folder):
                 shutil.rmtree(backup_folder)
 
+            invalidate_all_plugin_cache()
             return {
                 "message": "플러그인 메타데이터 업로드 성공",
                 "plugin": db_plugin,
@@ -375,7 +377,8 @@ async def upload_scripts(
                             shutil.copytree(str(item), str(target_dir))
             
             logger.info(f"Successfully moved {scripts_staging_dir} to {scripts_dir}. Script update complete.")
-            
+
+            invalidate_all_plugin_cache()
             return {
                 "message": "Scripts uploaded successfully",
                 "scripts_path": str(scripts_dir),
@@ -537,8 +540,9 @@ async def upload_package(
             final_package_files = [f for f in os.listdir(dependency_folder) if f.endswith(('.whl', '.tar.gz'))]
             print(f"Final package files in dependency folder: {final_package_files}")
 
+            invalidate_all_plugin_cache()
             return {
-                "message": "Package uploaded successfully", 
+                "message": "Package uploaded successfully",
                 "packages": [file.filename for file in files],
                 "success": True
             }
@@ -636,6 +640,7 @@ async def build_plugin_docker(
             ignore_result=False
         )
 
+        invalidate_all_plugin_cache()
         return {
             "message": f"플러그인 Docker 이미지 빌드 시작: {plugin_name}",
             "task_id": task.id,
@@ -737,8 +742,33 @@ def list_plugins(
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
     try:
+        # Cache hit path
+        from app.common.utils.plugin_cache import get_cached_plugin_list, set_cached_plugin_list
+        cached = get_cached_plugin_list(current_user.id)
+        if cached is not None:
+            return cached
+
         plugins = crud_plugin.get_plugins(db)
         plugin_list = []
+
+        # Query user tasks once outside the loop (was N times inside)
+        from app.database.crud.crud_task import get_user_task
+        try:
+            user_tasks = get_user_task(db, current_user.id)
+        except Exception as e:
+            logger.warning(f"Error fetching user tasks: {e}")
+            user_tasks = []
+
+        # Create Docker client only if local plugins exist (avoids 21ms socket overhead)
+        import docker
+        docker_client = None
+        has_local = any(p.source == "local" for p in plugins)
+        if has_local:
+            try:
+                docker_client = docker.from_env()
+            except Exception:
+                docker_client = None
+
         for plugin in plugins:
             plugin_dict = plugin.__dict__
             plugin_dict['users'] = [user.__dict__ for user in plugin.users]
@@ -748,31 +778,32 @@ def list_plugins(
                 rules_dict = plugin_dict['rules']
                 rules_array = [rules_dict[str(i)] for i in range(len(rules_dict))]
                 plugin_dict['rules'] = rules_array
-            
+
             # 빌드 상태 정보 추가 (only for local plugins)
-            try:
-                if plugin.source == "local":
-                    plugin_dict['docker_image_exists'] = plugin_utils.check_plugin_docker_image(plugin.name)
-                else:
-                    plugin_dict['docker_image_exists'] = False  # Official plugins don't have local Docker images
-            except Exception as e:
-                print(f"Error checking Docker image for {plugin.name}: {e}")
+            if plugin.source == "local" and docker_client:
+                try:
+                    image_tag = f"plugin-{plugin.name.lower()}"
+                    docker_client.images.get(image_tag)
+                    plugin_dict['docker_image_exists'] = True
+                except docker.errors.ImageNotFound:
+                    plugin_dict['docker_image_exists'] = False
+                except Exception as e:
+                    logger.warning(f"Error checking Docker image for {plugin.name}: {e}")
+                    plugin_dict['docker_image_exists'] = False
+            else:
                 plugin_dict['docker_image_exists'] = False
-            
-            # 최근 빌드 태스크 정보 조회
+
+            # 최근 빌드 태스크 정보 조회 (using pre-fetched user_tasks)
             try:
-                from app.database.crud.crud_task import get_user_task
-                user_tasks = get_user_task(db, current_user.id)
                 plugin_build_tasks = [
-                    task for task in user_tasks 
+                    task for task in user_tasks
                     if task.task_type == "plugin_build" and task.plugin_name == plugin.name
                 ]
-                
+
                 if plugin_build_tasks:
-                    # 가장 최근 빌드 태스크 정보
                     latest_task = max(plugin_build_tasks, key=lambda x: x.start_time or datetime.min.replace(tzinfo=None))
                     task_result = AsyncResult(latest_task.task_id)
-                    
+
                     plugin_dict['latest_build'] = {
                         "task_id": latest_task.task_id,
                         "status": task_result.state,
@@ -782,24 +813,27 @@ def list_plugins(
                 else:
                     plugin_dict['latest_build'] = None
             except Exception as e:
-                print(f"Error getting build tasks for {plugin.name}: {e}")
+                logger.warning(f"Error getting build tasks for {plugin.name}: {e}")
                 plugin_dict['latest_build'] = None
-            
+
             # Official 플러그인의 경우 데이터베이스 version 컬럼 직접 사용
             if plugin.source == "official":
-                # GitHub Registry API 호출을 제거하고 데이터베이스 version 직접 사용
                 plugin_dict['current_version'] = plugin.version or "1.0"
-                plugin_dict['available_versions'] = []  # 빈 배열로 설정
-                
+                plugin_dict['available_versions'] = []
+
                 logger.info(f"Plugin {plugin.name} - Using database version: {plugin_dict['current_version']}")
             else:
-                # Local 플러그인의 경우 기존 로직 유지
                 plugin_dict['current_version'] = plugin.version or "local"
                 plugin_dict['available_versions'] = []
-            
+
             plugin_list.append(plugin_dict)
-        
-        return {"plugins": plugin_list}
+
+        if docker_client:
+            docker_client.close()
+
+        response = {"plugins": plugin_list}
+        set_cached_plugin_list(current_user.id, response)
+        return response
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -836,10 +870,11 @@ def associate_plugin(
         # Get the plugin by ID
         plugin = crud_plugin.get_plugin_by_id(db, pluginInfo.plugin_id)
 
+        invalidate_all_plugin_cache()
         return { "message": "Plugin associated with user successfully", "plugin": plugin }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-    
+
 @router.post("/dissociate")
 def dissociate_plugin(
     *,
@@ -854,6 +889,7 @@ def dissociate_plugin(
         # Get the plugin by ID
         plugin = crud_plugin.get_plugin_by_id(db, pluginInfo.plugin_id)
 
+        invalidate_all_plugin_cache()
         return { "message": "Plugin dissociated from user successfully", "plugin": plugin }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -932,6 +968,7 @@ async def build_plugin(
             ignore_result=False
         )
 
+        invalidate_all_plugin_cache()
         return {
             "message": f"Plugin build started for {plugin_name}",
             "task_id": task.id,
@@ -1072,6 +1109,7 @@ async def update_plugin_complete(
             db.commit()
             db.refresh(db_plugin)
             
+            invalidate_all_plugin_cache()
             return {
                 "message": f"Plugin {plugin_name} successfully synchronized",
                 "updated_fields": {
@@ -1080,14 +1118,14 @@ async def update_plugin_complete(
                     "drawflow_nodes": len(metadata.get('drawflow', {}).get('drawflow', {}).get('Home', {}).get('data', {})) if metadata.get('drawflow') else 0
                 }
             }
-            
+
         except Exception as e:
             db.rollback()
             raise HTTPException(
                 status_code=500,
                 detail=f"Failed to update database: {str(e)}"
             )
-        
+
     except HTTPException as he:
         raise he
     except Exception as e:
@@ -1170,13 +1208,14 @@ async def upload_text_dependencies(
             db.commit()
             db.refresh(db_plugin)
             
+            invalidate_all_plugin_cache()
             return {
-                "message": "Text dependency files uploaded and synchronized successfully", 
+                "message": "Text dependency files uploaded and synchronized successfully",
                 "uploaded_files": uploaded_files,
                 "total_dependencies": len(dependencies_dict),
                 "success": True
             }
-            
+
         except Exception as e:
             db.rollback()
             raise HTTPException(
@@ -1311,9 +1350,10 @@ async def cancel_build_task(
     try:
         # Celery 태스크 취소
         celery_app.control.revoke(task_id, terminate=True)
-        
+
         task_result = AsyncResult(task_id)
-        
+
+        invalidate_all_plugin_cache()
         return {
             "message": f"Build task {task_id} cancellation requested",
             "task_id": task_id,
@@ -1510,6 +1550,7 @@ async def update_plugin_version(
             except docker.errors.DockerException as e:
                 logger.warning(f"Docker not available for image pull: {e}")
             
+            invalidate_all_plugin_cache()
             return {
                 "message": f"Plugin '{plugin_name}' version updated successfully",
                 "plugin_name": plugin_name,
@@ -1517,7 +1558,7 @@ async def update_plugin_version(
                 "new_version": version,
                 "image_uri": registry.get_image_uri(plugin_name, version)
             }
-            
+
         except Exception as e:
             db.rollback()
             logger.error(f"Failed to update plugin version in database: {e}")

--- a/backend/app/routes/endpoints/task.py
+++ b/backend/app/routes/endpoints/task.py
@@ -59,7 +59,7 @@ async def get_task_status(task_id: str) -> dict:
                     task = get_task_info(task_id)
                     task_status = task.get('task_status', 'UNKNOWN')
 
-                    if task_status in ['SUCCESS', 'FAILURE', 'REVOKED', 'RETRY']:
+                    if task_status in ['SUCCESS', 'FAILURE', 'REVOKED']:
                         yield f"{task_status}"
                         break
 

--- a/backend/app/routes/endpoints/task.py
+++ b/backend/app/routes/endpoints/task.py
@@ -79,6 +79,21 @@ async def get_task_status(task_id: str) -> dict:
 
     return EventSourceResponse(event_generator())
 
+@router.get("/status/{task_id}")
+async def get_task_status_simple(task_id: str) -> dict:
+    """
+    SSE 재연결 판단용 경량 상태 확인 엔드포인트.
+    Celery AsyncResult 상태만 반환. 인증 불필요 (SSE 엔드포인트와 동일 패턴).
+    """
+    if not task_id or not task_id.strip():
+        raise HTTPException(status_code=400, detail="Invalid task_id")
+
+    task = get_task_info(task_id)
+    return {
+        "task_id": task_id,
+        "status": task.get("task_status", "UNKNOWN")
+    }
+
 @router.get("/monitoring", response_model=List[TaskMonitoringItem])
 async def get_task_monitoring(
     *,

--- a/backend/app/routes/endpoints/task.py
+++ b/backend/app/routes/endpoints/task.py
@@ -24,7 +24,19 @@ import os
 from pathlib import Path
 import time
 
-router = APIRouter()                  
+router = APIRouter()
+
+
+@router.get("/resources")
+async def get_resources():
+    """리소스 할당 현황 및 실행 중 작업 목록 조회"""
+    from app.common.utils.resource_manager import get_resource_status
+
+    status = get_resource_status()
+    if status is None:
+        raise HTTPException(status_code=503, detail="Resource monitoring unavailable")
+    return status
+
 
 @router.get("/info/{task_id}")
 async def get_task_status(task_id: str) -> dict:

--- a/backend/app/routes/endpoints/workflow.py
+++ b/backend/app/routes/endpoints/workflow.py
@@ -27,7 +27,7 @@ from app.common.utils.workflow_utils import (
     extract_visualization_data, extract_target_data, generate_user_input,
     generate_plugin_params, generate_visualization_params,
     resolve_algorithm_path_from_files, validate_file_paths,
-    find_connected_visualization_nodes
+    find_connected_visualization_nodes, extract_file_sources
 )
 from app.common.utils.log_archive_utils import cleanup_task_results
 from app.database.crud import crud_workflow, crud_plugin
@@ -83,8 +83,13 @@ def compileWorkflow(
                 except Exception as e:
                     raise HTTPException(status_code=404, detail=f"Plugin '{selected_plugin_name}' not found: {str(e)}")
 
-                # 입력 데이터 및 파라미터 추출
-                user_input = generate_user_input(algorithm['selectedPluginInputOutput'])
+                # 입력 데이터 및 파라미터 추출 (파일 소스에 따라 전체 경로 구성)
+                file_sources = extract_file_sources(algorithm)
+                user_input = generate_user_input(
+                    algorithm['selectedPluginInputOutput'],
+                    username=current_user.username,
+                    file_sources=file_sources,
+                )
                 plugin_params = generate_plugin_params(algorithm['selectedPluginRules'])
                 target_list = extract_target_data(algorithm['selectedPluginInputOutput'], user_workflow_task_path)
 

--- a/backend/app/routes/endpoints/workflow.py
+++ b/backend/app/routes/endpoints/workflow.py
@@ -135,10 +135,31 @@ def compileWorkflow(
                 plugin_snakefile_path = os.path.join(plugin_path, "Snakefile")
                 user_snakefile_path = change_snakefile_parameter(plugin_snakefile_path, user_workflow_task_path + "/Snakefile", user_input, plugin_params)
 
+                # 리소스 요구량 추출
+                plugin_db = db.query(models.Plugin).filter_by(name=selected_plugin_name).first()
+                use_gpu = plugin_db.use_gpu if plugin_db else False
+                resource_type = 'gpu' if use_gpu else 'cpu'
+
+                num_devices_raw = plugin_params.get("number of devices")
+                if num_devices_raw is not None:
+                    resource_slots = int(num_devices_raw)
+                else:
+                    from app.common.config import settings as app_settings
+                    resource_slots = (app_settings.RESOURCE_DEFAULT_GPU_SLOTS
+                                     if use_gpu else app_settings.RESOURCE_DEFAULT_CPU_SLOTS)
+
                 # Celery 작업 실행
                 process_task = process_data_task.apply_async(
                     args=[current_user.username, user_snakefile_path, selected_plugin_name, target_list],
-                    kwargs={'user_id': current_user.id, 'workflow_id': workflow.id, 'algorithm_id': algorithm['id'], 'plugin_name': selected_plugin_name, 'task_type': 'compile'},
+                    kwargs={
+                        'user_id': current_user.id,
+                        'workflow_id': workflow.id,
+                        'algorithm_id': algorithm['id'],
+                        'plugin_name': selected_plugin_name,
+                        'task_type': 'compile',
+                        'resource_type': resource_type,
+                        'resource_slots': resource_slots,
+                    },
                     ignore_result=False
                 )
 
@@ -565,6 +586,8 @@ def visualizeData(
                     'algorithm_id': workflow_request.current_node_id,  # Use visualization node ID for correct log path
                     'plugin_name': selected_plugin_name,
                     'task_type': 'visualization',
+                    'resource_type': 'cpu',
+                    'resource_slots': 1,
                     'cache_key': cache_key,
                     'cache_info': {
                         'user_path': user_path,

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -31,6 +31,7 @@ markers =
     enum: Enumeration tests
     error: Error handling and exception tests
     models: SQLAlchemy database model tests
+    benchmark: Performance benchmark tests (excluded from normal runs)
 
 # Asyncio configuration
 asyncio_mode = auto

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -144,6 +144,7 @@ pytz==2022.2.1
 pyu2f==0.1.5
 PyYAML==6.0
 ratelimiter==1.2.0
+redis==5.0.1
 requests==2.28.1
 retry==0.9.2
 rich==12.5.1

--- a/backend/tests/benchmarks/conftest.py
+++ b/backend/tests/benchmarks/conftest.py
@@ -1,0 +1,7 @@
+"""
+Benchmarks-specific conftest.
+
+This file exists so that pytest can collect tests from this sub-package
+without requiring the root conftest.py fixtures (which need httpx/TestClient).
+No DB or HTTP fixtures are needed for function-level benchmarks.
+"""

--- a/backend/tests/benchmarks/run_api_benchmarks.py
+++ b/backend/tests/benchmarks/run_api_benchmarks.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+"""
+H5AD API endpoint benchmarks — Before Redis caching baseline.
+
+Standalone script (no pytest) to measure actual HTTP response times
+through FastAPI TestClient for /routes/files/columns and /routes/files/clusters.
+
+Usage (inside backend container):
+    docker exec cellcraft-backend-1 python tests/benchmarks/run_api_benchmarks.py
+"""
+import gc
+import json
+import os
+import sys
+import time
+import statistics
+import tempfile
+
+import numpy as np
+import pandas as pd
+import anndata as ad
+
+# Ensure TESTING is NOT set so the app connects to the real DB (db:5432)
+os.environ.pop("TESTING", None)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+ITERATIONS = 10
+REAL_H5AD_NAME = "pbmc_light_1000.h5ad"
+REAL_H5AD_PATH = "/app/tutorials/pbmc_light_1000.h5ad"
+
+# ---------------------------------------------------------------------------
+# Benchmark timer (inline to avoid import issues)
+# ---------------------------------------------------------------------------
+
+class BenchmarkTimer:
+    def __init__(self, name, iterations=ITERATIONS):
+        self.name = name
+        self.iterations = iterations
+        self.times = []
+
+    def stats(self):
+        if not self.times:
+            return {}
+        s = sorted(self.times)
+        n = len(s)
+        return {
+            "name": self.name,
+            "iterations": n,
+            "mean_s": round(statistics.mean(s), 6),
+            "median_s": round(statistics.median(s), 6),
+            "std_s": round(statistics.stdev(s), 6) if n > 1 else 0.0,
+            "min_s": round(s[0], 6),
+            "max_s": round(s[-1], 6),
+            "mean_ms": round(statistics.mean(s) * 1000, 2),
+            "median_ms": round(statistics.median(s) * 1000, 2),
+            "cold_ms": round(s[0] * 1000, 2) if n > 0 else 0,
+        }
+
+
+def print_stats(stats):
+    print(f"\n{'='*60}")
+    print(f"  {stats['name']}")
+    print(f"{'='*60}")
+    print(f"  Iterations : {stats['iterations']}")
+    print(f"  Mean       : {stats['mean_ms']:.2f} ms")
+    print(f"  Median     : {stats['median_ms']:.2f} ms")
+    print(f"  Std        : {stats.get('std_s', 0)*1000:.2f} ms")
+    print(f"  Min        : {stats['min_s']*1000:.2f} ms")
+    print(f"  Max        : {stats['max_s']*1000:.2f} ms")
+    if stats['iterations'] > 1:
+        cold = stats['times_ms'][0]
+        warm_avg = statistics.mean(stats['times_ms'][1:])
+        print(f"  Cold (1st) : {cold:.2f} ms")
+        print(f"  Warm (avg) : {warm_avg:.2f} ms")
+
+
+# ---------------------------------------------------------------------------
+# Prepare test data (small & large mock h5ad as user-owned files)
+# ---------------------------------------------------------------------------
+
+def create_test_h5ad(n_obs, n_vars, path):
+    adata = ad.AnnData(
+        X=np.random.rand(n_obs, n_vars).astype(np.float32),
+        obs=pd.DataFrame({
+            "cell_type": np.random.choice(["TypeA", "TypeB", "TypeC", "TypeD"], n_obs),
+            "cluster": np.random.choice([f"C{i}" for i in range(10)], n_obs),
+            "pseudotime": np.random.rand(n_obs),
+        }),
+        var=pd.DataFrame(index=[f"Gene{i}" for i in range(n_vars)]),
+    )
+    adata.obsm["X_umap"] = np.random.rand(n_obs, 2).astype(np.float32)
+    adata.write_h5ad(path)
+    size_mb = os.path.getsize(path) / (1024 * 1024)
+    del adata
+    gc.collect()
+    return size_mb
+
+
+# ---------------------------------------------------------------------------
+# Authentication helper
+# ---------------------------------------------------------------------------
+
+def get_auth_token(client):
+    """Login as admin user and return auth headers."""
+    response = client.post(
+        "/routes/auth/login/access-token",
+        data={
+            "username": "cellcraft@cellcraft.com",
+            "password": "cellcraft2024!",
+        },
+    )
+    if response.status_code != 200:
+        print(f"  Login failed ({response.status_code}): {response.text}")
+        print("  Trying to create admin user or use existing credentials...")
+        return None
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Main benchmark
+# ---------------------------------------------------------------------------
+
+def main():
+    all_results = {}
+
+    print("\n" + "#" * 60)
+    print("# H5AD API Endpoint Benchmark — Before Redis Caching Baseline")
+    print("#" * 60)
+
+    # --- Setup TestClient ---
+    print("\n--- Setting up FastAPI TestClient ---")
+    client = TestClient(app)
+
+    # --- Authenticate ---
+    print("--- Authenticating as admin ---")
+    headers = get_auth_token(client)
+    if not headers:
+        print("ERROR: Cannot authenticate. Aborting.")
+        return
+
+    print("  Auth OK")
+
+    # --- Prepare test data ---
+    # For small/large: create h5ad in tutorials/ dir and use source=shared
+    # This avoids needing file DB records
+    tmpdir = tempfile.mkdtemp(prefix="bench_api_", dir="/app/tutorials")
+    small_name = "bench_small.h5ad"
+    large_name = "bench_large.h5ad"
+    small_path = os.path.join("/app/tutorials", small_name)
+    large_path = os.path.join("/app/tutorials", large_name)
+
+    print("\n--- Preparing test data ---")
+    small_size = create_test_h5ad(100, 50, small_path)
+    print(f"  Small (100×50)   : {small_size:.2f} MB")
+    large_size = create_test_h5ad(10_000, 2_000, large_path)
+    print(f"  Large (10k×2k)   : {large_size:.2f} MB")
+    real_exists = os.path.isfile(REAL_H5AD_PATH)
+    if real_exists:
+        real_size = os.path.getsize(REAL_H5AD_PATH) / (1024 * 1024)
+        print(f"  Real (pbmc 1k)   : {real_size:.2f} MB")
+    else:
+        print("  Real (pbmc 1k)   : NOT FOUND — skipping")
+
+    # Define test datasets: (label, filename, anno_column_for_clusters)
+    datasets = [
+        ("small", small_name, "cluster"),
+        ("large", large_name, "cluster"),
+    ]
+    if real_exists:
+        # Discover annotation column from real data first
+        import scanpy as sc
+        from app.common.utils.h5ad_utils import organize_column_dtypes, get_annotation_columns
+        adata = sc.read_h5ad(REAL_H5AD_PATH)
+        obs = organize_column_dtypes(adata.obs)
+        anno_cols = get_annotation_columns(obs)
+        real_anno_col = anno_cols[0] if anno_cols else "cluster"
+        del adata
+        gc.collect()
+        print(f"  Real anno column : {real_anno_col}")
+        datasets.append(("real", REAL_H5AD_NAME, real_anno_col))
+
+    # ==================================================================
+    # /routes/files/columns benchmarks
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SECTION 1: POST /routes/files/columns")
+    print("=" * 60)
+
+    for label, filename, _ in datasets:
+        timer = BenchmarkTimer(f"API /columns [{label}]", ITERATIONS)
+
+        for i in range(ITERATIONS):
+            start = time.perf_counter()
+            resp = client.post(
+                "/routes/files/columns",
+                json={"file_name": filename, "source": "shared"},
+                headers=headers,
+            )
+            elapsed = time.perf_counter() - start
+            timer.times.append(elapsed)
+
+            if i == 0:
+                # Verify first response
+                if resp.status_code != 200:
+                    print(f"\n  ERROR [{label}]: status={resp.status_code}, body={resp.text[:200]}")
+                    break
+                body = resp.json()
+                print(f"\n  [{label}] First response: anno={len(body.get('anno_columns', []))} cols, "
+                      f"pseudo={len(body.get('pseudo_columns', []))} cols")
+
+        stats = timer.stats()
+        stats["times_ms"] = [round(t * 1000, 2) for t in timer.times]
+        print_stats(stats)
+        all_results[f"api_columns_{label}"] = stats
+
+    # ==================================================================
+    # /routes/files/clusters benchmarks
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SECTION 2: POST /routes/files/clusters")
+    print("=" * 60)
+
+    for label, filename, anno_col in datasets:
+        timer = BenchmarkTimer(f"API /clusters [{label}]", ITERATIONS)
+
+        for i in range(ITERATIONS):
+            start = time.perf_counter()
+            resp = client.post(
+                "/routes/files/clusters",
+                json={"file_name": filename, "anno_column": anno_col, "source": "shared"},
+                headers=headers,
+            )
+            elapsed = time.perf_counter() - start
+            timer.times.append(elapsed)
+
+            if i == 0:
+                if resp.status_code != 200:
+                    print(f"\n  ERROR [{label}]: status={resp.status_code}, body={resp.text[:200]}")
+                    break
+                body = resp.json()
+                print(f"\n  [{label}] First response: {len(body.get('clusters', []))} clusters")
+
+        stats = timer.stats()
+        stats["times_ms"] = [round(t * 1000, 2) for t in timer.times]
+        print_stats(stats)
+        all_results[f"api_clusters_{label}"] = stats
+
+    # ==================================================================
+    # Summary
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SUMMARY TABLE")
+    print("=" * 60)
+    print(f"{'Endpoint':<40} {'Mean (ms)':>10} {'Median (ms)':>12} {'Cold (ms)':>10} {'Warm avg (ms)':>14}")
+    print("-" * 90)
+    for key, val in all_results.items():
+        times = val.get("times_ms", [])
+        cold = times[0] if times else 0
+        warm_avg = round(statistics.mean(times[1:]), 2) if len(times) > 1 else 0
+        print(f"{val['name']:<40} {val['mean_ms']:>10.2f} {val['median_ms']:>12.2f} {cold:>10.2f} {warm_avg:>14.2f}")
+
+    # JSON output
+    print("\n--- RAW JSON ---")
+    print(json.dumps(all_results, indent=2))
+
+    # Cleanup temp files
+    try:
+        os.unlink(small_path)
+        os.unlink(large_path)
+        os.rmdir(tmpdir)
+    except Exception:
+        pass
+
+    return all_results
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/benchmarks/run_datatable_benchmarks.py
+++ b/backend/tests/benchmarks/run_datatable_benchmarks.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python
+"""
+DataTable benchmarks — Before/After Redis caching.
+
+Measures function-level (load_tab_file) and API-level (POST /datatable/load_data)
+performance to establish baselines and validate Redis caching improvements.
+
+Usage (function-level, inside backend container):
+    docker exec cellcraft-backend-1 python tests/benchmarks/run_datatable_benchmarks.py --func
+
+Usage (API-level, inside backend container):
+    docker exec cellcraft-backend-1 python tests/benchmarks/run_datatable_benchmarks.py --api
+
+Usage (both):
+    docker exec cellcraft-backend-1 python tests/benchmarks/run_datatable_benchmarks.py
+"""
+import argparse
+import gc
+import json
+import os
+import sys
+import time
+import statistics
+import tracemalloc
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DATASETS = {
+    "pbmc": {
+        "path": "/app/tutorials/pbmc_light_1000.h5ad",
+        "iterations_func": 5,
+        "iterations_api": 10,
+        "description": "1K cells, 27 MB",
+    },
+    "CRC": {
+        "path": "/app/tutorials/CRCBraw.h5ad",
+        "iterations_func": 3,
+        "iterations_api": 5,
+        "description": "12.6K cells, 138 MB",
+    },
+    "GTEx": {
+        "path": "/app/tutorials/GTEx_8_tissues.h5ad",
+        "iterations_func": 2,
+        "iterations_api": 3,
+        "description": "209K cells, 1.8 GB",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Benchmark utilities (reused from run_realdata_benchmarks.py)
+# ---------------------------------------------------------------------------
+
+class BenchmarkTimer:
+    def __init__(self, name: str, iterations: int):
+        self.name = name
+        self.iterations = iterations
+        self.times = []
+
+    def run(self, func, *args, **kwargs):
+        result = None
+        for _ in range(self.iterations):
+            start = time.perf_counter()
+            result = func(*args, **kwargs)
+            elapsed = time.perf_counter() - start
+            self.times.append(elapsed)
+        return result
+
+    def stats(self):
+        if not self.times:
+            return {}
+        s = sorted(self.times)
+        n = len(s)
+        return {
+            "name": self.name,
+            "iterations": n,
+            "mean_s": round(statistics.mean(s), 6),
+            "median_s": round(statistics.median(s), 6),
+            "std_s": round(statistics.stdev(s), 6) if n > 1 else 0.0,
+            "min_s": round(s[0], 6),
+            "max_s": round(s[-1], 6),
+            "mean_ms": round(statistics.mean(s) * 1000, 2),
+            "median_ms": round(statistics.median(s) * 1000, 2),
+        }
+
+
+def measure_memory(func, *args, **kwargs):
+    """Run func once, return tracemalloc peak and RSS delta."""
+    rss_before = _get_rss_kb()
+    tracemalloc.start()
+    result = func(*args, **kwargs)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    rss_after = _get_rss_kb()
+    return {
+        "result": result,
+        "tracemalloc_peak_mb": round(peak / (1024 * 1024), 2),
+        "rss_before_mb": round(rss_before / 1024, 2),
+        "rss_after_mb": round(rss_after / 1024, 2),
+        "rss_delta_mb": round((rss_after - rss_before) / 1024, 2),
+    }
+
+
+def _get_rss_kb():
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return float(line.split()[1])
+    except (FileNotFoundError, ValueError):
+        pass
+    try:
+        import resource
+        return float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    except Exception:
+        return 0.0
+
+
+def print_bench(stats, mem=None):
+    print(f"\n{'='*60}")
+    print(f"  {stats['name']}")
+    print(f"{'='*60}")
+    print(f"  Iterations : {stats['iterations']}")
+    print(f"  Mean       : {stats['mean_ms']:.2f} ms")
+    print(f"  Median     : {stats['median_ms']:.2f} ms")
+    print(f"  Std        : {stats.get('std_s', 0)*1000:.2f} ms")
+    print(f"  Min        : {stats['min_s']*1000:.2f} ms")
+    print(f"  Max        : {stats['max_s']*1000:.2f} ms")
+    if mem:
+        print(f"  Peak Mem   : {mem.get('tracemalloc_peak_mb', 'N/A')} MB (tracemalloc)")
+        print(f"  RSS Delta  : {mem.get('rss_delta_mb', 'N/A')} MB")
+
+
+# ---------------------------------------------------------------------------
+# PART 1: Function-level benchmarks
+# ---------------------------------------------------------------------------
+
+def run_function_benchmarks():
+    from app.common.utils.workflow_utils import load_tab_file
+
+    all_results = {}
+
+    print("\n" + "#" * 60)
+    print("# PART 1: Function-Level Benchmarks (load_tab_file)")
+    print("#" * 60)
+
+    available = []
+    for label, cfg in DATASETS.items():
+        path = cfg["path"]
+        if not os.path.isfile(path):
+            print(f"\n  WARNING: {path} not found — skipping {label}")
+            continue
+        size_mb = round(os.path.getsize(path) / (1024 * 1024), 1)
+        print(f"\n--- {label}: {cfg['description']}, file={size_mb} MB ---")
+        available.append((label, cfg))
+
+    # === load_tab_file ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 1: load_tab_file (sc.read_h5ad + obs + UMAP concat)")
+    print("=" * 60)
+
+    for label, cfg in available:
+        path = cfg["path"]
+        iters = cfg["iterations_func"]
+
+        def _load(p=path):
+            df = load_tab_file(p)
+            shape = df.shape
+            del df
+            gc.collect()
+            return shape
+
+        timer = BenchmarkTimer(f"load_tab_file [{label}]", iters)
+        timer.run(_load)
+        stats = timer.stats()
+
+        mem_result = measure_memory(_load)
+        mem = {k: v for k, v in mem_result.items() if k != "result"}
+        df_shape = mem_result["result"]
+
+        print_bench(stats, mem)
+        print(f"  DataFrame  : {df_shape[0]} rows × {df_shape[1]} cols")
+
+        all_results[f"load_tab_file_{label}"] = {**stats, **mem, "df_shape": list(df_shape)}
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# PART 2: API-level benchmarks
+# ---------------------------------------------------------------------------
+
+def run_api_benchmarks():
+    all_results = {}
+
+    print("\n\n" + "#" * 60)
+    print("# PART 2: API Endpoint Benchmarks (POST /datatable/load_data)")
+    print("#" * 60)
+
+    os.environ.pop("TESTING", None)
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    print("\n--- Setting up FastAPI TestClient ---")
+    client = TestClient(app)
+
+    # Authenticate
+    print("--- Authenticating as admin ---")
+    response = client.post(
+        "/routes/auth/login/access-token",
+        data={
+            "username": "cellcraft@cellcraft.com",
+            "password": "cellcraft2024!",
+        },
+    )
+    if response.status_code != 200:
+        print(f"  Login failed ({response.status_code}): {response.text}")
+        return {}
+    headers = {"Authorization": f"Bearer {response.json()['access_token']}"}
+    print("  Auth OK")
+
+    # Filter available datasets
+    api_datasets = {}
+    for label, cfg in DATASETS.items():
+        path = cfg["path"]
+        if not os.path.isfile(path):
+            continue
+        filename = os.path.basename(path)
+        api_datasets[label] = {
+            "filename": filename,
+            "iterations": cfg["iterations_api"],
+        }
+        print(f"  {label}: {filename}, iters={cfg['iterations_api']}")
+
+    def make_payload(filename, page=1, per_page=20, sort_field=None, sort_type=None, filters=None):
+        payload = {
+            "file_name": filename,
+            "source": "shared",
+            "page": page,
+            "perPage": per_page,
+            "columnFilters": filters or {},
+            "sort": [],
+        }
+        if sort_field and sort_type:
+            payload["sort"] = [{"field": sort_field, "type": sort_type}]
+        return payload
+
+    # === Scenario 1: Cold / Warm page loads ===
+    print("\n\n" + "=" * 60)
+    print("SCENARIO 1: Repeated page loads (page 1, same params)")
+    print("=" * 60)
+
+    for label, acfg in api_datasets.items():
+        iters = acfg["iterations"]
+        timer = BenchmarkTimer(f"API load_data repeated [{label}]", iters)
+        skip = False
+
+        for i in range(iters):
+            payload = make_payload(acfg["filename"])
+            start = time.perf_counter()
+            try:
+                resp = client.post("/routes/datatable/load_data", json=payload, headers=headers)
+                elapsed = time.perf_counter() - start
+            except Exception as e:
+                elapsed = time.perf_counter() - start
+                print(f"\n  ERROR [{label}] iter {i}: {type(e).__name__}: {str(e)[:200]}")
+                skip = True
+                break
+            timer.times.append(elapsed)
+
+            if i == 0:
+                if resp.status_code != 200:
+                    print(f"\n  ERROR [{label}]: status={resp.status_code}, body={resp.text[:300]}")
+                    skip = True
+                    break
+                body = resp.json()
+                print(f"\n  [{label}] First response: {len(body.get('rows', []))} rows, "
+                      f"{body.get('totalRecords', 0)} total, "
+                      f"{len(body.get('columns', []))} columns")
+
+        if skip:
+            print(f"  SKIPPING {label} due to error (likely NaN in data)")
+            continue
+
+        stats = timer.stats()
+        times_ms = [round(t * 1000, 2) for t in timer.times]
+        stats["times_ms"] = times_ms
+        cold = times_ms[0] if times_ms else 0
+        warm_avg = round(statistics.mean(times_ms[1:]), 2) if len(times_ms) > 1 else cold
+
+        print_bench(stats)
+        print(f"  Cold (1st) : {cold:.2f} ms")
+        print(f"  Warm (avg) : {warm_avg:.2f} ms")
+
+        all_results[f"api_repeated_{label}"] = {**stats, "cold_ms": cold, "warm_avg_ms": warm_avg}
+
+    # === Scenario 2: Page navigation ===
+    print("\n\n" + "=" * 60)
+    print("SCENARIO 2: Page navigation (page 1 → 2 → 3)")
+    print("=" * 60)
+
+    for label, acfg in api_datasets.items():
+        times = []
+        skip = False
+        for page in [1, 2, 3]:
+            payload = make_payload(acfg["filename"], page=page)
+            start = time.perf_counter()
+            try:
+                resp = client.post("/routes/datatable/load_data", json=payload, headers=headers)
+                elapsed = time.perf_counter() - start
+                times.append({"page": page, "ms": round(elapsed * 1000, 2), "status": resp.status_code})
+            except Exception as e:
+                elapsed = time.perf_counter() - start
+                print(f"\n  ERROR [{label}] page {page}: {type(e).__name__}: {str(e)[:200]}")
+                skip = True
+                break
+
+        if skip:
+            print(f"  SKIPPING {label} due to error")
+            continue
+
+        print(f"\n  [{label}] Page navigation:")
+        for t in times:
+            print(f"    Page {t['page']}: {t['ms']:.2f} ms (status={t['status']})")
+
+        all_results[f"api_pages_{label}"] = times
+
+    # === Scenario 3: Sort changes ===
+    print("\n\n" + "=" * 60)
+    print("SCENARIO 3: Sort changes (same file, different sort)")
+    print("=" * 60)
+
+    for label, acfg in api_datasets.items():
+        # First get column names from a load
+        payload = make_payload(acfg["filename"])
+        try:
+            resp = client.post("/routes/datatable/load_data", json=payload, headers=headers)
+        except Exception as e:
+            print(f"\n  SKIPPING {label} sort test: {type(e).__name__}: {str(e)[:200]}")
+            continue
+        if resp.status_code != 200:
+            print(f"\n  SKIPPING {label} sort test: status={resp.status_code}")
+            continue
+        columns = resp.json().get("columns", [])
+        sort_fields = [c["field"] for c in columns[:3]] if columns else []
+
+        times = []
+        skip = False
+        for field in sort_fields:
+            for sort_type in ["asc", "desc"]:
+                payload = make_payload(acfg["filename"], sort_field=field, sort_type=sort_type)
+                start = time.perf_counter()
+                try:
+                    resp = client.post("/routes/datatable/load_data", json=payload, headers=headers)
+                    elapsed = time.perf_counter() - start
+                    times.append({
+                        "sort": f"{field}/{sort_type}",
+                        "ms": round(elapsed * 1000, 2),
+                        "status": resp.status_code,
+                    })
+                except Exception as e:
+                    elapsed = time.perf_counter() - start
+                    print(f"\n  ERROR [{label}] sort {field}/{sort_type}: {type(e).__name__}")
+                    skip = True
+                    break
+            if skip:
+                break
+
+        if skip:
+            print(f"  SKIPPING {label} sort test due to error")
+            continue
+
+        print(f"\n  [{label}] Sort changes:")
+        for t in times:
+            print(f"    {t['sort']}: {t['ms']:.2f} ms (status={t['status']})")
+
+        all_results[f"api_sorts_{label}"] = times
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+def print_summary(func_results, api_results):
+    print("\n\n" + "=" * 70)
+    print("FUNCTION-LEVEL SUMMARY TABLE")
+    print("=" * 70)
+    print(f"{'Benchmark':<45} {'Mean (ms)':>10} {'Median (ms)':>12} {'Peak Mem (MB)':>14}")
+    print("-" * 85)
+    for key, val in func_results.items():
+        mem_str = str(val.get("tracemalloc_peak_mb", "N/A"))
+        print(f"{val['name']:<45} {val['mean_ms']:>10.2f} {val['median_ms']:>12.2f} {mem_str:>14}")
+
+    print("\n\n" + "=" * 70)
+    print("API-LEVEL SUMMARY TABLE")
+    print("=" * 70)
+
+    # Repeated loads summary
+    print(f"\n{'Endpoint':<45} {'Mean (ms)':>10} {'Cold (ms)':>10} {'Warm avg':>10}")
+    print("-" * 80)
+    for key, val in api_results.items():
+        if key.startswith("api_repeated_"):
+            print(f"{val['name']:<45} {val['mean_ms']:>10.2f} {val.get('cold_ms', 0):>10.2f} {val.get('warm_avg_ms', 0):>10.2f}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="DataTable benchmark suite")
+    parser.add_argument("--func", action="store_true", help="Run function-level benchmarks only")
+    parser.add_argument("--api", action="store_true", help="Run API-level benchmarks only")
+    args = parser.parse_args()
+
+    run_func = args.func or (not args.func and not args.api)
+    run_api = args.api or (not args.func and not args.api)
+
+    print("\n" + "#" * 70)
+    print("#  DataTable Benchmark — P2 Redis Caching")
+    print("#" * 70)
+
+    func_results = {}
+    api_results = {}
+
+    if run_func:
+        func_results = run_function_benchmarks()
+
+    if run_api:
+        api_results = run_api_benchmarks()
+
+    # Summary
+    print_summary(func_results, api_results)
+
+    # Combined JSON output
+    all_results = {"function_level": func_results, "api_level": api_results}
+    print("\n\n--- RAW JSON ---")
+    print(json.dumps(all_results, indent=2, default=str))
+
+    return all_results
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/benchmarks/run_function_benchmarks.py
+++ b/backend/tests/benchmarks/run_function_benchmarks.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python
+"""
+H5AD function-level benchmarks — Before Redis caching baseline.
+
+Standalone script (no pytest) to avoid root conftest DB dependency.
+
+Usage (inside backend container):
+    docker exec cellcraft-backend-1 python tests/benchmarks/run_function_benchmarks.py
+"""
+import gc
+import json
+import os
+import sys
+import tempfile
+import time
+import tracemalloc
+import statistics
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import scanpy as sc
+
+# Add backend root to path so we can import app modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from app.common.utils.h5ad_utils import (
+    get_annotation_columns,
+    get_pseudotime_columns,
+    organize_column_dtypes,
+)
+
+# ---------------------------------------------------------------------------
+# Inline benchmark utilities (no relative import needed)
+# ---------------------------------------------------------------------------
+ITERATIONS = 10
+
+
+class BenchmarkTimer:
+    def __init__(self, name: str, iterations: int = ITERATIONS):
+        self.name = name
+        self.iterations = iterations
+        self.times = []
+
+    def run(self, func, *args, **kwargs):
+        result = None
+        for _ in range(self.iterations):
+            start = time.perf_counter()
+            result = func(*args, **kwargs)
+            elapsed = time.perf_counter() - start
+            self.times.append(elapsed)
+        return result
+
+    def stats(self):
+        if not self.times:
+            return {}
+        s = sorted(self.times)
+        n = len(s)
+        return {
+            "name": self.name,
+            "iterations": n,
+            "mean_s": round(statistics.mean(s), 6),
+            "median_s": round(statistics.median(s), 6),
+            "std_s": round(statistics.stdev(s), 6) if n > 1 else 0.0,
+            "min_s": round(s[0], 6),
+            "max_s": round(s[-1], 6),
+            "p95_s": round(s[int(n * 0.95)], 6) if n >= 20 else round(s[-1], 6),
+            "mean_ms": round(statistics.mean(s) * 1000, 2),
+            "median_ms": round(statistics.median(s) * 1000, 2),
+        }
+
+
+def measure_memory(func, *args, **kwargs):
+    """Run func once, return tracemalloc peak and RSS delta."""
+    rss_before = _get_rss_kb()
+    tracemalloc.start()
+    result = func(*args, **kwargs)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    rss_after = _get_rss_kb()
+    return {
+        "result": result,
+        "tracemalloc_peak_mb": round(peak / (1024 * 1024), 2),
+        "rss_before_mb": round(rss_before / 1024, 2),
+        "rss_after_mb": round(rss_after / 1024, 2),
+        "rss_delta_mb": round((rss_after - rss_before) / 1024, 2),
+    }
+
+
+def _get_rss_kb():
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return float(line.split()[1])
+    except (FileNotFoundError, ValueError):
+        pass
+    try:
+        import resource
+        return float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Data preparation
+# ---------------------------------------------------------------------------
+REAL_H5AD = None
+for p in ["/app/tutorials/pbmc_light_1000.h5ad",
+          os.path.join(os.path.dirname(__file__), "..", "..", "tutorials", "pbmc_light_1000.h5ad")]:
+    if os.path.isfile(p):
+        REAL_H5AD = os.path.abspath(p)
+        break
+
+
+def create_h5ad(n_obs, n_vars, path):
+    adata = ad.AnnData(
+        X=np.random.rand(n_obs, n_vars).astype(np.float32),
+        obs=pd.DataFrame({
+            "cell_type": np.random.choice(["TypeA", "TypeB", "TypeC", "TypeD"], n_obs),
+            "cluster": np.random.choice([f"C{i}" for i in range(10)], n_obs),
+            "pseudotime": np.random.rand(n_obs),
+        }),
+        var=pd.DataFrame(index=[f"Gene{i}" for i in range(n_vars)]),
+    )
+    adata.obsm["X_umap"] = np.random.rand(n_obs, 2).astype(np.float32)
+    adata.write_h5ad(path)
+    size_mb = os.path.getsize(path) / (1024 * 1024)
+    del adata
+    gc.collect()
+    return size_mb
+
+
+def load_obs(h5ad_path):
+    adata = sc.read_h5ad(h5ad_path)
+    obs = adata.obs.copy()
+    del adata
+    gc.collect()
+    return obs
+
+
+# ---------------------------------------------------------------------------
+# Pipeline simulations (mirror endpoint logic)
+# ---------------------------------------------------------------------------
+def columns_pipeline(filepath):
+    """Mirrors files.py h5ad_columns endpoint."""
+    adata = sc.read_h5ad(filepath)
+    adata.obs = organize_column_dtypes(adata.obs)
+    anno = get_annotation_columns(adata.obs)
+    pseudo = get_pseudotime_columns(adata.obs)
+    result = {"anno_columns": anno, "pseudo_columns": pseudo}
+    del adata
+    gc.collect()
+    return result
+
+
+def clusters_pipeline(filepath, anno_column):
+    """Mirrors files.py h5ad_cluster endpoint."""
+    adata = sc.read_h5ad(filepath)
+    adata.obs = organize_column_dtypes(adata.obs)
+    clusters = list(map(str, adata.obs[anno_column].value_counts().index))
+    result = {"clusters": clusters}
+    del adata
+    gc.collect()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runner
+# ---------------------------------------------------------------------------
+def run_bench(name, func, *args, with_memory=True, **kwargs):
+    timer = BenchmarkTimer(name, ITERATIONS)
+    timer.run(func, *args, **kwargs)
+    stats = timer.stats()
+
+    mem = {}
+    if with_memory:
+        mem_result = measure_memory(func, *args, **kwargs)
+        mem = {k: v for k, v in mem_result.items() if k != "result"}
+
+    # Print formatted
+    print(f"\n{'='*60}")
+    print(f"  {stats['name']}")
+    print(f"{'='*60}")
+    print(f"  Iterations : {stats['iterations']}")
+    print(f"  Mean       : {stats['mean_ms']:.2f} ms")
+    print(f"  Median     : {stats['median_ms']:.2f} ms")
+    print(f"  Std        : {stats.get('std_s', 0)*1000:.2f} ms")
+    print(f"  Min        : {stats['min_s']*1000:.2f} ms")
+    print(f"  Max        : {stats['max_s']*1000:.2f} ms")
+    if mem:
+        print(f"  Peak Mem   : {mem.get('tracemalloc_peak_mb', 'N/A')} MB (tracemalloc)")
+        print(f"  RSS Delta  : {mem.get('rss_delta_mb', 'N/A')} MB")
+
+    return {**stats, **mem}
+
+
+def main():
+    all_results = {}
+
+    print("\n" + "#" * 60)
+    print("# H5AD Function Benchmark — Before Redis Caching Baseline")
+    print("#" * 60)
+
+    # --- Create test data ---
+    tmpdir = tempfile.mkdtemp(prefix="bench_h5ad_")
+    small_path = os.path.join(tmpdir, "small.h5ad")
+    large_path = os.path.join(tmpdir, "large.h5ad")
+
+    print("\n--- Preparing test data ---")
+    small_size = create_h5ad(100, 50, small_path)
+    print(f"  Small (100×50)   : {small_size:.2f} MB → {small_path}")
+    large_size = create_h5ad(10_000, 2_000, large_path)
+    print(f"  Large (10k×2k)   : {large_size:.2f} MB → {large_path}")
+    if REAL_H5AD:
+        real_size = os.path.getsize(REAL_H5AD) / (1024 * 1024)
+        print(f"  Real (pbmc 1k)   : {real_size:.2f} MB → {REAL_H5AD}")
+    else:
+        print("  Real (pbmc 1k)   : NOT FOUND — skipping real data tests")
+
+    datasets = [
+        ("small", small_path),
+        ("large", large_path),
+    ]
+    if REAL_H5AD:
+        datasets.append(("real", REAL_H5AD))
+
+    # ==================================================================
+    # 1. scanpy.read_h5ad
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SECTION 1: scanpy.read_h5ad")
+    print("=" * 60)
+
+    for label, path in datasets:
+        def _read(p=path):
+            a = sc.read_h5ad(p)
+            shape = a.shape
+            del a
+            gc.collect()
+            return shape
+
+        r = run_bench(f"scanpy.read_h5ad [{label}]", _read)
+        all_results[f"read_h5ad_{label}"] = r
+
+    # ==================================================================
+    # 2. organize_column_dtypes
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SECTION 2: organize_column_dtypes")
+    print("=" * 60)
+
+    for label, path in datasets:
+        obs = load_obs(path)
+        r = run_bench(f"organize_column_dtypes [{label}]", organize_column_dtypes, obs)
+        all_results[f"organize_dtypes_{label}"] = r
+
+    # ==================================================================
+    # 3. get_annotation_columns
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SECTION 3: get_annotation_columns")
+    print("=" * 60)
+
+    for label, path in datasets:
+        obs = load_obs(path)
+        r = run_bench(f"get_annotation_columns [{label}]", get_annotation_columns, obs)
+        all_results[f"anno_columns_{label}"] = r
+
+    # ==================================================================
+    # 4. get_pseudotime_columns
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SECTION 4: get_pseudotime_columns")
+    print("=" * 60)
+
+    for label, path in datasets:
+        obs = load_obs(path)
+        r = run_bench(f"get_pseudotime_columns [{label}]", get_pseudotime_columns, obs)
+        all_results[f"pseudo_columns_{label}"] = r
+
+    # ==================================================================
+    # 5. Full /columns pipeline
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SECTION 5: /columns Full Pipeline (read + organize + anno + pseudo)")
+    print("=" * 60)
+
+    for label, path in datasets:
+        r = run_bench(f"columns_pipeline [{label}]", columns_pipeline, path)
+        all_results[f"columns_pipeline_{label}"] = r
+
+    # ==================================================================
+    # 6. Full /clusters pipeline
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SECTION 6: /clusters Full Pipeline (read + organize + value_counts)")
+    print("=" * 60)
+
+    for label, path in datasets:
+        # Determine a valid annotation column
+        if label == "real":
+            obs = load_obs(path)
+            anno_cols = get_annotation_columns(obs)
+            anno_col = anno_cols[0] if anno_cols else "cluster"
+        else:
+            anno_col = "cluster"
+
+        r = run_bench(f"clusters_pipeline [{label}]", clusters_pipeline, path, anno_col)
+        all_results[f"clusters_pipeline_{label}"] = r
+
+    # ==================================================================
+    # Summary table
+    # ==================================================================
+    print("\n\n" + "=" * 60)
+    print("SUMMARY TABLE")
+    print("=" * 60)
+    print(f"{'Benchmark':<45} {'Mean (ms)':>10} {'Median (ms)':>12} {'Peak Mem (MB)':>14}")
+    print("-" * 85)
+    for key, val in all_results.items():
+        mem_str = str(val.get("tracemalloc_peak_mb", "N/A"))
+        print(f"{val['name']:<45} {val['mean_ms']:>10.2f} {val['median_ms']:>12.2f} {mem_str:>14}")
+
+    # ==================================================================
+    # JSON output
+    # ==================================================================
+    json_path = os.path.join(tmpdir, "benchmark_results.json")
+    with open(json_path, "w") as f:
+        json.dump(all_results, f, indent=2)
+    print(f"\n  Raw JSON saved → {json_path}")
+
+    # Also print JSON to stdout for capture
+    print("\n--- RAW JSON ---")
+    print(json.dumps(all_results, indent=2))
+
+    # Cleanup
+    import shutil
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return all_results
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/benchmarks/run_plugin_list_benchmarks.py
+++ b/backend/tests/benchmarks/run_plugin_list_benchmarks.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python
+"""
+Plugin List benchmarks — Before/After Redis caching + code optimizations.
+
+Measures GET /plugin/list performance across three scenarios:
+  1. Before (original code path simulation): cache disabled, old loop pattern
+  2. Cold  (optimized, cache miss): cache cleared before each call
+  3. Warm  (cache hit): cached response served from Redis
+
+Usage (inside backend container):
+    docker exec cellcraft-backend-1 python tests/benchmarks/run_plugin_list_benchmarks.py
+"""
+import json
+import os
+import sys
+import time
+import statistics
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+
+# ---------------------------------------------------------------------------
+# Benchmark utilities
+# ---------------------------------------------------------------------------
+
+class BenchmarkTimer:
+    def __init__(self, name: str):
+        self.name = name
+        self.times = []
+
+    def record(self, elapsed: float):
+        self.times.append(elapsed)
+
+    def stats(self):
+        if not self.times:
+            return {"name": self.name, "iterations": 0}
+        s = sorted(self.times)
+        n = len(s)
+        return {
+            "name": self.name,
+            "iterations": n,
+            "mean_ms": round(statistics.mean(s) * 1000, 2),
+            "median_ms": round(statistics.median(s) * 1000, 2),
+            "std_ms": round(statistics.stdev(s) * 1000, 2) if n > 1 else 0.0,
+            "min_ms": round(s[0] * 1000, 2),
+            "max_ms": round(s[-1] * 1000, 2),
+            "times_ms": [round(t * 1000, 2) for t in self.times],
+        }
+
+
+def print_bench(stats):
+    print(f"\n{'='*60}")
+    print(f"  {stats['name']}")
+    print(f"{'='*60}")
+    print(f"  Iterations : {stats['iterations']}")
+    print(f"  Mean       : {stats['mean_ms']:.2f} ms")
+    print(f"  Median     : {stats['median_ms']:.2f} ms")
+    print(f"  Std        : {stats.get('std_ms', 0):.2f} ms")
+    print(f"  Min        : {stats['min_ms']:.2f} ms")
+    print(f"  Max        : {stats['max_ms']:.2f} ms")
+    if stats.get("times_ms"):
+        print(f"  All times  : {stats['times_ms']}")
+
+
+# ---------------------------------------------------------------------------
+# Setup: FastAPI TestClient + Auth
+# ---------------------------------------------------------------------------
+
+def setup_client():
+    os.environ.pop("TESTING", None)
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    print("\n--- Setting up FastAPI TestClient ---")
+    client = TestClient(app)
+
+    print("--- Authenticating as admin ---")
+    response = client.post(
+        "/routes/auth/login/access-token",
+        data={
+            "username": "cellcraft@cellcraft.com",
+            "password": "cellcraft2024!",
+        },
+    )
+    if response.status_code != 200:
+        print(f"  Login failed ({response.status_code}): {response.text}")
+        sys.exit(1)
+
+    token = response.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    print("  Auth OK")
+
+    # Extract user_id from token for cache operations
+    from app.routes.dep import get_current_active_user
+    import jwt
+    from app.common.config import settings
+    payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+    user_id = payload.get("sub")
+    print(f"  User ID: {user_id}")
+
+    return client, headers, user_id
+
+
+# ---------------------------------------------------------------------------
+# Redis cache helpers
+# ---------------------------------------------------------------------------
+
+def clear_plugin_cache():
+    """Clear all plugin list cache entries from Redis."""
+    try:
+        from app.common.utils.redis_cache import cache_delete_pattern
+        count = cache_delete_pattern("plugin:list:*")
+        return count
+    except Exception as e:
+        print(f"  WARNING: Failed to clear plugin cache: {e}")
+        return 0
+
+
+def check_cache_exists(user_id):
+    """Check if cache exists for user."""
+    try:
+        from app.common.utils.redis_cache import cache_get_bytes
+        data = cache_get_bytes(f"plugin:list:{user_id}")
+        return data is not None
+    except Exception:
+        return False
+
+
+def get_cache_size(user_id):
+    """Get size of cached data in bytes."""
+    try:
+        from app.common.utils.redis_cache import cache_get_bytes
+        data = cache_get_bytes(f"plugin:list:{user_id}")
+        return len(data) if data else 0
+    except Exception:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: "Before" — Original code path simulation
+# ---------------------------------------------------------------------------
+
+def run_before_benchmark(client, headers, iterations=5):
+    """
+    Simulate original code path by clearing cache before every call.
+
+    Note: The code optimizations (get_user_task outside loop, Docker client reuse)
+    are already in place. This measures the "cold" path with optimizations applied.
+    For true "before" comparison, we also run the old-style function directly.
+    """
+    print("\n\n" + "#" * 60)
+    print("# SCENARIO 1: Before (cache disabled — clear before each call)")
+    print("# This simulates pre-cache behavior. Code optimizations are")
+    print("# already applied, so this is optimized-cold, not true-original.")
+    print("#" * 60)
+
+    timer = BenchmarkTimer("GET /plugin/list [cache disabled]")
+
+    for i in range(iterations):
+        clear_plugin_cache()
+
+        start = time.perf_counter()
+        resp = client.get("/routes/plugin/list", headers=headers)
+        elapsed = time.perf_counter() - start
+        timer.record(elapsed)
+
+        if i == 0:
+            if resp.status_code != 200:
+                print(f"  ERROR: status={resp.status_code}, body={resp.text[:300]}")
+                return {}
+            body = resp.json()
+            plugin_count = len(body.get("plugins", []))
+            print(f"\n  Response: {plugin_count} plugins, status={resp.status_code}")
+
+        # Clear cache after each call to force next call to be cold
+        clear_plugin_cache()
+
+    stats = timer.stats()
+    print_bench(stats)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1b: True "Before" — Old code path with N queries + N docker calls
+# ---------------------------------------------------------------------------
+
+def run_true_before_benchmark(db_session, user_id, iterations=5):
+    """
+    Execute the original list_plugins logic (before code optimizations):
+    - get_user_task() called N times inside loop
+    - docker.from_env() called N times inside loop
+
+    This gives us the true "before" baseline.
+    """
+    print("\n\n" + "#" * 60)
+    print("# SCENARIO 1b: True Before (original code path, no optimizations)")
+    print("# Reproduces N×get_user_task + N×docker.from_env loop pattern")
+    print("#" * 60)
+
+    from app.database.crud import crud_plugin
+    from app.database.crud.crud_task import get_user_task
+    from celery.result import AsyncResult
+    from datetime import datetime
+    import docker
+
+    timer = BenchmarkTimer("list_plugins [original code path]")
+
+    for iteration in range(iterations):
+        start = time.perf_counter()
+
+        # === Original code path (pre-optimization) ===
+        plugins = crud_plugin.get_plugins(db_session)
+        plugin_list = []
+
+        for plugin in plugins:
+            plugin_dict = plugin.__dict__.copy()
+            plugin_dict['users'] = [user.__dict__ for user in plugin.users]
+
+            if 'rules' in plugin_dict and plugin_dict['rules']:
+                rules_dict = plugin_dict['rules']
+                rules_array = [rules_dict[str(i)] for i in range(len(rules_dict))]
+                plugin_dict['rules'] = rules_array
+
+            # Original: check_plugin_docker_image per plugin (creates client each time)
+            try:
+                if plugin.source == "local":
+                    docker_client = None
+                    try:
+                        docker_client = docker.from_env()
+                        image_tag = f"plugin-{plugin.name.lower()}"
+                        docker_client.images.get(image_tag)
+                        plugin_dict['docker_image_exists'] = True
+                    except docker.errors.ImageNotFound:
+                        plugin_dict['docker_image_exists'] = False
+                    except Exception:
+                        plugin_dict['docker_image_exists'] = False
+                    finally:
+                        if docker_client:
+                            docker_client.close()
+                else:
+                    plugin_dict['docker_image_exists'] = False
+            except Exception:
+                plugin_dict['docker_image_exists'] = False
+
+            # Original: get_user_task called EVERY iteration (N times)
+            try:
+                user_tasks = get_user_task(db_session, int(user_id))
+                plugin_build_tasks = [
+                    task for task in user_tasks
+                    if task.task_type == "plugin_build" and task.plugin_name == plugin.name
+                ]
+                if plugin_build_tasks:
+                    latest_task = max(plugin_build_tasks,
+                                     key=lambda x: x.start_time or datetime.min.replace(tzinfo=None))
+                    task_result = AsyncResult(latest_task.task_id)
+                    plugin_dict['latest_build'] = {
+                        "task_id": latest_task.task_id,
+                        "status": task_result.state,
+                        "start_time": latest_task.start_time.isoformat() if latest_task.start_time else None,
+                        "end_time": latest_task.end_time.isoformat() if latest_task.end_time else None,
+                    }
+                else:
+                    plugin_dict['latest_build'] = None
+            except Exception:
+                plugin_dict['latest_build'] = None
+
+            if plugin.source == "official":
+                plugin_dict['current_version'] = plugin.version or "1.0"
+                plugin_dict['available_versions'] = []
+            else:
+                plugin_dict['current_version'] = plugin.version or "local"
+                plugin_dict['available_versions'] = []
+
+            plugin_list.append(plugin_dict)
+
+        response = {"plugins": plugin_list}
+        elapsed = time.perf_counter() - start
+        timer.record(elapsed)
+
+        if iteration == 0:
+            print(f"\n  Response: {len(plugin_list)} plugins")
+
+    stats = timer.stats()
+    print_bench(stats)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Cold (optimized, cache miss)
+# ---------------------------------------------------------------------------
+
+def run_cold_benchmark(client, headers, user_id, iterations=5):
+    """Measure optimized code with cache miss (clear before each call)."""
+    print("\n\n" + "#" * 60)
+    print("# SCENARIO 2: Cold (optimized code, cache miss)")
+    print("# Cache is cleared before each call")
+    print("#" * 60)
+
+    timer = BenchmarkTimer("GET /plugin/list [cold — cache miss]")
+
+    for i in range(iterations):
+        clear_plugin_cache()
+
+        start = time.perf_counter()
+        resp = client.get("/routes/plugin/list", headers=headers)
+        elapsed = time.perf_counter() - start
+        timer.record(elapsed)
+
+        if i == 0 and resp.status_code != 200:
+            print(f"  ERROR: status={resp.status_code}")
+            return {}
+
+        # Verify cache was created
+        if i == 0:
+            exists = check_cache_exists(user_id)
+            size = get_cache_size(user_id)
+            print(f"\n  Cache created: {exists}, size: {size} bytes ({size/1024:.1f} KB)")
+
+        clear_plugin_cache()
+
+    stats = timer.stats()
+    print_bench(stats)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Warm (cache hit)
+# ---------------------------------------------------------------------------
+
+def run_warm_benchmark(client, headers, user_id, iterations=10):
+    """Measure cache hit performance."""
+    print("\n\n" + "#" * 60)
+    print("# SCENARIO 3: Warm (cache hit)")
+    print("# First call populates cache, subsequent calls are cache hits")
+    print("#" * 60)
+
+    # Ensure cache is populated
+    clear_plugin_cache()
+    resp = client.get("/routes/plugin/list", headers=headers)
+    if resp.status_code != 200:
+        print(f"  ERROR populating cache: status={resp.status_code}")
+        return {}
+
+    exists = check_cache_exists(user_id)
+    size = get_cache_size(user_id)
+    print(f"\n  Cache populated: {exists}, size: {size} bytes ({size/1024:.1f} KB)")
+
+    timer = BenchmarkTimer("GET /plugin/list [warm — cache hit]")
+
+    for i in range(iterations):
+        start = time.perf_counter()
+        resp = client.get("/routes/plugin/list", headers=headers)
+        elapsed = time.perf_counter() - start
+        timer.record(elapsed)
+
+    stats = timer.stats()
+    print_bench(stats)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Cache invalidation + re-population
+# ---------------------------------------------------------------------------
+
+def run_invalidation_benchmark(client, headers, user_id, iterations=5):
+    """Measure invalidation + re-population cycle."""
+    print("\n\n" + "#" * 60)
+    print("# SCENARIO 4: Invalidation + Re-population cycle")
+    print("# Simulates associate/dissociate → next list call")
+    print("#" * 60)
+
+    timer_invalidate = BenchmarkTimer("invalidate_all_plugin_cache()")
+    timer_repopulate = BenchmarkTimer("GET /plugin/list [after invalidation]")
+
+    # Ensure cache exists
+    clear_plugin_cache()
+    client.get("/routes/plugin/list", headers=headers)
+
+    for i in range(iterations):
+        # Measure invalidation
+        start = time.perf_counter()
+        from app.common.utils.plugin_cache import invalidate_all_plugin_cache
+        invalidate_all_plugin_cache()
+        elapsed = time.perf_counter() - start
+        timer_invalidate.record(elapsed)
+
+        # Measure re-population
+        start = time.perf_counter()
+        resp = client.get("/routes/plugin/list", headers=headers)
+        elapsed = time.perf_counter() - start
+        timer_repopulate.record(elapsed)
+
+    stats_inv = timer_invalidate.stats()
+    stats_rep = timer_repopulate.stats()
+    print_bench(stats_inv)
+    print_bench(stats_rep)
+    return {"invalidation": stats_inv, "repopulation": stats_rep}
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Redis fallback (graceful degradation)
+# ---------------------------------------------------------------------------
+
+def run_fallback_check(client, headers):
+    """Verify endpoint works when Redis is unreachable (manual check instruction)."""
+    print("\n\n" + "#" * 60)
+    print("# SCENARIO 5: Redis fallback verification")
+    print("#" * 60)
+    print("\n  To verify Redis fallback, run manually:")
+    print("    1. docker stop cellcraft-redis-1")
+    print("    2. curl -H 'Authorization: Bearer <token>' http://localhost:8000/routes/plugin/list")
+    print("    3. Verify response is 200 with plugins data")
+    print("    4. docker start cellcraft-redis-1")
+    print("\n  (Automated test skipped — stopping Redis affects other services)")
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+def print_summary(results):
+    print("\n\n" + "=" * 70)
+    print("SUMMARY — P3: Plugin List Cache Performance")
+    print("=" * 70)
+
+    print(f"\n{'Scenario':<50} {'Mean (ms)':>10} {'Median (ms)':>12}")
+    print("-" * 75)
+
+    for key in ["true_before", "cold", "warm"]:
+        if key in results and results[key].get("iterations", 0) > 0:
+            r = results[key]
+            print(f"{r['name']:<50} {r['mean_ms']:>10.2f} {r['median_ms']:>12.2f}")
+
+    # Speedup calculations
+    print("\n" + "-" * 75)
+    before = results.get("true_before", {})
+    cold = results.get("cold", {})
+    warm = results.get("warm", {})
+
+    if before.get("mean_ms") and cold.get("mean_ms"):
+        speedup = before["mean_ms"] / cold["mean_ms"]
+        print(f"  Code optimization speedup (before→cold): {speedup:.1f}x")
+        print(f"    ({before['mean_ms']:.0f}ms → {cold['mean_ms']:.0f}ms)")
+
+    if before.get("mean_ms") and warm.get("mean_ms"):
+        speedup = before["mean_ms"] / warm["mean_ms"]
+        print(f"  Cache hit speedup (before→warm):          {speedup:.0f}x")
+        print(f"    ({before['mean_ms']:.0f}ms → {warm['mean_ms']:.0f}ms)")
+
+    if cold.get("mean_ms") and warm.get("mean_ms"):
+        speedup = cold["mean_ms"] / warm["mean_ms"]
+        print(f"  Cache hit speedup (cold→warm):            {speedup:.0f}x")
+        print(f"    ({cold['mean_ms']:.0f}ms → {warm['mean_ms']:.0f}ms)")
+
+    # Invalidation info
+    inv = results.get("invalidation", {})
+    if isinstance(inv, dict) and "invalidation" in inv:
+        inv_stats = inv["invalidation"]
+        rep_stats = inv["repopulation"]
+        print(f"\n  Invalidation time: {inv_stats.get('mean_ms', 0):.2f}ms avg")
+        print(f"  Re-population time: {rep_stats.get('mean_ms', 0):.2f}ms avg")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("\n" + "#" * 70)
+    print("#  P3: Plugin List Cache Benchmark")
+    print("#  Before/After Redis Caching + Code Optimizations")
+    print("#" * 70)
+
+    client, headers, user_id = setup_client()
+
+    results = {}
+
+    # Scenario 1b: True before (original code path)
+    try:
+        from app.database.conn import get_db_session
+        with get_db_session() as db:
+            results["true_before"] = run_true_before_benchmark(db, user_id, iterations=5)
+    except Exception as e:
+        print(f"\n  WARNING: True before benchmark failed: {e}")
+        import traceback
+        traceback.print_exc()
+
+    # Scenario 2: Cold (optimized, cache miss)
+    results["cold"] = run_cold_benchmark(client, headers, user_id, iterations=5)
+
+    # Scenario 3: Warm (cache hit)
+    results["warm"] = run_warm_benchmark(client, headers, user_id, iterations=10)
+
+    # Scenario 4: Invalidation cycle
+    results["invalidation"] = run_invalidation_benchmark(client, headers, user_id, iterations=5)
+
+    # Scenario 5: Fallback info
+    run_fallback_check(client, headers)
+
+    # Summary
+    print_summary(results)
+
+    # Clean up
+    clear_plugin_cache()
+
+    # Raw JSON
+    print("\n\n--- RAW JSON ---")
+    print(json.dumps(results, indent=2, default=str))
+
+    return results
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/benchmarks/run_realdata_benchmarks.py
+++ b/backend/tests/benchmarks/run_realdata_benchmarks.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python
+"""
+Real scRNA-seq data benchmarks — Before Redis caching baseline.
+
+Measures function-level and API-level performance using actual h5ad files
+(pbmc_light_1000, CRCBraw, GTEx_8_tissues) to establish realistic baselines.
+
+Usage (inside backend container):
+    docker exec cellcraft-backend-1 python tests/benchmarks/run_realdata_benchmarks.py
+"""
+import gc
+import json
+import os
+import sys
+import time
+import statistics
+import tracemalloc
+
+import scanpy as sc
+
+# Add backend root to path so we can import app modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from app.common.utils.h5ad_utils import (
+    get_annotation_columns,
+    get_pseudotime_columns,
+    organize_column_dtypes,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DATASETS = {
+    "pbmc": {
+        "path": "/app/tutorials/pbmc_light_1000.h5ad",
+        "iterations_func": 10,
+        "iterations_api": 10,
+        "description": "1K cells × 13.7K genes, 27 MB",
+    },
+    "CRC": {
+        "path": "/app/tutorials/CRCBraw.h5ad",
+        "iterations_func": 10,
+        "iterations_api": 10,
+        "description": "12.6K cells × 27.9K genes, 138 MB",
+    },
+    "GTEx": {
+        "path": "/app/tutorials/GTEx_8_tissues.h5ad",
+        "iterations_func": 5,
+        "iterations_api": 3,
+        "description": "209K cells × 17.7K genes, 1.8 GB",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Benchmark utilities
+# ---------------------------------------------------------------------------
+
+class BenchmarkTimer:
+    def __init__(self, name: str, iterations: int):
+        self.name = name
+        self.iterations = iterations
+        self.times = []
+
+    def run(self, func, *args, **kwargs):
+        result = None
+        for _ in range(self.iterations):
+            start = time.perf_counter()
+            result = func(*args, **kwargs)
+            elapsed = time.perf_counter() - start
+            self.times.append(elapsed)
+        return result
+
+    def stats(self):
+        if not self.times:
+            return {}
+        s = sorted(self.times)
+        n = len(s)
+        return {
+            "name": self.name,
+            "iterations": n,
+            "mean_s": round(statistics.mean(s), 6),
+            "median_s": round(statistics.median(s), 6),
+            "std_s": round(statistics.stdev(s), 6) if n > 1 else 0.0,
+            "min_s": round(s[0], 6),
+            "max_s": round(s[-1], 6),
+            "p95_s": round(s[int(n * 0.95)], 6) if n >= 20 else round(s[-1], 6),
+            "mean_ms": round(statistics.mean(s) * 1000, 2),
+            "median_ms": round(statistics.median(s) * 1000, 2),
+        }
+
+
+def measure_memory(func, *args, **kwargs):
+    """Run func once, return tracemalloc peak and RSS delta."""
+    rss_before = _get_rss_kb()
+    tracemalloc.start()
+    result = func(*args, **kwargs)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    rss_after = _get_rss_kb()
+    return {
+        "result": result,
+        "tracemalloc_peak_mb": round(peak / (1024 * 1024), 2),
+        "rss_before_mb": round(rss_before / 1024, 2),
+        "rss_after_mb": round(rss_after / 1024, 2),
+        "rss_delta_mb": round((rss_after - rss_before) / 1024, 2),
+    }
+
+
+def _get_rss_kb():
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return float(line.split()[1])
+    except (FileNotFoundError, ValueError):
+        pass
+    try:
+        import resource
+        return float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+def load_obs(h5ad_path):
+    adata = sc.read_h5ad(h5ad_path)
+    obs = adata.obs.copy()
+    del adata
+    gc.collect()
+    return obs
+
+
+def columns_pipeline(filepath):
+    """Mirrors files.py h5ad_columns endpoint."""
+    adata = sc.read_h5ad(filepath)
+    adata.obs = organize_column_dtypes(adata.obs)
+    anno = get_annotation_columns(adata.obs)
+    pseudo = get_pseudotime_columns(adata.obs)
+    result = {"anno_columns": anno, "pseudo_columns": pseudo}
+    del adata
+    gc.collect()
+    return result
+
+
+def clusters_pipeline(filepath, anno_column):
+    """Mirrors files.py h5ad_cluster endpoint."""
+    adata = sc.read_h5ad(filepath)
+    adata.obs = organize_column_dtypes(adata.obs)
+    clusters = list(map(str, adata.obs[anno_column].value_counts().index))
+    result = {"clusters": clusters}
+    del adata
+    gc.collect()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runner
+# ---------------------------------------------------------------------------
+
+def run_bench(name, func, iterations, *args, with_memory=True, **kwargs):
+    timer = BenchmarkTimer(name, iterations)
+    timer.run(func, *args, **kwargs)
+    stats = timer.stats()
+
+    mem = {}
+    if with_memory:
+        mem_result = measure_memory(func, *args, **kwargs)
+        mem = {k: v for k, v in mem_result.items() if k != "result"}
+
+    print(f"\n{'='*60}")
+    print(f"  {stats['name']}")
+    print(f"{'='*60}")
+    print(f"  Iterations : {stats['iterations']}")
+    print(f"  Mean       : {stats['mean_ms']:.2f} ms")
+    print(f"  Median     : {stats['median_ms']:.2f} ms")
+    print(f"  Std        : {stats.get('std_s', 0)*1000:.2f} ms")
+    print(f"  Min        : {stats['min_s']*1000:.2f} ms")
+    print(f"  Max        : {stats['max_s']*1000:.2f} ms")
+    if mem:
+        print(f"  Peak Mem   : {mem.get('tracemalloc_peak_mb', 'N/A')} MB (tracemalloc)")
+        print(f"  RSS Delta  : {mem.get('rss_delta_mb', 'N/A')} MB")
+
+    return {**stats, **mem}
+
+
+def get_data_info(path):
+    """Read h5ad once to get shape, obs columns, and sparsity info."""
+    adata = sc.read_h5ad(path)
+    info = {
+        "n_obs": adata.n_obs,
+        "n_vars": adata.n_vars,
+        "obs_columns": list(adata.obs.columns),
+        "n_obs_columns": len(adata.obs.columns),
+        "file_size_mb": round(os.path.getsize(path) / (1024 * 1024), 1),
+    }
+    # Sparsity
+    try:
+        from scipy import sparse
+        if sparse.issparse(adata.X):
+            info["sparse"] = True
+            info["dtype"] = str(adata.X.dtype)
+            total = adata.X.shape[0] * adata.X.shape[1]
+            nnz = adata.X.nnz
+            info["sparsity_pct"] = round((1 - nnz / total) * 100, 1)
+        else:
+            info["sparse"] = False
+            info["dtype"] = str(adata.X.dtype)
+    except Exception:
+        pass
+
+    # Find annotation column
+    obs_organized = organize_column_dtypes(adata.obs)
+    anno_cols = get_annotation_columns(obs_organized)
+    info["anno_columns_detected"] = anno_cols
+    info["first_anno_col"] = anno_cols[0] if anno_cols else None
+
+    del adata
+    gc.collect()
+    return info
+
+
+# ---------------------------------------------------------------------------
+# PART 1: Function-level benchmarks
+# ---------------------------------------------------------------------------
+
+def run_function_benchmarks():
+    all_results = {}
+
+    print("\n" + "#" * 60)
+    print("# PART 1: Function-Level Benchmarks (Real scRNA-seq Data)")
+    print("#" * 60)
+
+    # Collect dataset info
+    data_info = {}
+    for label, cfg in DATASETS.items():
+        path = cfg["path"]
+        if not os.path.isfile(path):
+            print(f"\n  WARNING: {path} not found — skipping {label}")
+            continue
+        print(f"\n--- Profiling {label}: {cfg['description']} ---")
+        info = get_data_info(path)
+        data_info[label] = info
+        print(f"  Shape     : {info['n_obs']} × {info['n_vars']}")
+        print(f"  obs cols  : {info['n_obs_columns']}")
+        print(f"  Sparse    : {info.get('sparse', 'N/A')}, dtype={info.get('dtype', 'N/A')}")
+        if info.get("sparse"):
+            print(f"  Sparsity  : {info.get('sparsity_pct', 'N/A')}%")
+        print(f"  Anno cols : {info.get('first_anno_col', 'N/A')}")
+
+    all_results["data_info"] = data_info
+    available = [(l, c) for l, c in DATASETS.items() if l in data_info]
+
+    # === 1. scanpy.read_h5ad ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 1: scanpy.read_h5ad")
+    print("=" * 60)
+
+    for label, cfg in available:
+        path = cfg["path"]
+        iters = cfg["iterations_func"]
+
+        def _read(p=path):
+            a = sc.read_h5ad(p)
+            shape = a.shape
+            del a
+            gc.collect()
+            return shape
+
+        r = run_bench(f"scanpy.read_h5ad [{label}]", _read, iters)
+        all_results[f"read_h5ad_{label}"] = r
+
+    # === 2. organize_column_dtypes ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 2: organize_column_dtypes")
+    print("=" * 60)
+
+    for label, cfg in available:
+        path = cfg["path"]
+        iters = cfg["iterations_func"]
+        obs = load_obs(path)
+        r = run_bench(f"organize_column_dtypes [{label}]", organize_column_dtypes, iters, obs)
+        all_results[f"organize_dtypes_{label}"] = r
+        del obs
+        gc.collect()
+
+    # === 3. get_annotation_columns ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 3: get_annotation_columns")
+    print("=" * 60)
+
+    for label, cfg in available:
+        path = cfg["path"]
+        iters = cfg["iterations_func"]
+        obs = load_obs(path)
+        r = run_bench(f"get_annotation_columns [{label}]", get_annotation_columns, iters, obs)
+        all_results[f"anno_columns_{label}"] = r
+        del obs
+        gc.collect()
+
+    # === 4. get_pseudotime_columns ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 4: get_pseudotime_columns")
+    print("=" * 60)
+
+    for label, cfg in available:
+        path = cfg["path"]
+        iters = cfg["iterations_func"]
+        obs = load_obs(path)
+        r = run_bench(f"get_pseudotime_columns [{label}]", get_pseudotime_columns, iters, obs)
+        all_results[f"pseudo_columns_{label}"] = r
+        del obs
+        gc.collect()
+
+    # === 5. Full /columns pipeline ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 5: /columns Full Pipeline (read + organize + anno + pseudo)")
+    print("=" * 60)
+
+    for label, cfg in available:
+        path = cfg["path"]
+        iters = cfg["iterations_func"]
+        r = run_bench(f"columns_pipeline [{label}]", columns_pipeline, iters, path)
+        all_results[f"columns_pipeline_{label}"] = r
+
+    # === 6. Full /clusters pipeline ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 6: /clusters Full Pipeline (read + organize + value_counts)")
+    print("=" * 60)
+
+    for label, cfg in available:
+        path = cfg["path"]
+        iters = cfg["iterations_func"]
+        anno_col = data_info[label].get("first_anno_col")
+        if not anno_col:
+            print(f"\n  SKIP {label}: no annotation column detected")
+            continue
+        r = run_bench(f"clusters_pipeline [{label}]", clusters_pipeline, iters, path, anno_col)
+        all_results[f"clusters_pipeline_{label}"] = r
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# PART 2: API-level benchmarks
+# ---------------------------------------------------------------------------
+
+def run_api_benchmarks():
+    all_results = {}
+
+    print("\n\n" + "#" * 60)
+    print("# PART 2: API Endpoint Benchmarks (Real scRNA-seq Data)")
+    print("#" * 60)
+
+    # Import here to delay app init
+    os.environ.pop("TESTING", None)
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    print("\n--- Setting up FastAPI TestClient ---")
+    client = TestClient(app)
+
+    # Authenticate
+    print("--- Authenticating as admin ---")
+    response = client.post(
+        "/routes/auth/login/access-token",
+        data={
+            "username": "cellcraft@cellcraft.com",
+            "password": "cellcraft2024!",
+        },
+    )
+    if response.status_code != 200:
+        print(f"  Login failed ({response.status_code}): {response.text}")
+        return {}
+    headers = {"Authorization": f"Bearer {response.json()['access_token']}"}
+    print("  Auth OK")
+
+    # Only test CRC and GTEx via API (pbmc already measured in previous benchmarks)
+    api_datasets = {}
+    for label, cfg in DATASETS.items():
+        path = cfg["path"]
+        if not os.path.isfile(path):
+            continue
+        # Get annotation column
+        adata = sc.read_h5ad(path)
+        obs_organized = organize_column_dtypes(adata.obs)
+        anno_cols = get_annotation_columns(obs_organized)
+        anno_col = anno_cols[0] if anno_cols else None
+        del adata
+        gc.collect()
+
+        filename = os.path.basename(path)
+        api_datasets[label] = {
+            "filename": filename,
+            "anno_col": anno_col,
+            "iterations": cfg["iterations_api"],
+        }
+        print(f"  {label}: {filename}, anno_col={anno_col}, iters={cfg['iterations_api']}")
+
+    # === /routes/files/columns ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 1: POST /routes/files/columns")
+    print("=" * 60)
+
+    for label, acfg in api_datasets.items():
+        iters = acfg["iterations"]
+        timer = BenchmarkTimer(f"API /columns [{label}]", iters)
+
+        for i in range(iters):
+            start = time.perf_counter()
+            resp = client.post(
+                "/routes/files/columns",
+                json={"file_name": acfg["filename"], "source": "shared"},
+                headers=headers,
+            )
+            elapsed = time.perf_counter() - start
+            timer.times.append(elapsed)
+
+            if i == 0:
+                if resp.status_code != 200:
+                    print(f"\n  ERROR [{label}]: status={resp.status_code}, body={resp.text[:300]}")
+                    break
+                body = resp.json()
+                print(f"\n  [{label}] First response: anno={len(body.get('anno_columns', []))} cols, "
+                      f"pseudo={len(body.get('pseudo_columns', []))} cols")
+
+        stats = timer.stats()
+        stats["times_ms"] = [round(t * 1000, 2) for t in timer.times]
+        if stats.get("iterations", 0) > 1:
+            cold = stats["times_ms"][0]
+            warm_avg = round(statistics.mean(stats["times_ms"][1:]), 2)
+        else:
+            cold = stats["times_ms"][0] if stats.get("times_ms") else 0
+            warm_avg = cold
+
+        print(f"\n{'='*60}")
+        print(f"  {stats['name']}")
+        print(f"{'='*60}")
+        print(f"  Iterations : {stats['iterations']}")
+        print(f"  Mean       : {stats['mean_ms']:.2f} ms")
+        print(f"  Median     : {stats['median_ms']:.2f} ms")
+        print(f"  Std        : {stats.get('std_s', 0)*1000:.2f} ms")
+        print(f"  Min        : {stats['min_s']*1000:.2f} ms")
+        print(f"  Max        : {stats['max_s']*1000:.2f} ms")
+        print(f"  Cold (1st) : {cold:.2f} ms")
+        print(f"  Warm (avg) : {warm_avg:.2f} ms")
+
+        all_results[f"api_columns_{label}"] = stats
+
+    # === /routes/files/clusters ===
+    print("\n\n" + "=" * 60)
+    print("SECTION 2: POST /routes/files/clusters")
+    print("=" * 60)
+
+    for label, acfg in api_datasets.items():
+        if not acfg["anno_col"]:
+            print(f"\n  SKIP {label}: no annotation column")
+            continue
+
+        iters = acfg["iterations"]
+        timer = BenchmarkTimer(f"API /clusters [{label}]", iters)
+
+        for i in range(iters):
+            start = time.perf_counter()
+            resp = client.post(
+                "/routes/files/clusters",
+                json={
+                    "file_name": acfg["filename"],
+                    "anno_column": acfg["anno_col"],
+                    "source": "shared",
+                },
+                headers=headers,
+            )
+            elapsed = time.perf_counter() - start
+            timer.times.append(elapsed)
+
+            if i == 0:
+                if resp.status_code != 200:
+                    print(f"\n  ERROR [{label}]: status={resp.status_code}, body={resp.text[:300]}")
+                    break
+                body = resp.json()
+                print(f"\n  [{label}] First response: {len(body.get('clusters', []))} clusters")
+
+        stats = timer.stats()
+        stats["times_ms"] = [round(t * 1000, 2) for t in timer.times]
+        if stats.get("iterations", 0) > 1:
+            cold = stats["times_ms"][0]
+            warm_avg = round(statistics.mean(stats["times_ms"][1:]), 2)
+        else:
+            cold = stats["times_ms"][0] if stats.get("times_ms") else 0
+            warm_avg = cold
+
+        print(f"\n{'='*60}")
+        print(f"  {stats['name']}")
+        print(f"{'='*60}")
+        print(f"  Iterations : {stats['iterations']}")
+        print(f"  Mean       : {stats['mean_ms']:.2f} ms")
+        print(f"  Median     : {stats['median_ms']:.2f} ms")
+        print(f"  Std        : {stats.get('std_s', 0)*1000:.2f} ms")
+        print(f"  Min        : {stats['min_s']*1000:.2f} ms")
+        print(f"  Max        : {stats['max_s']*1000:.2f} ms")
+        print(f"  Cold (1st) : {cold:.2f} ms")
+        print(f"  Warm (avg) : {warm_avg:.2f} ms")
+
+        all_results[f"api_clusters_{label}"] = stats
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("\n" + "#" * 70)
+    print("#  Real scRNA-seq Data Benchmark — Before Redis Caching Baseline")
+    print("#" * 70)
+
+    # Part 1
+    func_results = run_function_benchmarks()
+
+    # Part 2
+    api_results = run_api_benchmarks()
+
+    # Merge
+    all_results = {"function_level": func_results, "api_level": api_results}
+
+    # ==================================================================
+    # Summary tables
+    # ==================================================================
+    print("\n\n" + "=" * 70)
+    print("FUNCTION-LEVEL SUMMARY TABLE")
+    print("=" * 70)
+    print(f"{'Benchmark':<50} {'Mean (ms)':>10} {'Median (ms)':>12} {'Peak Mem (MB)':>14}")
+    print("-" * 90)
+    for key, val in func_results.items():
+        if key == "data_info":
+            continue
+        mem_str = str(val.get("tracemalloc_peak_mb", "N/A"))
+        print(f"{val['name']:<50} {val['mean_ms']:>10.2f} {val['median_ms']:>12.2f} {mem_str:>14}")
+
+    print("\n\n" + "=" * 70)
+    print("API-LEVEL SUMMARY TABLE")
+    print("=" * 70)
+    print(f"{'Endpoint':<50} {'Mean (ms)':>10} {'Median (ms)':>12} {'Cold (ms)':>10} {'Warm avg':>10}")
+    print("-" * 95)
+    for key, val in api_results.items():
+        times = val.get("times_ms", [])
+        cold = times[0] if times else 0
+        warm_avg = round(statistics.mean(times[1:]), 2) if len(times) > 1 else 0
+        print(f"{val['name']:<50} {val['mean_ms']:>10.2f} {val['median_ms']:>12.2f} {cold:>10.2f} {warm_avg:>10.2f}")
+
+    # JSON output
+    print("\n\n--- RAW JSON ---")
+    print(json.dumps(all_results, indent=2))
+
+    return all_results
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/benchmarks/test_cache_api.py
+++ b/backend/tests/benchmarks/test_cache_api.py
@@ -1,0 +1,86 @@
+"""API-level test for h5ad metadata caching.
+
+Tests cache by making repeated API calls through the Uvicorn server.
+The in-process cache lives in the Uvicorn worker, so we can't clear it
+from this script. Instead we rely on:
+  - 1st call: cache miss (server just started or file not yet cached)
+  - 2nd+ calls: cache hit (in-process cache populated by 1st call)
+
+To test cold performance, restart the backend container first:
+  docker restart cellcraft-backend-1 && sleep 3
+"""
+import httpx
+import time
+import os
+import sys
+
+BASE = "http://localhost:8000/routes"
+
+
+def login():
+    resp = httpx.post(
+        f"{BASE}/auth/login/access-token",
+        data={"username": "cellcraft@cellcraft.com", "password": "cellcraft2024!"},
+    )
+    assert resp.status_code == 200, f"Login failed: {resp.status_code}"
+    return resp.json()["access_token"]
+
+
+def timed_post(url, json, headers, timeout=30):
+    t0 = time.perf_counter()
+    r = httpx.post(url, json=json, headers=headers, timeout=timeout)
+    elapsed = (time.perf_counter() - t0) * 1000
+    return r, elapsed
+
+
+def main():
+    token = login()
+    headers = {"Authorization": f"Bearer {token}"}
+    print("Login OK\n")
+
+    datasets = [
+        ("pbmc_light_1000.h5ad", "./tutorials/pbmc_light_1000.h5ad"),
+        ("CRCBraw.h5ad", "./tutorials/CRCBraw.h5ad"),
+    ]
+
+    for fname, fpath in datasets:
+        if not os.path.isfile(fpath):
+            print(f"[SKIP] {fname} not found at {fpath}")
+            continue
+
+        print(f"=== {fname} ===")
+        payload = {"file_name": fname, "source": "shared"}
+
+        # 1st call (may be cold or warm depending on server state)
+        r1, t1 = timed_post(f"{BASE}/files/columns", payload, headers, timeout=60)
+        assert r1.status_code == 200, f"/columns failed: {r1.status_code} {r1.text}"
+
+        # 2nd call (should be warm/cached)
+        r2, t2 = timed_post(f"{BASE}/files/columns", payload, headers, timeout=60)
+        assert r2.status_code == 200
+        assert r1.json() == r2.json(), "Results differ between calls!"
+
+        # 3rd call to confirm consistency
+        r3, t3 = timed_post(f"{BASE}/files/columns", payload, headers, timeout=60)
+        assert r3.status_code == 200
+        assert r1.json() == r3.json()
+
+        print(f"  /columns: call1={t1:.0f}ms  call2={t2:.0f}ms  call3={t3:.0f}ms")
+
+        # Clusters
+        anno_col = r1.json()["anno_columns"][0]
+        payload_cl = {"file_name": fname, "anno_column": anno_col, "source": "shared"}
+
+        rc1, tc1 = timed_post(f"{BASE}/files/clusters", payload_cl, headers, timeout=60)
+        rc2, tc2 = timed_post(f"{BASE}/files/clusters", payload_cl, headers, timeout=60)
+        assert rc1.status_code == 200 and rc2.status_code == 200
+        assert rc1.json() == rc2.json()
+
+        print(f"  /clusters ({anno_col}): call1={tc1:.0f}ms  call2={tc2:.0f}ms")
+        print()
+
+    print("All API cache tests PASSED!")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/benchmarks/test_cache_api_gtex.py
+++ b/backend/tests/benchmarks/test_cache_api_gtex.py
@@ -1,0 +1,80 @@
+"""API-level cache benchmark for all 3 datasets including GTEx.
+
+Run after: docker restart cellcraft-backend-1 && sleep 5
+"""
+import httpx
+import time
+import os
+
+BASE = "http://localhost:8000/routes"
+
+
+def login():
+    resp = httpx.post(
+        f"{BASE}/auth/login/access-token",
+        data={"username": "cellcraft@cellcraft.com", "password": "cellcraft2024!"},
+    )
+    assert resp.status_code == 200, f"Login failed: {resp.status_code}"
+    return resp.json()["access_token"]
+
+
+def timed_post(url, json, headers, timeout=120):
+    t0 = time.perf_counter()
+    r = httpx.post(url, json=json, headers=headers, timeout=timeout)
+    elapsed = (time.perf_counter() - t0) * 1000
+    return r, elapsed
+
+
+def main():
+    token = login()
+    headers = {"Authorization": f"Bearer {token}"}
+    print("Login OK\n")
+
+    datasets = [
+        ("pbmc_light_1000.h5ad", "./tutorials/pbmc_light_1000.h5ad", "pbmc (1K cells, 27MB)"),
+        ("CRCBraw.h5ad", "./tutorials/CRCBraw.h5ad", "CRC (12.6K cells, 138MB)"),
+        ("GTEx_8_tissues.h5ad", "./tutorials/GTEx_8_tissues.h5ad", "GTEx (209K cells, 1.8GB)"),
+    ]
+
+    print(f"{'Dataset':<30} {'Endpoint':<12} {'Cold (ms)':>10} {'Warm1 (ms)':>11} {'Warm2 (ms)':>11} {'Speedup':>8}")
+    print("-" * 90)
+
+    for fname, fpath, label in datasets:
+        if not os.path.isfile(fpath):
+            print(f"[SKIP] {label} — file not found")
+            continue
+
+        payload = {"file_name": fname, "source": "shared"}
+
+        # /columns: cold
+        r1, t_cold = timed_post(f"{BASE}/files/columns", payload, headers)
+        assert r1.status_code == 200, f"/columns failed: {r1.status_code} {r1.text}"
+
+        # /columns: warm x2
+        r2, t_warm1 = timed_post(f"{BASE}/files/columns", payload, headers)
+        r3, t_warm2 = timed_post(f"{BASE}/files/columns", payload, headers)
+        assert r2.status_code == 200 and r3.status_code == 200
+        assert r1.json() == r2.json() == r3.json()
+
+        speedup = t_cold / t_warm1
+        print(f"{label:<30} {'/ columns':<12} {t_cold:>10.0f} {t_warm1:>11.0f} {t_warm2:>11.0f} {speedup:>7.1f}x")
+
+        # /clusters
+        anno_col = r1.json()["anno_columns"][0]
+        payload_cl = {"file_name": fname, "anno_column": anno_col, "source": "shared"}
+
+        rc1, tc_cold = timed_post(f"{BASE}/files/clusters", payload_cl, headers)
+        rc2, tc_warm1 = timed_post(f"{BASE}/files/clusters", payload_cl, headers)
+        rc3, tc_warm2 = timed_post(f"{BASE}/files/clusters", payload_cl, headers)
+        assert rc1.status_code == 200 and rc2.status_code == 200 and rc3.status_code == 200
+        assert rc1.json() == rc2.json() == rc3.json()
+
+        speedup_cl = tc_cold / tc_warm1
+        print(f"{'':30} {'/ clusters':<12} {tc_cold:>10.0f} {tc_warm1:>11.0f} {tc_warm2:>11.0f} {speedup_cl:>7.1f}x")
+        print()
+
+    print("All tests PASSED!")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/benchmarks/test_h5ad_function_benchmarks.py
+++ b/backend/tests/benchmarks/test_h5ad_function_benchmarks.py
@@ -1,0 +1,368 @@
+"""
+H5AD function-level benchmarks — Before Redis caching baseline.
+
+Measures scanpy.read_h5ad, organize_column_dtypes, get_annotation_columns,
+get_pseudotime_columns, and full /columns + /clusters pipeline simulation.
+
+Run inside backend container:
+    docker exec cellcraft-backend-1 \
+        python -m pytest tests/benchmarks/test_h5ad_function_benchmarks.py \
+        -v -s -m benchmark --no-header --override-ini="addopts=" 2>&1
+"""
+import gc
+import json
+import os
+import tempfile
+import time
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+import scanpy as sc
+
+from app.common.utils.h5ad_utils import (
+    get_annotation_columns,
+    get_pseudotime_columns,
+    organize_column_dtypes,
+)
+
+from .utils import BenchmarkTimer, MemoryProfiler, format_benchmark_result, get_real_h5ad_path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+ITERATIONS = 10
+REAL_H5AD = get_real_h5ad_path()
+
+# ---------------------------------------------------------------------------
+# Fixtures — create h5ad files once per module for speed
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def small_h5ad(tmp_path_factory):
+    """100 cells × 50 genes"""
+    path = str(tmp_path_factory.mktemp("small") / "small.h5ad")
+    n_obs, n_vars = 100, 50
+    adata = ad.AnnData(
+        X=np.random.rand(n_obs, n_vars).astype(np.float32),
+        obs=pd.DataFrame({
+            "cell_type": np.random.choice(["TypeA", "TypeB", "TypeC"], n_obs),
+            "cluster": np.random.choice(["C1", "C2"], n_obs),
+            "pseudotime": np.random.rand(n_obs),
+        }),
+        var=pd.DataFrame(index=[f"Gene{i}" for i in range(n_vars)]),
+    )
+    adata.obsm["X_umap"] = np.random.rand(n_obs, 2)
+    adata.write_h5ad(path)
+    del adata
+    gc.collect()
+    return path
+
+
+@pytest.fixture(scope="module")
+def large_h5ad(tmp_path_factory):
+    """10 000 cells × 2 000 genes"""
+    path = str(tmp_path_factory.mktemp("large") / "large.h5ad")
+    n_obs, n_vars = 10_000, 2_000
+    adata = ad.AnnData(
+        X=np.random.rand(n_obs, n_vars).astype(np.float32),
+        obs=pd.DataFrame({
+            "cell_type": np.random.choice(["TypeA", "TypeB", "TypeC", "TypeD"], n_obs),
+            "cluster": np.random.choice([f"C{i}" for i in range(10)], n_obs),
+            "pseudotime": np.random.rand(n_obs),
+        }),
+        var=pd.DataFrame(index=[f"Gene{i}" for i in range(n_vars)]),
+    )
+    adata.obsm["X_umap"] = np.random.rand(n_obs, 2)
+    adata.write_h5ad(path)
+    del adata
+    gc.collect()
+    return path
+
+
+# ===================================================================
+# scanpy.read_h5ad benchmarks
+# ===================================================================
+
+@pytest.mark.benchmark
+class TestBenchScanpyReadH5ad:
+
+    def test_bench_scanpy_read_h5ad_small(self, small_h5ad):
+        """scanpy.read_h5ad — 100×50"""
+        timer = BenchmarkTimer("scanpy.read_h5ad [small 100×50]", ITERATIONS)
+
+        def _read():
+            adata = sc.read_h5ad(small_h5ad)
+            result = adata.shape
+            del adata
+            gc.collect()
+            return result
+
+        timer.run(_read)
+        mem = MemoryProfiler.measure(lambda: sc.read_h5ad(small_h5ad))
+        stats = timer.stats()
+
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+        assert stats["mean_s"] < 30, "read_h5ad small should complete within 30s"
+
+    def test_bench_scanpy_read_h5ad_large(self, large_h5ad):
+        """scanpy.read_h5ad — 10000×2000"""
+        timer = BenchmarkTimer("scanpy.read_h5ad [large 10k×2k]", ITERATIONS)
+
+        def _read():
+            adata = sc.read_h5ad(large_h5ad)
+            result = adata.shape
+            del adata
+            gc.collect()
+            return result
+
+        timer.run(_read)
+        mem = MemoryProfiler.measure(lambda: sc.read_h5ad(large_h5ad))
+        stats = timer.stats()
+
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+        assert stats["mean_s"] < 60, "read_h5ad large should complete within 60s"
+
+    @pytest.mark.skipif(REAL_H5AD is None, reason="pbmc_light_1000.h5ad not found")
+    def test_bench_scanpy_read_h5ad_real(self):
+        """scanpy.read_h5ad — pbmc_light_1000.h5ad (~28.7 MB)"""
+        timer = BenchmarkTimer("scanpy.read_h5ad [real pbmc 1k]", ITERATIONS)
+
+        def _read():
+            adata = sc.read_h5ad(REAL_H5AD)
+            result = adata.shape
+            del adata
+            gc.collect()
+            return result
+
+        timer.run(_read)
+        mem = MemoryProfiler.measure(lambda: sc.read_h5ad(REAL_H5AD))
+        stats = timer.stats()
+
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+        assert stats["mean_s"] < 120, "read_h5ad real should complete within 120s"
+
+
+# ===================================================================
+# organize_column_dtypes benchmarks
+# ===================================================================
+
+@pytest.mark.benchmark
+class TestBenchOrganizeColumnDtypes:
+
+    @staticmethod
+    def _load_obs(h5ad_path):
+        adata = sc.read_h5ad(h5ad_path)
+        obs = adata.obs.copy()
+        del adata
+        gc.collect()
+        return obs
+
+    def test_bench_organize_column_dtypes_small(self, small_h5ad):
+        obs = self._load_obs(small_h5ad)
+        timer = BenchmarkTimer("organize_column_dtypes [small]", ITERATIONS)
+        timer.run(organize_column_dtypes, obs)
+        mem = MemoryProfiler.measure(organize_column_dtypes, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+    def test_bench_organize_column_dtypes_large(self, large_h5ad):
+        obs = self._load_obs(large_h5ad)
+        timer = BenchmarkTimer("organize_column_dtypes [large]", ITERATIONS)
+        timer.run(organize_column_dtypes, obs)
+        mem = MemoryProfiler.measure(organize_column_dtypes, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+    @pytest.mark.skipif(REAL_H5AD is None, reason="pbmc_light_1000.h5ad not found")
+    def test_bench_organize_column_dtypes_real(self):
+        obs = self._load_obs(REAL_H5AD)
+        timer = BenchmarkTimer("organize_column_dtypes [real]", ITERATIONS)
+        timer.run(organize_column_dtypes, obs)
+        mem = MemoryProfiler.measure(organize_column_dtypes, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+
+# ===================================================================
+# get_annotation_columns benchmarks
+# ===================================================================
+
+@pytest.mark.benchmark
+class TestBenchGetAnnotationColumns:
+
+    @staticmethod
+    def _load_obs(h5ad_path):
+        adata = sc.read_h5ad(h5ad_path)
+        obs = adata.obs.copy()
+        del adata
+        gc.collect()
+        return obs
+
+    def test_bench_get_annotation_columns_small(self, small_h5ad):
+        obs = self._load_obs(small_h5ad)
+        timer = BenchmarkTimer("get_annotation_columns [small]", ITERATIONS)
+        timer.run(get_annotation_columns, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats))
+
+    def test_bench_get_annotation_columns_large(self, large_h5ad):
+        obs = self._load_obs(large_h5ad)
+        timer = BenchmarkTimer("get_annotation_columns [large]", ITERATIONS)
+        timer.run(get_annotation_columns, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats))
+
+    @pytest.mark.skipif(REAL_H5AD is None, reason="pbmc_light_1000.h5ad not found")
+    def test_bench_get_annotation_columns_real(self):
+        obs = self._load_obs(REAL_H5AD)
+        timer = BenchmarkTimer("get_annotation_columns [real]", ITERATIONS)
+        timer.run(get_annotation_columns, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats))
+
+
+# ===================================================================
+# get_pseudotime_columns benchmarks
+# ===================================================================
+
+@pytest.mark.benchmark
+class TestBenchGetPseudotimeColumns:
+
+    @staticmethod
+    def _load_obs(h5ad_path):
+        adata = sc.read_h5ad(h5ad_path)
+        obs = adata.obs.copy()
+        del adata
+        gc.collect()
+        return obs
+
+    def test_bench_get_pseudotime_columns_small(self, small_h5ad):
+        obs = self._load_obs(small_h5ad)
+        timer = BenchmarkTimer("get_pseudotime_columns [small]", ITERATIONS)
+        timer.run(get_pseudotime_columns, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats))
+
+    def test_bench_get_pseudotime_columns_large(self, large_h5ad):
+        obs = self._load_obs(large_h5ad)
+        timer = BenchmarkTimer("get_pseudotime_columns [large]", ITERATIONS)
+        timer.run(get_pseudotime_columns, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats))
+
+    @pytest.mark.skipif(REAL_H5AD is None, reason="pbmc_light_1000.h5ad not found")
+    def test_bench_get_pseudotime_columns_real(self):
+        obs = self._load_obs(REAL_H5AD)
+        timer = BenchmarkTimer("get_pseudotime_columns [real]", ITERATIONS)
+        timer.run(get_pseudotime_columns, obs)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats))
+
+
+# ===================================================================
+# Full pipeline simulation (mirrors /columns and /clusters endpoints)
+# ===================================================================
+
+@pytest.mark.benchmark
+class TestBenchFullPipeline:
+    """
+    Simulates the exact code path of the /columns and /clusters endpoints
+    without HTTP/DB overhead — pure function-level measurement.
+    """
+
+    @staticmethod
+    def _columns_pipeline(filepath):
+        """Mirrors files.py h5ad_columns endpoint logic."""
+        adata = sc.read_h5ad(filepath)
+        adata.obs = organize_column_dtypes(adata.obs)
+        anno = get_annotation_columns(adata.obs)
+        pseudo = get_pseudotime_columns(adata.obs)
+        result = {"anno_columns": anno, "pseudo_columns": pseudo}
+        del adata
+        gc.collect()
+        return result
+
+    @staticmethod
+    def _clusters_pipeline(filepath, anno_column):
+        """Mirrors files.py h5ad_cluster endpoint logic."""
+        adata = sc.read_h5ad(filepath)
+        adata.obs = organize_column_dtypes(adata.obs)
+        clusters = list(map(str, adata.obs[anno_column].value_counts().index))
+        result = {"clusters": clusters}
+        del adata
+        gc.collect()
+        return result
+
+    # --- /columns pipeline ---
+
+    def test_bench_columns_pipeline_small(self, small_h5ad):
+        timer = BenchmarkTimer("columns_pipeline [small]", ITERATIONS)
+        timer.run(self._columns_pipeline, small_h5ad)
+        mem = MemoryProfiler.measure(self._columns_pipeline, small_h5ad)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+    def test_bench_columns_pipeline_large(self, large_h5ad):
+        timer = BenchmarkTimer("columns_pipeline [large]", ITERATIONS)
+        timer.run(self._columns_pipeline, large_h5ad)
+        mem = MemoryProfiler.measure(self._columns_pipeline, large_h5ad)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+    @pytest.mark.skipif(REAL_H5AD is None, reason="pbmc_light_1000.h5ad not found")
+    def test_bench_columns_pipeline_real(self):
+        timer = BenchmarkTimer("columns_pipeline [real pbmc 1k]", ITERATIONS)
+        timer.run(self._columns_pipeline, REAL_H5AD)
+        mem = MemoryProfiler.measure(self._columns_pipeline, REAL_H5AD)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+    # --- /clusters pipeline ---
+
+    def test_bench_clusters_pipeline_small(self, small_h5ad):
+        timer = BenchmarkTimer("clusters_pipeline [small]", ITERATIONS)
+        timer.run(self._clusters_pipeline, small_h5ad, "cluster")
+        mem = MemoryProfiler.measure(self._clusters_pipeline, small_h5ad, "cluster")
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+    def test_bench_clusters_pipeline_large(self, large_h5ad):
+        timer = BenchmarkTimer("clusters_pipeline [large]", ITERATIONS)
+        timer.run(self._clusters_pipeline, large_h5ad, "cluster")
+        mem = MemoryProfiler.measure(self._clusters_pipeline, large_h5ad, "cluster")
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")
+
+    @pytest.mark.skipif(REAL_H5AD is None, reason="pbmc_light_1000.h5ad not found")
+    def test_bench_clusters_pipeline_real(self):
+        """Use first annotation column found in real data."""
+        adata = sc.read_h5ad(REAL_H5AD)
+        obs = organize_column_dtypes(adata.obs)
+        anno_cols = get_annotation_columns(obs)
+        del adata
+        gc.collect()
+
+        anno_col = anno_cols[0] if anno_cols else "cluster"
+
+        timer = BenchmarkTimer("clusters_pipeline [real pbmc 1k]", ITERATIONS)
+        timer.run(self._clusters_pipeline, REAL_H5AD, anno_col)
+        mem = MemoryProfiler.measure(self._clusters_pipeline, REAL_H5AD, anno_col)
+        stats = timer.stats()
+        print("\n" + format_benchmark_result(stats, mem))
+        print(f"  JSON: {json.dumps({**stats, **{k: v for k, v in mem.items() if k != 'result'}})}")

--- a/backend/tests/benchmarks/utils.py
+++ b/backend/tests/benchmarks/utils.py
@@ -1,0 +1,122 @@
+"""
+Benchmark utility module for h5ad performance measurement.
+
+Provides BenchmarkTimer and MemoryProfiler for systematic
+before/after performance comparison of Redis caching.
+"""
+import time
+import tracemalloc
+import statistics
+import json
+import os
+from typing import Callable, Any
+
+
+class BenchmarkTimer:
+    """Measures execution time using time.perf_counter() with repeated runs."""
+
+    def __init__(self, name: str, iterations: int = 10):
+        self.name = name
+        self.iterations = iterations
+        self.times: list[float] = []
+
+    def run(self, func: Callable, *args, **kwargs) -> Any:
+        """Execute func for self.iterations times, recording each duration."""
+        result = None
+        for i in range(self.iterations):
+            start = time.perf_counter()
+            result = func(*args, **kwargs)
+            elapsed = time.perf_counter() - start
+            self.times.append(elapsed)
+        return result
+
+    def stats(self) -> dict:
+        if not self.times:
+            return {}
+        sorted_times = sorted(self.times)
+        n = len(sorted_times)
+        return {
+            "name": self.name,
+            "iterations": n,
+            "mean_s": statistics.mean(sorted_times),
+            "median_s": statistics.median(sorted_times),
+            "std_s": statistics.stdev(sorted_times) if n > 1 else 0.0,
+            "min_s": sorted_times[0],
+            "max_s": sorted_times[-1],
+            "p95_s": sorted_times[int(n * 0.95)] if n >= 20 else sorted_times[-1],
+            "p99_s": sorted_times[int(n * 0.99)] if n >= 100 else sorted_times[-1],
+        }
+
+
+class MemoryProfiler:
+    """Measures memory usage via tracemalloc (peak) and /proc RSS."""
+
+    @staticmethod
+    def measure(func: Callable, *args, **kwargs) -> dict:
+        """Run func once, return peak tracemalloc and RSS delta."""
+        # RSS before (Linux /proc/self/status)
+        rss_before = MemoryProfiler._get_rss_kb()
+
+        tracemalloc.start()
+        result = func(*args, **kwargs)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        rss_after = MemoryProfiler._get_rss_kb()
+
+        return {
+            "result": result,
+            "tracemalloc_peak_mb": round(peak / (1024 * 1024), 2),
+            "rss_before_mb": round(rss_before / 1024, 2),
+            "rss_after_mb": round(rss_after / 1024, 2),
+            "rss_delta_mb": round((rss_after - rss_before) / 1024, 2),
+        }
+
+    @staticmethod
+    def _get_rss_kb() -> float:
+        """Read VmRSS from /proc/self/status (Linux only)."""
+        try:
+            with open("/proc/self/status") as f:
+                for line in f:
+                    if line.startswith("VmRSS:"):
+                        return float(line.split()[1])  # kB
+        except (FileNotFoundError, ValueError):
+            pass
+        # Fallback: resource module
+        try:
+            import resource
+            return float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+        except Exception:
+            return 0.0
+
+
+def format_benchmark_result(timer_stats: dict, memory_info: dict | None = None) -> str:
+    """Pretty-print a single benchmark result."""
+    lines = [
+        f"=== {timer_stats['name']} ===",
+        f"  Iterations : {timer_stats['iterations']}",
+        f"  Mean       : {timer_stats['mean_s']*1000:.2f} ms",
+        f"  Median     : {timer_stats['median_s']*1000:.2f} ms",
+        f"  Std        : {timer_stats['std_s']*1000:.2f} ms",
+        f"  Min        : {timer_stats['min_s']*1000:.2f} ms",
+        f"  Max        : {timer_stats['max_s']*1000:.2f} ms",
+    ]
+    if memory_info:
+        lines.extend([
+            f"  Peak Mem   : {memory_info.get('tracemalloc_peak_mb', 'N/A')} MB (tracemalloc)",
+            f"  RSS Delta  : {memory_info.get('rss_delta_mb', 'N/A')} MB",
+        ])
+    return "\n".join(lines)
+
+
+def get_real_h5ad_path() -> str | None:
+    """Return path to pbmc_light_1000.h5ad if it exists."""
+    candidates = [
+        "/app/tutorials/pbmc_light_1000.h5ad",  # inside container
+        os.path.join(os.path.dirname(__file__), "..", "..", "tutorials", "pbmc_light_1000.h5ad"),
+    ]
+    for p in candidates:
+        resolved = os.path.abspath(p)
+        if os.path.isfile(resolved):
+            return resolved
+    return None

--- a/docker-compose.cpu.amd64.yml
+++ b/docker-compose.cpu.amd64.yml
@@ -102,6 +102,7 @@ services:
       - "5672:5672"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     restart: unless-stopped
     networks:
       - app-network

--- a/docker-compose.cpu.amd64.yml
+++ b/docker-compose.cpu.amd64.yml
@@ -48,6 +48,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - app-network
@@ -69,6 +71,22 @@ services:
       - app-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
+    restart: unless-stopped
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -129,3 +147,4 @@ networks:
 volumes:
   postgres_data:
   rabbitmq_data:
+  redis_data:

--- a/docker-compose.cpu.arm64.yml
+++ b/docker-compose.cpu.arm64.yml
@@ -102,6 +102,7 @@ services:
       - "5672:5672"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     restart: unless-stopped
     networks:
       - app-network

--- a/docker-compose.cpu.arm64.yml
+++ b/docker-compose.cpu.arm64.yml
@@ -48,6 +48,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - app-network
@@ -69,6 +71,22 @@ services:
       - app-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
+    restart: unless-stopped
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -129,3 +147,4 @@ networks:
 volumes:
   postgres_data:
   rabbitmq_data:
+  redis_data:

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -38,6 +38,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - app-network
@@ -65,6 +67,22 @@ services:
       - app-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
+    restart: unless-stopped
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -127,3 +145,4 @@ networks:
 volumes:
   postgres_data:
   rabbitmq_data:
+  redis_data:

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -98,6 +98,7 @@ services:
       - "5672:5672"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     restart: unless-stopped
     networks:
       - app-network

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,6 +34,7 @@ services:
       - ./backend/plugin/build_logs:/app/plugin/build_logs:rw
     depends_on:
       - db
+      - redis
     restart: always
     networks:
       - app-network
@@ -73,6 +74,22 @@ services:
     # No volumes - ephemeral test database
     # No restart - manual control for testing
     # No healthcheck - keep it minimal
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
+    restart: always
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   rabbitmq:
     image: "rabbitmq:management"
@@ -122,3 +139,4 @@ networks:
 
 volumes:
   postgres_data:
+  redis_data:

--- a/docker-compose.gpu.amd64.yml
+++ b/docker-compose.gpu.amd64.yml
@@ -49,6 +49,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - app-network
@@ -70,6 +72,22 @@ services:
       - app-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
+    restart: unless-stopped
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -137,3 +155,4 @@ networks:
 volumes:
   postgres_data:
   rabbitmq_data:
+  redis_data:

--- a/docker-compose.gpu.amd64.yml
+++ b/docker-compose.gpu.amd64.yml
@@ -103,6 +103,7 @@ services:
       - "5672:5672"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     restart: unless-stopped
     networks:
       - app-network

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -88,6 +88,7 @@ services:
       - "5672:5672"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     restart: unless-stopped
     networks:
       - app-network

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -34,6 +34,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - app-network
@@ -55,6 +57,22 @@ services:
       - app-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
+    restart: unless-stopped
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -114,3 +132,4 @@ networks:
 volumes:
   postgres_data:
   rabbitmq_data:
+  redis_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: always
 
   db:
@@ -56,6 +58,20 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    expose:
+      - "6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
       timeout: 5s
       retries: 5
 
@@ -151,6 +167,7 @@ services:
 
 volumes:
   postgres_data:
+  redis_data:
   jenkins_data:
   playwright_browsers:
   uptime_kuma_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,6 +82,8 @@ services:
     expose:
       - "15672"
       - "5672"
+    volumes:
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     restart: always
 
   celery:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -14,7 +14,7 @@ http {
         listen 8080;
         server_name localhost;
 
-        client_max_body_size 10G;
+        client_max_body_size 5G;
 
         location / {
             root /usr/share/nginx/html;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,6 +22,35 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
+        # SSE endpoint - disable buffering for real-time streaming
+        location /api/routes/task/info/ {
+            rewrite ^/api(.*)$ $1 break;
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3700s;
+            proxy_set_header Connection '';
+            chunked_transfer_encoding off;
+        }
+
+        # Upload endpoint - extended timeout for H5AD compression
+        location /api/routes/files/upload {
+            rewrite ^/api(.*)$ $1 break;
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+
         location /api/ {
             rewrite ^/api(.*)$ $1 break;
             proxy_pass http://backend:8000;

--- a/frontend/nginx.local.conf
+++ b/frontend/nginx.local.conf
@@ -53,6 +53,35 @@ http {
             try_files $uri =404;
         }
 
+        # SSE endpoint - disable buffering for real-time streaming
+        location /api/routes/task/info/ {
+            rewrite ^/api(.*)$ $1 break;
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3700s;
+            proxy_set_header Connection '';
+            chunked_transfer_encoding off;
+        }
+
+        # Upload endpoint - extended timeout for H5AD compression
+        location /api/routes/files/upload {
+            rewrite ^/api(.*)$ $1 break;
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+
         # API proxy configuration
         location /api/ {
             rewrite ^/api(.*)$ $1 break;

--- a/frontend/nginx.local.conf
+++ b/frontend/nginx.local.conf
@@ -37,7 +37,7 @@ http {
         index index.html index.htm;
 
         # Increase client body size for file uploads
-        client_max_body_size 10G;
+        client_max_body_size 5G;
         
         # Timeout settings for large file uploads
         client_body_timeout 300s;

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -407,7 +407,7 @@ function getTaskStatusSimple(taskId) {
 }
 
 function createTaskEventSource(taskId, callbacks = {}) {
-  const TERMINAL_STATES = ['SUCCESS', 'FAILURE', 'REVOKED', 'RETRY'];
+  const TERMINAL_STATES = ['SUCCESS', 'FAILURE', 'REVOKED'];
   const MAX_CONSECUTIVE_FAILURES = 3;
   const RECONNECT_DELAY_MS = 5000;
 

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -112,6 +112,7 @@ function uploadForm(formData, onUploadProgress) {
       "Content-Type": "multipart/form-data",
     },
     onUploadProgress,
+    timeout: 3600000, // 1 hour — matches nginx proxy_read_timeout
   });
 }
 
@@ -397,33 +398,113 @@ function clearDAGCaches() {
   return instance.delete(`/routes/task/cache/clear`);
 }
 
+function getTaskStatusSimple(taskId) {
+  return fetch(`${process.env.VUE_APP_BASE_URL}/routes/task/status/${taskId}`)
+    .then(response => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json();
+    });
+}
+
 function createTaskEventSource(taskId, callbacks = {}) {
-  const eventSource = new EventSource(`${process.env.VUE_APP_BASE_URL}/routes/task/info/${taskId}`);
-  
-  eventSource.onmessage = (event) => {
-    // 기본 메시지 핸들러
-    if (callbacks.onMessage) {
-      callbacks.onMessage(event);
+  const TERMINAL_STATES = ['SUCCESS', 'FAILURE', 'REVOKED', 'RETRY'];
+  const MAX_CONSECUTIVE_FAILURES = 3;
+  const RECONNECT_DELAY_MS = 5000;
+
+  let closed = false;
+  let consecutiveFailures = 0;
+  let reconnectTimer = null;
+  let currentEventSource = null;
+
+  function cleanup() {
+    closed = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
     }
-    
-    // 작업 완료시 이벤트소스 자동 종료
-    if (event.data === "SUCCESS" || event.data === "FAILURE" || event.data === "REVOKED") {
-      if (callbacks.onComplete) {
-        callbacks.onComplete(event.data);
+    if (currentEventSource) {
+      currentEventSource.close();
+      currentEventSource = null;
+    }
+  }
+
+  function scheduleReconnect() {
+    if (closed) return;
+    reconnectTimer = setTimeout(() => {
+      if (!closed) connect();
+    }, RECONNECT_DELAY_MS);
+  }
+
+  function checkTaskStatusAndReconnect() {
+    if (closed) return;
+    getTaskStatusSimple(taskId)
+      .then(data => {
+        if (closed) return;
+        const status = data.status;
+        if (TERMINAL_STATES.includes(status)) {
+          if (callbacks.onComplete) callbacks.onComplete(status);
+          cleanup();
+        } else {
+          // Task still running — REST succeeded, reset failure counter
+          consecutiveFailures = 0;
+          scheduleReconnect();
+        }
+      })
+      .catch(() => {
+        if (closed) return;
+        consecutiveFailures++;
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          console.error(`SSE reconnection giving up for task ${taskId} after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`);
+          if (callbacks.onError) callbacks.onError(new Error('SSE reconnection failed'));
+          cleanup();
+        } else {
+          scheduleReconnect();
+        }
+      });
+  }
+
+  function connect() {
+    if (closed) return;
+    currentEventSource = new EventSource(`${process.env.VUE_APP_BASE_URL}/routes/task/info/${taskId}`);
+
+    currentEventSource.onmessage = (event) => {
+      if (closed) return;
+
+      // TIMEOUT — expected hourly disconnect, reconnect immediately
+      if (event.data === 'TIMEOUT') {
+        console.log(`SSE timeout for task ${taskId}, reconnecting...`);
+        currentEventSource.close();
+        scheduleReconnect();
+        return;
       }
-      eventSource.close();
+
+      // Terminal state — task finished
+      if (TERMINAL_STATES.includes(event.data)) {
+        if (callbacks.onComplete) callbacks.onComplete(event.data);
+        cleanup();
+        return;
+      }
+
+      // Normal status update — reset failure counter
+      consecutiveFailures = 0;
+      if (callbacks.onMessage) callbacks.onMessage(event);
+    };
+
+    currentEventSource.onerror = () => {
+      if (closed) return;
+      currentEventSource.close();
+      checkTaskStatusAndReconnect();
+    };
+  }
+
+  connect();
+
+  // Return wrapper with same .close() interface as EventSource
+  return {
+    close() {
+      cleanup();
     }
   };
-
-  // 에러 핸들링
-  eventSource.onerror = (error) => {
-    if (callbacks.onError) {
-      callbacks.onError(error);
-    }
-    eventSource.close();
-  };
-
-  return eventSource;
 }
 
 // Admin APIs

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -119,6 +119,14 @@ function getFiles() {
   return instance.get("/routes/files/me");
 }
 
+function getSharedFiles() {
+  return instance.get("/routes/files/shared");
+}
+
+function findSharedFile(fileInfo) {
+  return instance.post("/routes/files/shared/find", fileInfo);
+}
+
 function findFile(fileInfo) {
   return instance.post("/routes/files/find", fileInfo);
 }
@@ -453,6 +461,8 @@ export {
   getResults,
   uploadForm,
   getFiles,
+  getSharedFiles,
+  findSharedFile,
   findFile,
   findFolder,
   getWorkflows,

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -80,6 +80,10 @@ function getSystemResources() {
   return instance.get("/routes/admin/system/stats");
 }
 
+function getTaskResources() {
+  return instance.get("/routes/task/resources");
+}
+
 function exportData(data) {
   return instance.post("/routes/workflow/compile", data);
 }
@@ -585,6 +589,7 @@ export {
   readWorkflowNodeFile,
   getFileData,
   getSystemResources,
+  getTaskResources,
   getPluginFile,
   getPluginPackageList,
   getPluginInfo,

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -167,8 +167,9 @@ function setupAlgorithm(options) {
   return instance.post("/routes/files/setup", options);
 }
 
-function getFileData(filename) {
-  return instance.get(`/routes/files/data/${filename}`);
+function getFileData(filename, source) {
+  const params = source ? { source } : {};
+  return instance.get(`/routes/files/data/${filename}`, { params });
 }
 
 function getWorkflows() {

--- a/frontend/src/components/modals/Algorithm.vue
+++ b/frontend/src/components/modals/Algorithm.vue
@@ -222,6 +222,7 @@ export default {
                 updatedItem.selected_file = savedItem.selected_file;
                 updatedItem.activate = true;
                 updatedItem.file_name = savedItem.selected_file.file_name;
+                updatedItem.fileSource = savedItem.selected_file.fileSource || savedItem.fileSource || "user";
               }
               return updatedItem;
             });
@@ -385,7 +386,8 @@ export default {
                 node_id: connection.id,
                 file_name: connection.data.file,
                 display_name: connection.data.title || connection.data.file,
-                node_class: connection.class
+                node_class: connection.class,
+                fileSource: connection.data.fileSource || "user"
               };
 
               // 중복 방지
@@ -422,10 +424,12 @@ export default {
       if (inputItem.selected_file) {
         inputItem.activate = true;
         inputItem.file_name = inputItem.selected_file.file_name;
+        inputItem.fileSource = inputItem.selected_file.fileSource || "user";
       } else {
         // 선택 해제된 경우
         inputItem.activate = false;
         inputItem.file_name = null;
+        inputItem.fileSource = "user";
       }
 
       // Vue의 반응성을 위해 배열 항목을 교체
@@ -546,9 +550,12 @@ export default {
       }
 
       try {
+        const fileSource = selectedInputFile
+          ? (selectedInputFile.fileSource || "user") : "user";
         const result = await getClusters({
           file_name: h5adFileName,
           anno_column: anno_column,
+          source: fileSource,
         });
         console.log('Clusters loaded:', result.data);
         return result.data.clusters;
@@ -597,7 +604,8 @@ export default {
               node_id: matchingConnection.id,
               file_name: matchingConnection.data.file,
               display_name: matchingConnection.data.title || matchingConnection.data.file,
-              node_class: matchingConnection.class
+              node_class: matchingConnection.class,
+              fileSource: matchingConnection.data.fileSource || "user"
             };
           }
         } else if (item.type === 'optionalInputFile') {
@@ -615,7 +623,8 @@ export default {
           ...item,
           activate,
           file_name,
-          selected_file
+          selected_file,
+          fileSource: selected_file ? (selected_file.fileSource || "user") : (item.fileSource || "user")
         };
       });
     },
@@ -763,8 +772,11 @@ export default {
         }
 
         try {
+          const fileSource = selectedInputFile
+            ? (selectedInputFile.fileSource || "user") : "user";
           const result = await getColumns({
             file_name: h5adFileName,
+            source: fileSource,
           });
           console.log('Columns loaded:', result.data);
           this.annotations = result.data.anno_columns;

--- a/frontend/src/components/modals/Algorithm.vue
+++ b/frontend/src/components/modals/Algorithm.vue
@@ -36,6 +36,10 @@
           <div class="algorithm-logo">{{ selectedPlugin ? selectedPlugin.name : 'Select a Plugin' }}</div>
         </div>
         <div class="algorithm-parts">
+          <div v-if="isParameterLoading" class="parameter-loading-overlay">
+            <div class="parameter-spinner"></div>
+            <p class="parameter-loading-text">Loading parameters...</p>
+          </div>
           <div v-for="(rule, ruleIndex) in selectedPluginRules" :key="`rule-${ruleIndex}-${rule.name}`">
             <div class="part-title" v-show="rule.parameters.length != 0">{{ rule.name }}</div>
             <div v-for="(parameter, paramIndex) in rule.parameters"
@@ -170,6 +174,7 @@ export default {
       nodeInfo: {},
       currentCellGroup: '',
       activePluginType: 'official', // 기본적으로 Official 플러그인 표시
+      isParameterLoading: false,
     };
   },
   async mounted() {
@@ -231,20 +236,25 @@ export default {
           }
 
           if (this.selectedPluginInputOutput.some((item) => item.type === "inputFile" && item.fileExtension === ".h5ad")) {
-            await this.loadColumns();
+            this.isParameterLoading = true;
+            try {
+              await this.loadColumns();
 
-            // cell group 파라미터를 찾아서 defaultValue가 있으면 clusters를 할당
-            const cellGroupParam = this.selectedPluginRules.find(rule =>
-              rule.parameters.some(param => param.name === 'cell group' && param.defaultValue)
-            )?.parameters.find(param => param.name === 'cell group');
+              // cell group 파라미터를 찾아서 defaultValue가 있으면 clusters를 할당
+              const cellGroupParam = this.selectedPluginRules.find(rule =>
+                rule.parameters.some(param => param.name === 'cell group' && param.defaultValue)
+              )?.parameters.find(param => param.name === 'cell group');
 
-            if (cellGroupParam?.defaultValue) {
-              const clusters = await this.getCurrnetClusters(cellGroupParam.defaultValue);
-              this.clusters = clusters;
+              if (cellGroupParam?.defaultValue) {
+                const clusters = await this.getCurrnetClusters(cellGroupParam.defaultValue);
+                this.clusters = clusters;
+              }
+
+              // ScatterPlot Lasso 선택 정보 기반 cell group 및 clusters 자동 설정
+              await this.applyAutoClusterSelection();
+            } finally {
+              this.isParameterLoading = false;
             }
-
-            // ScatterPlot Lasso 선택 정보 기반 cell group 및 clusters 자동 설정
-            await this.applyAutoClusterSelection();
           }
         }
       }
@@ -490,16 +500,21 @@ export default {
         (item) => item.type === "inputFile" && item.fileExtension === ".h5ad" && item.activate
       );
       if (selectedInputFile) {
-        const clusters = await this.getCurrnetClusters(anno_column);
-        this.clusters = clusters;
+        this.isParameterLoading = true;
+        try {
+          const clusters = await this.getCurrnetClusters(anno_column);
+          this.clusters = clusters;
 
-        // cell group 변경 시 clusters 파라미터 초기화 (사용자가 직접 선택하도록)
-        const clustersParam = this.selectedPluginRules
-          .flatMap(rule => rule.parameters)
-          .find(param => param.name === 'clusters');
+          // cell group 변경 시 clusters 파라미터 초기화 (사용자가 직접 선택하도록)
+          const clustersParam = this.selectedPluginRules
+            .flatMap(rule => rule.parameters)
+            .find(param => param.name === 'clusters');
 
-        if (clustersParam) {
-          clustersParam.defaultValue = [];  // clusters 초기화
+          if (clustersParam) {
+            clustersParam.defaultValue = [];  // clusters 초기화
+          }
+        } finally {
+          this.isParameterLoading = false;
         }
       }
     },
@@ -1202,6 +1217,39 @@ export default {
   align-content: start;
   width: 100%;
   margin-bottom: 2rem;
+  min-height: 60px;
+}
+
+.parameter-loading-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.85);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  border-radius: 0.5rem;
+}
+
+.parameter-spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  animation: param-spin 1s linear infinite;
+}
+
+@keyframes param-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.parameter-loading-text {
+  margin-top: 0.5rem;
+  color: #666;
+  font-size: 0.85rem;
 }
 
 .algorithm-select__tenet {

--- a/frontend/src/components/modals/DataTable.vue
+++ b/frontend/src/components/modals/DataTable.vue
@@ -3,10 +3,11 @@
     <div v-if="current_file === null">
       <span>NO DATA FOR TABLE</span>
     </div>
-    <!-- <div v-else-if="isLoading" class="loading-layout">
-      <span v-if="current_files !== null"></span>
-    </div> -->
     <div v-else class="table-layout">
+      <div v-if="isLoading" class="loading-overlay">
+        <div class="spinner"></div>
+        <p class="loading-text">Loading data...</p>
+      </div>
       <vue-good-table class="dataTable" :columns="columns" :rows="rows" mode="remote" @on-page-change="onPageChange"
         @on-sort-change="onSortChange" @on-column-filter="onColumnFilter" @on-per-page-change="onPerPageChange"
         :line-numbers="true" theme="polar-bear" max-height="31.5rem" :isLoading.sync="isLoading"
@@ -168,6 +169,7 @@ export default {
 }
 
 .table-layout {
+  position: relative;
   width: 90%;
   height: 90%;
   background: #fff;
@@ -182,18 +184,35 @@ export default {
   overflow: auto;
 }
 
-.loading-layout {
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.85);
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  z-index: 10;
+  border-radius: 0.5rem;
 }
 
-.loading-layout span {
+.spinner {
   border: 4px solid #f3f3f3;
   border-top: 4px solid #3498db;
   border-radius: 50%;
   width: 40px;
   height: 40px;
-  animation: spin 2s linear infinite;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.loading-text {
+  margin-top: 0.75rem;
+  color: #666;
+  font-size: 0.9rem;
 }
 </style>

--- a/frontend/src/components/modals/DataTable.vue
+++ b/frontend/src/components/modals/DataTable.vue
@@ -129,12 +129,15 @@ export default {
   },
   async mounted() {
     this.current_file = this.$store.getters.getWorkflowNodeFileInfo(this.nodeId);
+    const nodeInfo = this.$store.getters.getWorkflowNodeInfo(this.nodeId);
+    const fileSource = (nodeInfo && nodeInfo.data && nodeInfo.data.fileSource) || "user";
     console.log(this.current_file);
     // const initial_file_ids = Object.keys(this.current_files);
     if (this.current_file) {
       this.isLoading = true;
       try {
-        this.serverParams.file_name = this.current_file
+        this.serverParams.file_name = this.current_file;
+        this.serverParams.source = fileSource;
         const dataTableResult = await getDataTableFile(this.serverParams);
 
         console.log(dataTableResult.data);

--- a/frontend/src/components/modals/InputFile.vue
+++ b/frontend/src/components/modals/InputFile.vue
@@ -1,26 +1,45 @@
 <template>
   <div class="layout">
     <form class="fileUpload-form" @submit.prevent="applyFile">
-      <ul class="folder__list">
-        <router-link class="cloud-row" target="_blank" to="/files">
-          <div class="cloud-textbox">
-            <p class="cloud-textbox__directory__desc">
-              If you want to upload a new file, please click here.
-            </p>
-            <h1 class="cloud-textbox__directory">Files Directory ></h1>
-          </div>
-        </router-link>
-        <li class="folder__item" v-for="(folder, idx) in folders_list" :key="idx + 'O'"
-          v-bind:class="{ toggleFolder: toggleFolder === idx }" @click="folderClick(idx, folder[0])">
-          <div class="folder__item--col">
-            <img class="folder__item--arrow" src="@/assets/arrow-right.png" v-if="toggleFolder === idx" />
-            <img class="folder__item--arrow" src="@/assets/arrow-right.png" v-else />
-            <img class="folder__item--icon" src="@/assets/open-folder.png" v-if="toggleFolder === idx" />
-            <img class="folder__item--icon" src="@/assets/folder.png" v-else />
-          </div>
-          <p class="folder__name">{{ folder[0] }}</p>
-        </li>
-      </ul>
+      <div class="folder__panel">
+        <div class="tab__bar">
+          <button type="button" class="tab__button" :class="{ 'tab__button--active': activeTab === 'user' }" @click="switchTab('user')">My Files</button>
+          <button type="button" class="tab__button" :class="{ 'tab__button--active': activeTab === 'shared' }" @click="switchTab('shared')">Tutorial Data</button>
+        </div>
+        <ul class="folder__list" v-if="activeTab === 'user'">
+          <router-link class="cloud-row" target="_blank" to="/files">
+            <div class="cloud-textbox">
+              <p class="cloud-textbox__directory__desc">
+                If you want to upload a new file, please click here.
+              </p>
+              <h1 class="cloud-textbox__directory">Files Directory ></h1>
+            </div>
+          </router-link>
+          <li class="folder__item" v-for="(folder, idx) in folders_list" :key="idx + 'O'"
+            v-bind:class="{ toggleFolder: toggleFolder === idx }" @click="folderClick(idx, folder[0])">
+            <div class="folder__item--col">
+              <img class="folder__item--arrow" src="@/assets/arrow-right.png" v-if="toggleFolder === idx" />
+              <img class="folder__item--arrow" src="@/assets/arrow-right.png" v-else />
+              <img class="folder__item--icon" src="@/assets/open-folder.png" v-if="toggleFolder === idx" />
+              <img class="folder__item--icon" src="@/assets/folder.png" v-else />
+            </div>
+            <p class="folder__name">{{ folder[0] }}</p>
+          </li>
+        </ul>
+        <ul class="folder__list folder__list--shared" v-if="activeTab === 'shared'">
+          <li class="folder__item" v-for="(file, idx) in shared_files_list" :key="idx + 'S'"
+            v-bind:class="{ toggleFolder: toggleSharedFile === idx }" @click="sharedFileClick(idx, file.file_name)">
+            <div class="folder__item--col">
+              <img class="folder__item--arrow" src="@/assets/arrow-right.png" />
+              <img class="folder__item--icon" src="@/assets/file-icon.png" />
+            </div>
+            <p class="folder__name">{{ file.file_name }}</p>
+          </li>
+          <li v-if="shared_files_list.length === 0" class="folder__item">
+            <p class="folder__name" style="color: rgba(51,51,51,0.5)">No tutorial data available</p>
+          </li>
+        </ul>
+      </div>
       <div class="fileUpload">
         <div class="form-row">
           <div class="form__selectFile">
@@ -70,6 +89,8 @@ import {
   getFiles,
   findFolder,
   findFile,
+  getSharedFiles,
+  findSharedFile,
 } from "@/api/index";
 import { formatBytes } from "@/utils/formatters";
 
@@ -83,11 +104,15 @@ export default {
       getFile: false,
       toggleFolder: null,
       toggleFile: null,
+      toggleSharedFile: null,
       folders_list: [],
       files_list: [],
+      shared_files_list: [],
       recentFiles_list: [],
       apply: false,
       isLoading: false,
+      activeTab: "user",
+      fileSource: "user",
       workflowId: this.$route.query.workflow_id,
       nodeId: this.$route.query.node,
     };
@@ -97,6 +122,22 @@ export default {
     previewFile() {
       if (this.$refs.selectFile.files.length > 0) {
         this.selectFile = this.$refs.selectFile.files[0];
+      }
+    },
+    async switchTab(tab) {
+      this.activeTab = tab;
+      this.toggleFile = null;
+      this.toggleSharedFile = null;
+      if (tab === "shared" && this.shared_files_list.length === 0) {
+        await this.loadSharedFiles();
+      }
+    },
+    async loadSharedFiles() {
+      try {
+        const res = await getSharedFiles();
+        this.shared_files_list = res.data;
+      } catch (error) {
+        console.error(error);
       }
     },
     async getFinder() {
@@ -130,6 +171,20 @@ export default {
           file_name: fileName,
         });
         this.selectFile = file.data;
+        this.fileSource = "user";
+      }
+    },
+    async sharedFileClick(idx, fileName) {
+      this.apply = false;
+      if (idx === this.toggleSharedFile) {
+        this.toggleSharedFile = null;
+      } else {
+        this.toggleSharedFile = idx;
+        const file = await findSharedFile({
+          file_name: fileName,
+        });
+        this.selectFile = file.data;
+        this.fileSource = "shared";
       }
     },
     applyFile() {
@@ -139,6 +194,7 @@ export default {
         const file_info = {
           file_name: this.selectFile.file_name,
           id: this.nodeId,
+          source: this.fileSource,
         };
         this.$store.commit("setWorkflowFile", file_info);
         this.$store.commit("shareWorkflowFile", this.nodeId);
@@ -154,10 +210,20 @@ export default {
       const currentFile = this.$store.getters.getWorkflowNodeFileInfo(this.nodeId);
 
       if (currentFile !== "") {
+        // 저장된 fileSource 확인
+        const nodeData = this.$store.getters.getWorkflowNodeInfo(this.nodeId);
+        const savedSource = nodeData && nodeData.data ? (nodeData.data.fileSource || "user") : "user";
+        this.fileSource = savedSource;
+
         try {
-          const file = await findFile({
-            file_name: currentFile,
-          });
+          let file;
+          if (savedSource === "shared") {
+            file = await findSharedFile({ file_name: currentFile });
+            this.activeTab = "shared";
+            await this.loadSharedFiles();
+          } else {
+            file = await findFile({ file_name: currentFile });
+          }
           this.selectFile = file.data;
           this.apply = true;
         } catch (error) {
@@ -207,16 +273,65 @@ export default {
   background-color: rgb(255, 255, 255);
 }
 
-.folder__list {
+.folder__panel {
   width: 45%;
   height: 95%;
   display: flex;
   flex-direction: column;
   margin: 1rem 0 1rem 1rem;
+}
+
+.tab__bar {
+  display: flex;
+  gap: 0;
+  margin-bottom: 0;
+}
+
+.tab__button {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  border: none;
+  background: rgb(220, 223, 228);
+  cursor: pointer;
+  font-family: "Montserrat", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgb(100, 100, 100);
+  transition: background 0.2s, color 0.2s;
+}
+
+.tab__button:first-child {
+  border-radius: 0.5rem 0 0 0;
+}
+
+.tab__button:last-child {
+  border-radius: 0 0.5rem 0 0;
+}
+
+.tab__button--active {
+  background: rgb(255, 255, 255);
+  color: rgb(40, 84, 197);
+  font-weight: 600;
+}
+
+.tab__button:hover:not(.tab__button--active) {
+  background: rgb(235, 237, 240);
+}
+
+.folder__list {
+  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   padding: 1rem 1rem;
-  border-radius: 0.5rem;
+  border-radius: 0 0 0.5rem 0.5rem;
   box-sizing: border-box;
   background-color: rgb(255, 255, 255);
+  overflow-y: auto;
+}
+
+.folder__list--shared {
+  padding-top: 0.5rem;
 }
 
 .folder__item {

--- a/frontend/src/components/modals/InputFile.vue
+++ b/frontend/src/components/modals/InputFile.vue
@@ -46,9 +46,7 @@
             </li>
             <li class="form__info--text">
               <p class="form__info--name">{{ selectFile.file_name }}</p>
-              <p class="form__info--size">{{
-                selectFile.file_size | formatBytes
-                }}</p>
+              <p class="form__info--size">{{ formatBytes(selectFile.file_size) }}</p>
             </li>
           </ul>
           <ul class="form__info" v-else>
@@ -73,6 +71,7 @@ import {
   findFolder,
   findFile,
 } from "@/api/index";
+import { formatBytes } from "@/utils/formatters";
 
 export default {
   data() {
@@ -94,6 +93,7 @@ export default {
     };
   },
   methods: {
+    formatBytes,
     previewFile() {
       if (this.$refs.selectFile.files.length > 0) {
         this.selectFile = this.$refs.selectFile.files[0];
@@ -175,17 +175,6 @@ export default {
     } catch (error) {
       console.error(error);
     }
-  },
-  filters: {
-    formatBytes(a, b) {
-      if (a === 0) return "0 Bytes";
-      const c = 1024;
-      const d = b || 2;
-      const e = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
-      const f = Math.floor(Math.log(a) / Math.log(c));
-
-      return parseFloat((a / Math.pow(c, f)).toFixed(d)) + " " + e[f];
-    },
   },
 };
 </script>

--- a/frontend/src/components/modals/ScatterPlot.vue
+++ b/frontend/src/components/modals/ScatterPlot.vue
@@ -96,6 +96,7 @@ export default {
       scatterResult: null,
       workflowId: this.$route.query.workflow_id,
       nodeId: this.$route.query.node,
+      current_file_source: "user",
     };
   },
   async mounted() {
@@ -135,6 +136,8 @@ export default {
 
     try {
       this.current_file = this.$store.getters.getWorkflowNodeFileInfo(this.nodeId);
+      const nodeInfo = this.$store.getters.getWorkflowNodeInfo(this.nodeId);
+      this.current_file_source = (nodeInfo && nodeInfo.data && nodeInfo.data.fileSource) || "user";
     } catch (error) {
       console.error("Error getting current file info:", error);
     }
@@ -164,7 +167,7 @@ export default {
     if (this.current_file !== "") {
       let scatterResult;
       try {
-        scatterResult = await getFileData(this.current_file);
+        scatterResult = await getFileData(this.current_file, this.current_file_source);
       } catch (error) {
         console.error("Error getting file data:", error);
       }

--- a/frontend/src/components/workflowComponents/CompileCheck.vue
+++ b/frontend/src/components/workflowComponents/CompileCheck.vue
@@ -6,7 +6,7 @@
                 <div class="loading-spinner"></div>
                 <p class="loading-text">Loading resource information...</p>
             </div>
-            
+
             <h2 class="modal-title">Confirm Task Execution</h2>
 
             <div class="task-info">
@@ -22,7 +22,7 @@
                         </div>
 
                         <!-- Arrow -->
-                        <div class="task-arrow">→</div>
+                        <div class="task-arrow">&rarr;</div>
 
                         <!-- Output Section -->
                         <div class="task-outputs">
@@ -35,99 +35,84 @@
             </div>
 
             <div class="resource-info">
-                <h3 class="resource-info__title">Server Resource Status</h3>
+                <h3 class="resource-info__title">Resource Allocation Status</h3>
 
-                <!-- CPU 정보 표시 -->
-                <div class="resource-bar">
-                    <label>CPU Usage: {{ Number(serverResources.total_cpu_usage_percent).toFixed(2) }}%</label>
-                    <div class="bar">
-                        <div class="fill"
-                            :style="{ width: Math.min(serverResources.total_cpu_usage_percent, 100) + '%' }">
-                        </div>
-                    </div>
-                    <div class="resource-details">
-                        <p><strong>Total Memory Usage:</strong> {{ formatBytes(serverResources.total_memory_usage_bytes)
-                            }}</p>
-                        <p><strong>Total Memory Limit:</strong> {{ formatBytes(serverResources.total_memory_limit_bytes)
-                            }}</p>
-                    </div>
+                <!-- Error state -->
+                <div v-if="hasError" class="error-state">
+                    <p>Resource monitoring temporarily unavailable</p>
                 </div>
 
-                <!-- 메모리 정보 표시 -->
-                <div class="resource-bar">
-                    <label>Memory Usage: {{ Number(serverResources.total_memory_usage_percent).toFixed(2) }}%</label>
-                    <div class="bar">
-                        <div class="fill"
-                            :style="{ width: Math.min(serverResources.total_memory_usage_percent, 100) + '%' }"></div>
-                    </div>
-                    <div class="resource-details">
-                        <p>
-                            <strong>Total Memory:</strong> {{ formatBytes(serverResources.total_memory_limit_bytes) }}
-                        </p>
-                        <p>
-                            <strong>Used Memory:</strong>
-                            <span :class="getMemoryUsageClass(serverResources.total_memory_usage_percent)">
-                                {{ formatBytes(serverResources.total_memory_usage_bytes) }}
-                            </span>
-                        </p>
-                        <p>
-                            <strong>Available Memory:</strong> {{ formatBytes(serverResources.total_memory_limit_bytes -
-                                serverResources.total_memory_usage_bytes) }}
-                        </p>
-                    </div>
+                <!-- Worker not initialized -->
+                <div v-else-if="resources && resources.cpu.total === 0 && resources.gpu.total === 0" class="empty-state">
+                    <p>Waiting for worker initialization...</p>
                 </div>
 
-                <!-- 컨테이너별 정보 표시 -->
-                <div v-for="(container, index) in serverResources.containers" :key="index" class="container-info">
-                    <h4>{{ container.container_info.name }}</h4>
-
-                    <!-- 컨테이너 CPU 정보 -->
-                    <div class="resource-sub-bar">
-                        <label>CPU Usage: {{ Number(container.cpu.usage_percent).toFixed(2) }}%</label>
+                <!-- Resource overview -->
+                <div v-else-if="resources" class="resource-overview">
+                    <!-- CPU Slots -->
+                    <div class="resource-bar">
+                        <label>CPU Slots: {{ resources.cpu.available }} / {{ resources.cpu.total }} available</label>
                         <div class="bar">
-                            <div class="fill" :style="{ width: Math.min(container.cpu.usage_percent, 100) + '%' }">
+                            <div class="fill" :class="getUsageClass(cpuPercent)"
+                                :style="{ width: cpuPercent + '%' }">
+                            </div>
+                        </div>
+                        <span class="bar-percent" :class="getUsageClass(cpuPercent)">{{ cpuPercent.toFixed(0) }}% used</span>
+                    </div>
+
+                    <!-- Memory -->
+                    <div v-if="resources.memory" class="resource-bar">
+                        <label>Memory: {{ formatBytes(resources.memory.used_bytes) }} / {{ formatBytes(resources.memory.total_bytes) }}</label>
+                        <div class="bar">
+                            <div class="fill" :class="getUsageClass(resources.memory.percent)"
+                                :style="{ width: Math.min(resources.memory.percent, 100) + '%' }">
+                            </div>
+                        </div>
+                        <span class="bar-percent" :class="getUsageClass(resources.memory.percent)">{{ resources.memory.percent.toFixed(1) }}%</span>
+                        <div class="resource-detail-line">
+                            Available: {{ formatBytes(resources.memory.available_bytes) }}
+                        </div>
+                    </div>
+
+                    <!-- GPU Slots (only when gpu.total > 0) -->
+                    <div v-if="resources.gpu.total > 0" class="resource-bar">
+                        <label>GPU Slots: {{ resources.gpu.available }} / {{ resources.gpu.total }} available</label>
+                        <div class="bar">
+                            <div class="fill" :class="getUsageClass(gpuPercent)"
+                                :style="{ width: gpuPercent + '%' }">
+                            </div>
+                        </div>
+                        <span class="bar-percent" :class="getUsageClass(gpuPercent)">{{ gpuPercent.toFixed(0) }}% used</span>
+                    </div>
+
+                    <!-- GPU Device details (only when gpu_devices has items) -->
+                    <div v-if="resources.gpu_devices && resources.gpu_devices.length > 0" class="gpu-devices">
+                        <div v-for="gpu in resources.gpu_devices" :key="gpu.id" class="gpu-device">
+                            <label>[GPU {{ gpu.id }}] {{ gpu.name }} - {{ gpu.load_percent }}%</label>
+                            <div class="resource-detail-line">
+                                VRAM: {{ formatBytes(gpu.memory_used_bytes) }} / {{ formatBytes(gpu.memory_total_bytes) }}
+                            </div>
+                            <div v-if="gpu.temperature_c !== null" class="resource-detail-line">
+                                Temp: {{ gpu.temperature_c }}&deg;C
                             </div>
                         </div>
                     </div>
 
-                    <!-- 컨테이너 메모리 정보 -->
-                    <div class="resource-sub-bar">
-                        <label>Memory Usage: {{ Number(container.memory.percent).toFixed(2) }}%</label>
-                        <div class="bar">
-                            <div class="fill" :style="{ width: Math.min(container.memory.percent, 100) + '%' }"></div>
+                    <!-- Running Tasks -->
+                    <div class="task-list-section">
+                        <label class="task-list-label">Running Tasks ({{ resources.tasks.length }})</label>
+                        <div v-if="resources.tasks.length > 0" class="task-list">
+                            <div v-for="task in resources.tasks" :key="task.task_id" class="task-item">
+                                <span class="task-dot">&#9679;</span>
+                                <span class="task-name">{{ task.plugin_name || 'Unknown' }}</span>
+                                <span class="resource-badge" :class="'badge-' + task.resource_type">
+                                    {{ task.resource_type.toUpperCase() }} x{{ task.resource_slots }}
+                                </span>
+                                <span class="task-elapsed">{{ getElapsedTime(task.started_at) }}</span>
+                            </div>
                         </div>
-                    </div>
-
-                    <!-- 컨테이너 GPU 정보 -->
-                    <div v-if="container.gpu" class="gpu-info">
-                        <div v-for="(gpu, gpuIndex) in container.gpu" :key="gpuIndex">
-                            <label>{{ gpu.name }} (GPU {{ gpu.id }})</label>
-                            <div class="resource-sub-bar">
-                                <label>GPU Usage: {{ gpu.utilization_percent }}%</label>
-                                <div class="bar">
-                                    <div class="fill" :style="{ width: Math.min(gpu.utilization_percent, 100) + '%' }">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="resource-sub-bar">
-                                <label>Memory Usage: {{ gpu.memory.utilization_percent.toFixed(2) }}%</label>
-                                <div class="bar">
-                                    <div class="fill"
-                                        :style="{ width: Math.min(gpu.memory.utilization_percent, 100) + '%' }"></div>
-                                </div>
-                            </div>
-                            <div class="resource-details">
-                                <p>
-                                    <strong>Memory:</strong>
-                                    {{ formatBytes(gpu.memory.used_bytes) }} / {{ formatBytes(gpu.memory.total_bytes) }}
-                                </p>
-                                <p>
-                                    <strong>Temperature:</strong> {{ gpu.temperature_c }}°C
-                                </p>
-                                <p>
-                                    <strong>Power:</strong> {{ gpu.power.draw_watts }}W / {{ gpu.power.limit_watts }}W
-                                </p>
-                            </div>
+                        <div v-else class="empty-state">
+                            <p>No active tasks</p>
                         </div>
                     </div>
                 </div>
@@ -143,52 +128,64 @@
 </template>
 
 <script>
-import { getSystemResources } from '@/api/index';
-import { formatBytes } from '@/utils/formatters';
+import { getTaskResources } from '@/api/index';
+import { formatBytes, getRunningTime } from '@/utils/formatters';
 
 export default {
     data() {
         return {
             taskInfoList: [],
-            serverResources: {
-                total_containers: 0,
-                total_cpu_usage_percent: 0,
-                total_memory_usage_bytes: 0,
-                total_memory_limit_bytes: 0,
-                total_memory_usage_percent: 0,
-                containers: []
-            },
+            resources: null,
             isLoadingResources: true,
             isPolling: false,
             resourceTimeoutId: null,
+            currentTime: new Date(),
+            currentTimeIntervalId: null,
+            hasError: false,
         };
+    },
+    computed: {
+        cpuPercent() {
+            if (!this.resources || this.resources.cpu.total === 0) return 0;
+            return (this.resources.cpu.used / this.resources.cpu.total) * 100;
+        },
+        gpuPercent() {
+            if (!this.resources || this.resources.gpu.total === 0) return 0;
+            return (this.resources.gpu.used / this.resources.gpu.total) * 100;
+        },
     },
     async mounted() {
         try {
-            const response = await getSystemResources();
-            this.serverResources = response.data;
-            this.isLoadingResources = false;
+            const response = await getTaskResources();
+            this.resources = response.data;
+            this.hasError = false;
         } catch (error) {
             console.error('Failed to load initial resources:', error);
+            if (error.response && error.response.status === 503) {
+                this.hasError = true;
+            }
+        } finally {
             this.isLoadingResources = false;
         }
-        
+
         this.startPolling();
+
+        // 1초마다 currentTime 갱신 (경과시간 실시간 표시)
+        this.currentTimeIntervalId = setInterval(() => {
+            this.currentTime = new Date();
+        }, 1000);
 
         // workflow 정보를 통해 Algorithm 노드들의 정보 가져오기
         try {
             const workflow_info = this.$store.getters.getWorkflowInfo;
-            console.log(workflow_info);
 
             const nodes_list = Object.values(workflow_info.drawflow.Home.data);
             const algorithm_nodes = nodes_list.filter(node => node.class === 'Algorithm');
-            console.log(algorithm_nodes);
 
             // 각 노드의 정보를 taskInfoList에 추가
             algorithm_nodes.forEach(node => {
                 const taskInfo = {
                     pluginName: node.data.selectedPlugin.name,
-                    // node.data.selectedPluginInputOutput에서 activate가 true고 type이 inputFile인 것만 고르기
                     inputs: node.data.selectedPluginInputOutput.filter(input => input.activate && input.type === 'inputFile').map(input => input.defaultValue),
                     outputs: node.data.selectedPluginInputOutput.filter(output => output.activate && output.type === 'outputFile').map(output => output.defaultValue)
                 };
@@ -200,8 +197,13 @@ export default {
     },
     beforeDestroy() {
         this.stopPolling();
+        if (this.currentTimeIntervalId) {
+            clearInterval(this.currentTimeIntervalId);
+            this.currentTimeIntervalId = null;
+        }
     },
     methods: {
+        formatBytes,
         startPolling() {
             this.isPolling = true;
             this.pollResources();
@@ -217,18 +219,29 @@ export default {
             if (!this.isPolling) return;
 
             try {
-                const response = await getSystemResources();
-                this.serverResources = response.data;
-                console.log(this.serverResources);
+                const response = await getTaskResources();
+                this.resources = response.data;
+                this.hasError = false;
             } catch (error) {
+                if (error.response && error.response.status === 503) {
+                    this.hasError = true;
+                }
                 console.error('Failed to refresh resources:', error);
             } finally {
                 if (this.isPolling) {
-                    this.resourceTimeoutId = setTimeout(this.pollResources, 10000);
+                    this.resourceTimeoutId = setTimeout(this.pollResources, 5000);
                 }
             }
         },
-        formatBytes,
+        getElapsedTime(startedAt) {
+            if (!startedAt) return '--:--:--';
+            return getRunningTime(startedAt, this.currentTime);
+        },
+        getUsageClass(percent) {
+            if (percent >= 90) return 'usage-critical';
+            if (percent >= 70) return 'usage-warning';
+            return 'usage-normal';
+        },
         confirmTask() {
             alert("Task is being executed...");
             this.closeModal();
@@ -238,32 +251,7 @@ export default {
             this.stopPolling();
             this.$emit('deactivate-compile-check');
         },
-        formatCPUUsage(usage) {
-            return usage ? Number(usage).toLocaleString() : '0';
-        },
-        getCPUUsageClass(usage) {
-            if (usage >= 90) return 'usage-critical';
-            if (usage >= 70) return 'usage-warning';
-            return 'usage-normal';
-        },
-        getMemoryUsageClass(percent) {
-            if (percent >= 90) return 'usage-critical';
-            if (percent >= 70) return 'usage-warning';
-            return 'usage-normal';
-        },
-        calculateCPUPercentage(usage) {
-            if (!this.serverResources.cpu.system_usage) return 0;
-            return (usage / (this.serverResources.cpu.system_usage / this.serverResources.cpu.num_cpus)) * 100;
-        }
     },
-    computed: {
-        getTotalMemory() {
-            return this.serverResources.available_memory_bytes / (1 - this.serverResources.memory_usage_percent / 100);
-        },
-        getUsedMemory() {
-            return this.getTotalMemory - this.serverResources.available_memory_bytes;
-        }
-    }
 };
 </script>
 
@@ -279,7 +267,7 @@ export default {
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 10000; /* 높은 z-index 설정 */
+    z-index: 10000;
 }
 
 .modal-container {
@@ -291,7 +279,7 @@ export default {
     max-width: 90%;
     text-align: center;
     position: relative;
-    z-index: 10001; /* modal-content보다 높은 z-index */
+    z-index: 10001;
 }
 
 .modal-container.loading-active > *:not(.full-loading-overlay) {
@@ -315,40 +303,31 @@ export default {
     text-align: left;
     margin-bottom: 1.5rem;
 
-    /* 스크롤바의 색상 설정 (Firefox) */
     scrollbar-color: #2c3e50 #34495e;
-    /* 스크롤바 핸들, 트랙 색상 */
     scrollbar-width: thin;
-    /* 스크롤바 두께 설정 (Firefox) */
 }
 
-/* WebKit 기반 브라우저용 스크롤바 스타일링 (Chrome, Edge, Safari 등) */
 .task-info::-webkit-scrollbar,
 .resource-info::-webkit-scrollbar {
     width: 8px;
-    /* 스크롤바의 너비 */
 }
 
 .task-info::-webkit-scrollbar-track,
 .resource-info::-webkit-scrollbar-track {
     background: #34495e;
-    /* 스크롤바 트랙(배경) 색상 */
     border-radius: 1rem;
 }
 
 .task-info::-webkit-scrollbar-thumb,
 .resource-info::-webkit-scrollbar-thumb {
     background-color: #2c3e50;
-    /* 스크롤바 핸들 색상 */
     border-radius: 1rem;
 }
 
 .task-info::-webkit-scrollbar-thumb:hover,
 .resource-info::-webkit-scrollbar-thumb:hover {
     background-color: #1f2a38;
-    /* 스크롤바 핸들 hover 색상 */
 }
-
 
 .task-info__title,
 .resource-info__title {
@@ -406,8 +385,22 @@ export default {
     margin: 0 10px;
 }
 
+/* Resource bars */
+.resource-overview {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 .resource-bar {
-    margin-bottom: 10px;
+    margin-bottom: 2px;
+}
+
+.resource-bar label {
+    font-size: 0.85rem;
+    color: #bdc3c7;
+    display: block;
+    margin-bottom: 4px;
 }
 
 .bar {
@@ -416,23 +409,151 @@ export default {
     background-color: #46627e;
     border-radius: 5px;
     overflow: hidden;
-    margin-top: 5px;
 }
 
 .fill {
     height: 100%;
     background-color: #3498db;
+    border-radius: 5px;
+    transition: width 0.3s ease;
 }
 
-.resource-details {
-    margin-top: 15px;
+.fill.usage-warning {
+    background-color: #f39c12;
+}
+
+.fill.usage-critical {
+    background-color: #e74c3c;
+}
+
+.bar-percent {
+    font-size: 0.75rem;
+    margin-top: 2px;
+    display: inline-block;
+}
+
+.resource-detail-line {
+    font-size: 0.8rem;
+    color: #95a5a6;
+    margin-top: 2px;
+}
+
+/* GPU devices */
+.gpu-devices {
+    margin-top: 4px;
+}
+
+.gpu-device {
+    background-color: #2c3e50;
+    padding: 8px 10px;
+    border-radius: 6px;
+    margin-bottom: 6px;
+}
+
+.gpu-device label {
+    font-size: 0.85rem;
+    font-weight: bold;
     color: #ecf0f1;
+    display: block;
+    margin-bottom: 4px;
 }
 
-.resource-details p {
-    margin: 5px 0;
+/* Running tasks list */
+.task-list-section {
+    margin-top: 8px;
 }
 
+.task-list-label {
+    font-size: 0.9rem;
+    color: #bdc3c7;
+    font-weight: bold;
+    display: block;
+    margin-bottom: 6px;
+}
+
+.task-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.task-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background-color: #2c3e50;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 0.85rem;
+}
+
+.task-dot {
+    color: #2ecc71;
+    font-size: 0.6rem;
+}
+
+.task-name {
+    flex: 1;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.resource-badge {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: bold;
+    white-space: nowrap;
+}
+
+.badge-cpu {
+    background-color: #2980b9;
+    color: #fff;
+}
+
+.badge-gpu {
+    background-color: #8e44ad;
+    color: #fff;
+}
+
+.task-elapsed {
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: #95a5a6;
+    white-space: nowrap;
+}
+
+/* States */
+.empty-state {
+    text-align: center;
+    color: #7f8c8d;
+    padding: 12px 0;
+    font-size: 0.9rem;
+}
+
+.error-state {
+    text-align: center;
+    color: #e67e22;
+    padding: 12px 0;
+    font-size: 0.9rem;
+}
+
+/* Usage color classes for text */
+.usage-normal {
+    color: #2ecc71;
+}
+
+.usage-warning {
+    color: #f39c12;
+}
+
+.usage-critical {
+    color: #e74c3c;
+}
+
+/* Modal actions */
 .modal-actions {
     display: flex;
     justify-content: space-between;
@@ -462,73 +583,6 @@ export default {
     background-color: #c0392b;
 }
 
-.gpu-info {
-    margin-bottom: 15px;
-    padding: 10px;
-    background-color: #2c3e50;
-    border-radius: 8px;
-}
-
-.resource-sub-bar {
-    margin: 8px 0;
-}
-
-.gpu-info label {
-    font-weight: bold;
-    margin-bottom: 5px;
-    display: block;
-}
-
-.usage-critical {
-    color: #e74c3c;
-}
-
-.usage-warning {
-    color: #f39c12;
-}
-
-.usage-normal {
-    color: #2ecc71;
-}
-
-.cpu-cores {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: 8px;
-    margin-top: 10px;
-}
-
-.usage-normal {
-    color: #2ecc71;
-}
-
-.usage-warning {
-    color: #f1c40f;
-}
-
-.usage-critical {
-    color: #e74c3c;
-}
-
-.resource-details p {
-    margin: 8px 0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.container-info {
-    margin-bottom: 15px;
-    padding: 10px;
-    background-color: #2c3e50;
-    border-radius: 8px;
-}
-
-.container-info h4 {
-    margin-bottom: 10px;
-    color: #ecf0f1;
-}
-
 /* Full modal loading overlay */
 .full-loading-overlay {
     position: absolute;
@@ -540,7 +594,7 @@ export default {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    z-index: 10002; /* 가장 높은 z-index로 설정 */
+    z-index: 10002;
     background-color: rgba(44, 62, 80, 0.3);
     border-radius: 1rem;
 }

--- a/frontend/src/components/workflowComponents/PopupFileTable.vue
+++ b/frontend/src/components/workflowComponents/PopupFileTable.vue
@@ -11,10 +11,10 @@
             </thead>
             <tbody>
                 <tr v-for="(file, index) in files_list" :key="index">
-                    <td>{{ file.file_name | cutFromDotName }}</td>
-                    <td>{{ file.created_at | cutFromT }}</td>
-                    <td>{{ file.file_name | cutFromDotType }}</td>
-                    <td>{{ file.file_size | formatBytes }}</td>
+                    <td>{{ extractFileName(file.file_name) }}</td>
+                    <td>{{ cutDateFromISO(file.created_at) }}</td>
+                    <td>{{ extractExtension(file.file_name) }}</td>
+                    <td>{{ formatBytes(file.file_size) }}</td>
                 </tr>
             </tbody>
         </table>
@@ -22,6 +22,8 @@
 </template>
 
 <script>
+import { formatBytes, extractFileName, cutDateFromISO, extractExtension } from "@/utils/formatters";
+
 export default {
     props: {
         show_files: {
@@ -33,28 +35,12 @@ export default {
             required: true
         }
     },
-    filters: {
-        cutFromDotName(value) {
-            // Implement the filter logic here
-            return value.split('.')[0];
-        },
-        cutFromT(value) {
-            // Implement the filter logic here
-            return value.split('T')[0];
-        },
-        cutFromDotType(value) {
-            // Implement the filter logic here
-            return value.split('.').pop();
-        },
-        formatBytes(value) {
-            // Implement the filter logic here
-            if (value === 0) return '0 Bytes';
-            const k = 1024;
-            const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-            const i = Math.floor(Math.log(value) / Math.log(k));
-            return parseFloat((value / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-        }
-    }
+    methods: {
+        formatBytes,
+        extractFileName,
+        cutDateFromISO,
+        extractExtension,
+    },
 };
 </script>
 

--- a/frontend/src/components/workflowComponents/PopupJobTable.vue
+++ b/frontend/src/components/workflowComponents/PopupJobTable.vue
@@ -143,7 +143,7 @@ export default {
         // 메뉴 크기 계산을 위해 임시로 메뉴를 표시
         this.currentTaskId = task.task_id;
         this.currentTask = task;
-        this.isCompleted = ["SUCCESS", "FAILURE", "REVOKED", "RETRY"].includes(task.status);
+        this.isCompleted = ["SUCCESS", "FAILURE", "REVOKED"].includes(task.status);
         this.canDownloadManifest = task.status === 'SUCCESS' && this.formatPluginType(task) === 'Analysis';
         this.isAnalysisTask = this.formatPluginType(task) === 'Analysis';
         this.R_Mouse_isActive = true;
@@ -400,6 +400,10 @@ export default {
 
 .status-running {
   background-color: #f39c12;
+}
+
+.status-retry {
+  background-color: #f1c40f;
 }
 
 /* 취소 아이콘 */

--- a/frontend/src/store/workflow/mutations.js
+++ b/frontend/src/store/workflow/mutations.js
@@ -27,6 +27,7 @@ export default {
   setWorkflowFile(state, file_info) {
     if (state.workflow_info.drawflow.Home.data[file_info.id]) {
       state.workflow_info.drawflow.Home.data[file_info.id].data.file = file_info.file_name;
+      state.workflow_info.drawflow.Home.data[file_info.id].data.fileSource = file_info.source || "user";
     } else {
       console.error(`No object found with id: ${file_info.id}`);
     }

--- a/frontend/src/store/workflow/utils.js
+++ b/frontend/src/store/workflow/utils.js
@@ -176,6 +176,10 @@ export function traverseGraphBFS(state, startNodeId, onNodeVisit, options = {}) 
  * @param {boolean} isMultiFile - 멀티파일 여부
  */
 export function propagateFileToConnectedNodes(state, sourceNodeId, filesToShare, isMultiFile = false) {
+  // 소스 노드의 fileSource 읽기
+  const sourceNode = getNodeFromState(state, sourceNodeId);
+  const fileSource = sourceNode ? (sourceNode.data.fileSource || "user") : "user";
+
   traverseGraphBFS(
     state,
     sourceNodeId,
@@ -201,6 +205,8 @@ export function propagateFileToConnectedNodes(state, sourceNodeId, filesToShare,
         // 단일 파일: 하위 호환성 유지
         targetNode.data.file = filesToShare;
       }
+      // fileSource 전파
+      targetNode.data.fileSource = fileSource;
 
       return 'continue';
     },

--- a/frontend/src/utils/taskStatus.js
+++ b/frontend/src/utils/taskStatus.js
@@ -19,8 +19,8 @@ export const TASK_STATUS = {
 export function getStatusClass(status) {
   if (status === TASK_STATUS.SUCCESS) return "status-success";
   if (status === TASK_STATUS.FAILURE ||
-      status === TASK_STATUS.REVOKED ||
-      status === TASK_STATUS.RETRY) return "status-failure";
+      status === TASK_STATUS.REVOKED) return "status-failure";
+  if (status === TASK_STATUS.RETRY) return "status-retry";
   if (status === TASK_STATUS.RUNNING ||
       status === TASK_STATUS.PENDING ||
       status === TASK_STATUS.INSTALLING) return "status-running";
@@ -36,8 +36,7 @@ export function isTaskCompleted(status) {
   return [
     TASK_STATUS.SUCCESS,
     TASK_STATUS.FAILURE,
-    TASK_STATUS.REVOKED,
-    TASK_STATUS.RETRY
+    TASK_STATUS.REVOKED
   ].includes(status);
 }
 
@@ -50,6 +49,7 @@ export function isTaskRunning(status) {
   return [
     TASK_STATUS.RUNNING,
     TASK_STATUS.PENDING,
-    TASK_STATUS.INSTALLING
+    TASK_STATUS.INSTALLING,
+    TASK_STATUS.RETRY
   ].includes(status);
 }

--- a/frontend/src/views/FilesPage.vue
+++ b/frontend/src/views/FilesPage.vue
@@ -72,11 +72,6 @@
         <li @click="removeFile">Delete</li>
       </ul>
     </main>
-    <div class="message" v-bind:class="{ toggleMessage: !toggleMessage }">
-      <p class="message__text">{{ messageContent }}</p>
-      <p class="message__undo" @click="undoDeletion">undo</p>
-      <img class="message__close" @click="toggleMessage = !toggleMessage" src="@/assets/close.png" />
-    </div>
   </div>
 </template>
 
@@ -108,10 +103,6 @@ export default {
       selectFile: null,
       file_name: null,
       list_idx: null,
-      toggleMessage: false,
-      deletionTimer: null,
-      messageContent: "",
-      targetFile: null,
       uploadPercentage: 0,
       isDeletingFile: false, // Track file deletion state to prevent concurrent deletions
     };
@@ -233,7 +224,6 @@ export default {
         await deleteFile(file);
 
         // Only remove from UI after successful deletion
-        this.targetFile = this.files_list[this.list_idx];
         this.files_list.splice(this.list_idx, 1);
 
       } catch (error) {
@@ -254,11 +244,6 @@ export default {
         // Reset loading state
         this.isDeletingFile = false;
       }
-    },
-    undoDeletion() {
-      this.files_list.push(this.targetFile);
-      this.toggleMessage = false;
-      clearTimeout(this.deletionTimer);
     },
   },
 
@@ -585,54 +570,6 @@ export default {
 
 .toggle__menu>li:hover {
   background: #e5e5e5;
-}
-
-.message {
-  width: 20rem;
-  height: 3rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  position: absolute;
-  bottom: 1rem;
-  left: calc(50% - 10rem);
-  background: rgba(0, 0, 0, 0.8);
-  border-radius: 1rem;
-  padding: 0 1rem;
-}
-
-.message__text {
-  font-family: "Montserrat", sans-serif;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 1rem;
-  line-height: 1rem;
-  color: #ffffff;
-}
-
-.message__undo {
-  font-family: "Montserrat", sans-serif;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 1rem;
-  line-height: 1rem;
-  color: #9196ff;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-.message__close {
-  cursor: pointer;
-  width: 1rem;
-  height: 1rem;
-  object-fit: contain;
-  margin: 0 0.5rem;
-  opacity: 0.5;
-  filter: invert(100%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(100%) contrast(100%);
-}
-
-.toggleMessage {
-  display: none;
 }
 
 .progress__box {

--- a/frontend/src/views/FilesPage.vue
+++ b/frontend/src/views/FilesPage.vue
@@ -38,9 +38,24 @@
             <h1>Upload File</h1>
             <input class="files__input" type="file" name="file" ref="selectFile" @change.prevent="uploadFile" />
           </label>
-          <div class="progress__box" v-if="uploadPercentage > 0">
-            <progress :value="uploadPercentage" max="100"></progress>
-            <span>{{ uploadPercentage }}%</span>
+          <div class="progress__box" v-if="isUploading">
+            <!-- Step 1: Upload progress bar -->
+            <template v-if="uploadStep === 1">
+              <div class="upload-bar-track">
+                <div class="upload-bar-fill" :style="{ width: uploadPercentage + '%' }"></div>
+              </div>
+              <span class="upload-status-text">
+                Uploading<template v-if="uploadTotalSteps > 1"> (1/{{ uploadTotalSteps }})</template>...
+                {{ uploadPercentage }}%
+              </span>
+            </template>
+            <!-- Step 2: Compression indeterminate bar (H5AD only) -->
+            <template v-if="uploadStep === 2">
+              <div class="upload-bar-track">
+                <div class="upload-bar-fill upload-bar-fill--indeterminate"></div>
+              </div>
+              <span class="upload-status-text">Compressing (2/{{ uploadTotalSteps }})</span>
+            </template>
           </div>
         </div>
       </div>
@@ -104,8 +119,16 @@ export default {
       file_name: null,
       list_idx: null,
       uploadPercentage: 0,
+      uploadStep: 0,        // 0=idle, 1=uploading, 2=compressing
+      uploadTotalSteps: 1,  // 1=non-H5AD, 2=H5AD
       isDeletingFile: false, // Track file deletion state to prevent concurrent deletions
     };
+  },
+
+  computed: {
+    isUploading() {
+      return this.uploadStep > 0;
+    },
   },
 
   methods: {
@@ -139,47 +162,54 @@ export default {
       if (this.$refs.selectFile.files.length > 0) {
         const file = this.$refs.selectFile.files[0];
 
-        // Validate file extension using utility function
         const validation = validateFileExtension(file.name);
         if (!validation.isValid) {
           alert(validation.message);
           return;
         }
 
-        // Generate upload filename using utility function
         const newFileName = generateUploadFileName(this.currentFolder, file.name);
         this.selectFile = new File([file], newFileName);
+
+        const isH5ad = file.name.toLowerCase().endsWith('.h5ad');
+
+        // Initialize step state
+        this.uploadTotalSteps = isH5ad ? 2 : 1;
+        this.uploadStep = 1;
+        this.uploadPercentage = 0;
 
         const form = new FormData();
         form.append("files", this.selectFile);
 
-        // 파일 업로드 진행률을 추적하기 위한 콜백
         const onUploadProgress = (progressEvent) => {
-          this.uploadPercentage = parseInt(
-            Math.round((progressEvent.loaded * 100) / progressEvent.total)
+          if (!progressEvent.total || progressEvent.total === 0) return;
+          const pct = Math.min(
+            100,
+            parseInt(Math.round((progressEvent.loaded * 100) / progressEvent.total))
           );
+          if (pct >= 100 && isH5ad) {
+            this.uploadPercentage = 100;
+            this.$nextTick(() => {
+              this.uploadStep = 2;
+              this.uploadPercentage = 0;
+            });
+          } else {
+            this.uploadPercentage = pct;
+          }
         };
 
         try {
           await uploadForm(form, onUploadProgress);
-          this.uploadPercentage = 0; // 업로드 완료 후 초기화
+          this.resetUploadState();
 
-          // 업로드 성공 후 파일 목록 새로고침
-          const folderList = await findFolder({
-            folder_name: this.currentFolder,
-          });
+          const folderList = await findFolder({ folder_name: this.currentFolder });
           this.files_list = folderList.data;
         } catch (error) {
           console.error('File upload failed:', error);
+          this.resetUploadState();
 
-          // 업로드 실패 시 진행률 리셋
-          this.uploadPercentage = 0;
-
-          // 사용자에게 에러 메시지 표시
           let errorMessage = 'File upload failed. Please try again.';
-
           if (error.response) {
-            // 백엔드 에러 응답이 있는 경우
             if (error.response.data && error.response.data.detail) {
               errorMessage = error.response.data.detail;
             } else if (error.response.status === 413) {
@@ -192,10 +222,14 @@ export default {
           } else if (error.request) {
             errorMessage = 'Network error. Please check your connection.';
           }
-
           alert(errorMessage);
         }
       }
+    },
+    resetUploadState() {
+      this.uploadStep = 0;
+      this.uploadTotalSteps = 1;
+      this.uploadPercentage = 0;
     },
     async removeFile() {
       // Prevent concurrent deletions
@@ -245,9 +279,27 @@ export default {
         this.isDeletingFile = false;
       }
     },
+    handleBeforeUnload(e) {
+      if (this.uploadStep > 0) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    },
+  },
+
+  beforeRouteLeave(to, from, next) {
+    if (this.uploadStep > 0) {
+      const answer = window.confirm(
+        'File upload is in progress. Are you sure you want to leave this page?'
+      );
+      next(answer);
+    } else {
+      next();
+    }
   },
 
   async mounted() {
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
     if (this.$route.query.doUploadFile) {
       this.$refs.selectFile.click();
     }
@@ -261,6 +313,10 @@ export default {
     } catch (error) {
       console.error(error);
     }
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('beforeunload', this.handleBeforeUnload);
   },
 };
 </script>
@@ -575,36 +631,43 @@ export default {
 .progress__box {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 15rem;
-  height: 1rem;
+  width: 18rem;
+  height: 1.2rem;
+  margin-right: 1rem;
 }
 
-/* progress bar */
-progress {
-  width: 100%;
-  /* 전체 너비를 차지하도록 설정 */
-  height: 100%;
-  /* 높이 설정 */
+.upload-bar-track {
+  width: 10rem;
+  height: 0.6rem;
   background-color: #eee;
-  /* 배경색 설정 */
   border-radius: 10px;
-  /* 모서리 둥글게 처리 */
+  overflow: hidden;
+  flex-shrink: 0;
   margin-right: 0.5rem;
 }
 
-progress::-webkit-progress-bar {
-  background-color: #eee;
-  /* 크롬, 사파리 등 WebKit 기반 브라우저에서의 배경색 */
+.upload-bar-fill {
+  height: 100%;
+  background-color: #4caf50;
+  border-radius: 10px;
+  transition: width 0.2s ease;
 }
 
-progress::-webkit-progress-value {
-  background-color: #4caf50;
-  /* 크롬, 사파리 등 WebKit 기반 브라우저에서의 진행률 색상 */
+.upload-bar-fill--indeterminate {
+  width: 40%;
+  animation: indeterminate-slide 1.4s ease-in-out infinite;
 }
 
-progress::-moz-progress-bar {
-  background-color: #4caf50;
-  /* 파이어폭스에서의 진행률 색상 */
+@keyframes indeterminate-slide {
+  0%   { transform: translateX(-100%); }
+  50%  { transform: translateX(150%); }
+  100% { transform: translateX(350%); }
+}
+
+.upload-status-text {
+  font-family: "Montserrat", sans-serif;
+  font-size: 0.8rem;
+  color: #666;
+  white-space: nowrap;
 }
 </style>

--- a/frontend/src/views/WorkFlowPage.vue
+++ b/frontend/src/views/WorkFlowPage.vue
@@ -354,12 +354,20 @@ export default {
       }
     }
 
-    // Task 모니터링
+    // Task 모니터링 — 실행 중인 task에 SSE 재연결
     try {
       const userTasks = await userTaskMonitoring();
       console.log(userTasks.data);
-      if (userTasks.data.some(task => task.status === "RUNNING" || task.status === "PENDING" || task.status === "INSTALLING")) {
+      const runningTasks = userTasks.data.filter(
+        task => task.status === "RUNNING" || task.status === "PENDING" || task.status === "INSTALLING"
+      );
+      if (runningTasks.length > 0) {
         this.on_progress = true;
+        runningTasks.forEach(task => {
+          if (!this.eventSources[task.task_id]) {
+            this.createEventSource(task.task_id);
+          }
+        });
       }
     } catch (error) {
       console.error(error);

--- a/frontend/src/views/WorkFlowPage.vue
+++ b/frontend/src/views/WorkFlowPage.vue
@@ -413,8 +413,17 @@ export default {
         onMessage: (event) => {
           console.log("Received update: ", event.data);
           // PENDING 상태도 진행 중으로 처리
-          if (event.data === "RUNNING" || event.data === "PENDING" || event.data === "INSTALLING") {
+          if (event.data === "RUNNING" || event.data === "PENDING" || event.data === "INSTALLING" || event.data === "RETRY") {
             this.on_progress = true;
+          }
+          if (event.data === "RETRY") {
+            const taskIndex = this.taskList.findIndex(task => task.task_id === task_id);
+            if (taskIndex !== -1) {
+              this.$set(this.taskList, taskIndex, {
+                ...this.taskList[taskIndex],
+                status: "RETRY",
+              });
+            }
           }
           if (event.data === "INSTALLING") {
             // taskList에서 해당 task에 대해서 status를 INSTALLING으로 변경
@@ -679,13 +688,12 @@ export default {
       this.taskList.forEach((task, idx) => {
         if (task.status === "SUCCESS" ||
           task.status === "FAILURE" ||
-          task.status === "REVOKED" ||
-          task.status === "RETRY") {
+          task.status === "REVOKED") {
           this.taskList[idx].running_time = getTimeDifference(
             task.start_time,
             task.end_time
           );
-        } else if (task.status === "RUNNING" || task.status === "PENDING" || task.status === "INSTALLING") {
+        } else if (task.status === "RUNNING" || task.status === "PENDING" || task.status === "INSTALLING" || task.status === "RETRY") {
           // RUNNING 또는 PENDING 상태일 때 타이머 시작
           this.timeInterval = this.startTimer(idx);
           // Task가 실행 중이므로 on_progress를 true로 설정

--- a/rabbitmq.conf
+++ b/rabbitmq.conf
@@ -1,5 +1,6 @@
 # rabbitmq.conf
-# Consumer timeout 설정 (72시간)
-consumer_timeout = 259200000
+# Consumer timeout 비활성화 — GRN inference 작업은 데이터셋에 따라 수일~수주 소요 가능
+# 0 = 무제한 (RabbitMQ 3.12+). task_acks_late=False이므로 실질적 영향 없으나 방어적 설정.
+consumer_timeout = 0
 queue_master_locator=min-masters
 queue_leader_locator=balanced


### PR DESCRIPTION
## Summary                                                                                                                                  
                                   
  v1.0.6 introduces backend performance caching, resource-aware task scheduling, file upload compression, and SSE stability improvements.     
                                                                                                                                              
  ### Performance: Redis/In-Process Caching (P1–P3)

  - Add in-process TTLCache for H5AD metadata (`/columns`, `/clusters`) — GTEx: 24,799ms → 28ms (872x)
  - Add Redis cache for DataTable (`load_tab_file`) — CRC: 3,487ms → 85ms (41x), pbmc: 324ms → 25ms (13x)
  - Add Redis cache for plugin list (TTL 120s) — eliminate N+1 queries, reuse Docker client
  - Add Redis 7 Alpine service (maxmemory 512MB, allkeys-lru) across all compose files
  - Graceful fallback on all cache layers: Redis down → original query path executes normally

  ### Infrastructure: Resource-Aware Task Queue (P5)

  - Redis Lua semaphore for CPU/GPU slot management (`resource_manager.py`)
  - Auto-detect CPU (`os.cpu_count()`), GPU (`GPU_COUNT` env / GPUtil)
  - Dynamic Celery worker concurrency (shell form CMD + `CELERY_WORKER_CONCURRENCY` env var)
  - Resource monitoring API: `GET /routes/task/resources` (host memory and GPU device info)
  - Handle RETRY state as transient to prevent slot leaks

  ### Feature: H5AD Upload Compression (P6)

  - Server-side gzip compression on upload (`write_h5ad(compression='gzip')`)
  - Auto-resolve anndata 0.8.0 `_index` reserved column name conflicts
  - Config: `H5AD_COMPRESSION_ENABLED`, `H5AD_COMPRESSION_MIN_SIZE` (default 1MB)
  - Increase MAX_UPLOAD_SIZE from 500MB to 10GB
  - Unified upload progress UX: step indicator (`Uploading (1/2)` → `Compressing (2/2)`)
  - Page leave prevention during upload (beforeRouteLeave + beforeunload)

  ### Feature: SSE Reconnection (P4)

  - Rewrite `createTaskEventSource` with auto-reconnect (REST fallback → status check → reconnect)
  - Add lightweight status endpoint: `GET /routes/task/status/{task_id}`
  - Re-establish SSE connections for running tasks on WorkFlowPage mount
  - Dedicated nginx location blocks for SSE (buffering off, 3700s timeout) and upload (3600s timeout)
  - Disable RabbitMQ `consumer_timeout` (set to 0) for long-running GRN inference tasks

  ### Feature: Shared Tutorial Data

  - Add Tutorial Data tab to InputFile modal for shared dataset selection
  - Support `source=shared` in `/columns`, `/clusters`, `/datatable` endpoints
  - Resolve shared file paths during workflow compilation

  ### Feature: UI Improvements

  - Add loading spinner to Algorithm modal during parameter fetch
  - Replace broken DataTable loading layout with overlay spinner
  - Switch CompileCheck from Docker stats to slot-based resource monitoring API

  ### Fix & Refactor

  - Fix duplicate function name and secure HTML endpoint in files.py
  - Remove dead undo deletion code from FilesPage
  - Replace Vue filters with shared formatter utilities
  - Fix missing sparse matrix to dense array conversion in H5AD fallback path