### PR TITLE
refactor(v1.0.7) PR-1: 안전망 구축 — OpenAPI 계약 스냅샷 + characterization 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ __pycache__
 # Frontend test artifacts
 frontend/coverage/
 frontend/coverage-output.txt
+
+# Backend test artifacts
+backend/.coverage
+backend/htmlcov/
+backend/logs/
+
+# oh-my-claudecode local state
+.omc/

--- a/backend/.importlinter
+++ b/backend/.importlinter
@@ -1,0 +1,30 @@
+# import-linter contracts for the cellcraft backend.
+#
+# Run (once import-linter is installed) from the backend/ directory:
+#     lint-imports
+#
+# Purpose: define the architectural import contracts up front (during PR-1,
+# the safety-net phase) so they can be switched on as the refactoring lands.
+#
+# STATUS: the `no-web-in-worker` contract is defined but INACTIVE. There is no
+# `app.worker` package yet — the Celery worker still boots via `app.main`
+# (Dockerfile.celery: `celery -A app.main.celery worker`). This contract becomes
+# meaningful in PR-2 (phase-1-app-assembly), where `app.worker` is introduced and
+# the worker entry point stops importing the web layer. To ACTIVATE in PR-2:
+#   1. Uncomment the [importlinter:contract:no-web-in-worker] block below.
+#   2. Ensure `app.worker` exists.
+#   3. Add `import-linter` to the backend dev/test dependencies and wire
+#      `lint-imports` into CI.
+
+[importlinter]
+root_package = app
+
+# --- Activated in PR-2 (phase-1-app-assembly) — keep commented until app.worker exists ---
+# [importlinter:contract:no-web-in-worker]
+# name = worker must not depend on the web layer
+# type = forbidden
+# source_modules =
+#     app.worker
+# forbidden_modules =
+#     app.main
+#     app.api

--- a/backend/Dockerfile.test
+++ b/backend/Dockerfile.test
@@ -1,0 +1,14 @@
+# Test image: app image + test-only dependencies.
+#
+# Build the base app image first (arm64 example):
+#   docker build -f backend/Dockerfile.cpu \
+#     --build-arg TARGETPLATFORM=linux/arm64 --platform linux/arm64 \
+#     -t cellcraft-backend:refactor-test backend/
+# Then:
+#   docker build -f backend/Dockerfile.test -t cellcraft-backend:test backend/
+#
+# Used by docker-compose.test.yml (backend-test service).
+FROM cellcraft-backend:refactor-test
+
+COPY requirements-test.txt /tmp/requirements-test.txt
+RUN pip install --no-cache-dir -r /tmp/requirements-test.txt

--- a/backend/alembic/versions/0001_initial_schema.py
+++ b/backend/alembic/versions/0001_initial_schema.py
@@ -46,7 +46,9 @@ def upgrade() -> None:
         sa.Column('description', sa.String(), nullable=False),
         sa.Column('author', sa.String(), nullable=False),
         sa.Column('plugin_path', sa.String(), nullable=False),
-        sa.Column('plugin_type', sa.Enum('ANALYSIS', 'VISUALIZATION', name='plugintype', create_type=False), nullable=True),
+        # create_type=False is only honored by postgresql.ENUM (generic sa.Enum
+        # ignores it and emits a duplicate CREATE TYPE, breaking fresh installs).
+        sa.Column('plugin_type', postgresql.ENUM('ANALYSIS', 'VISUALIZATION', name='plugintype', create_type=False), nullable=True),
         sa.Column('dependencies', postgresql.JSONB(), nullable=True),
         sa.Column('drawflow', postgresql.JSONB(), nullable=False),
         sa.Column('rules', postgresql.JSONB(), nullable=False),

--- a/backend/app/database/conn.py
+++ b/backend/app/database/conn.py
@@ -15,8 +15,13 @@ from app.common.security import get_password_hash
 
 # Use test PostgreSQL database when TESTING=1 (matches production environment)
 if os.environ.get("TESTING") == "1":
-    # Test DB runs on Docker test-db service (localhost:5433)
-    SQLALCHEMY_TEST_DATABASE_URI = "postgresql://test_user:test_pass@localhost:5433/cellcraft_test"
+    # Test DB runs on Docker test-db service (localhost:5433 by default).
+    # TEST_DATABASE_URI overrides it when tests run inside a container
+    # (e.g. docker-compose.test.yml uses test-db:5432 on its own network).
+    SQLALCHEMY_TEST_DATABASE_URI = os.environ.get(
+        "TEST_DATABASE_URI",
+        "postgresql://test_user:test_pass@localhost:5433/cellcraft_test",
+    )
     engine = create_engine(
         SQLALCHEMY_TEST_DATABASE_URI,
         echo=False,  # Disable SQL logging in tests

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -32,9 +32,15 @@ markers =
     error: Error handling and exception tests
     models: SQLAlchemy database model tests
     benchmark: Performance benchmark tests (excluded from normal runs)
+    contract: API contract (OpenAPI snapshot) tests
+    characterization: Characterization tests that pin current behavior
 
 # Asyncio configuration
 asyncio_mode = auto
+
+# Per-test hard timeout (pytest-timeout): a hung stream or unmocked SSE loop
+# fails fast instead of blocking the whole suite.
+timeout = 300
 
 # Coverage options
 [coverage:run]

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -1,0 +1,21 @@
+# Test-only dependencies, installed on top of the app image (see Dockerfile.test).
+# Versions verified against the snakemake conda env (python 3.10,
+# fastapi 0.92.0 / starlette 0.25.0 / pydantic 1.9.1 / SQLAlchemy 1.4.36).
+pytest==7.4.4
+pytest-cov==4.1.0
+pytest-asyncio==0.21.2
+# Hard per-test timeout so a hung stream (e.g. an unmocked SSE loop) fails the
+# suite instead of blocking it indefinitely.
+pytest-timeout==2.3.1
+# Used by existing integration tests (tests/integration/test_*_api.py).
+faker==25.9.2
+import-linter==1.12.1
+# starlette 0.25 TestClient passes app= to httpx.Client; that kwarg was removed
+# in httpx 0.27, so stay below 0.24.
+httpx==0.23.3
+requests>=2.28
+
+# App dependency missing from environment.yml (arm64): used by
+# app/common/utils/h5ad_metadata_cache.py. Kept here so tests run until the
+# conda env files are regenerated.
+cachetools==5.2.0

--- a/backend/scripts/update_openapi_snapshot.py
+++ b/backend/scripts/update_openapi_snapshot.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""
+Generate / refresh the OpenAPI contract snapshot.
+
+This MUST run inside the test environment. ``app.main`` executes
+``run_migrations()`` at import time (main.py:84), so importing the app requires a
+reachable database. Setting ``TESTING=1`` before the import routes the app to the
+test DB configuration (see ``app/database/conn.py`` and conftest).
+
+Usage (from the ``backend`` directory, inside the container / test env):
+
+    python scripts/update_openapi_snapshot.py
+
+The snapshot is written with ``sort_keys=True`` and ``indent=2`` so diffs stay
+stable and reviewable.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+# Ensure the test DB configuration is selected BEFORE importing the app,
+# mirroring the conftest import pattern (main.py runs migrations on import).
+os.environ.setdefault("TESTING", "1")
+
+# Make sure the backend package root is importable when run as a script.
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+SNAPSHOT_PATH = BACKEND_ROOT / "tests" / "contract" / "openapi_snapshot.json"
+
+
+def generate_snapshot() -> Path:
+    """Import the app, dump its OpenAPI document, and write the snapshot file."""
+    from app.main import app  # imported here so TESTING is already set
+
+    openapi_schema = app.openapi()
+
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SNAPSHOT_PATH.write_text(
+        json.dumps(openapi_schema, sort_keys=True, indent=2, ensure_ascii=False) + "\n"
+    )
+    return SNAPSHOT_PATH
+
+
+if __name__ == "__main__":
+    written = generate_snapshot()
+    print(f"OpenAPI snapshot written to: {written}")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -43,7 +43,10 @@ def test_engine():
     Note: Requires test-db service running:
         docker compose -f docker-compose.dev.yml up test-db -d
     """
-    TEST_DATABASE_URI = "postgresql://test_user:test_pass@localhost:5433/cellcraft_test"
+    TEST_DATABASE_URI = os.environ.get(
+        "TEST_DATABASE_URI",
+        "postgresql://test_user:test_pass@localhost:5433/cellcraft_test"
+    )
 
     engine = create_engine(
         TEST_DATABASE_URI,

--- a/backend/tests/contract/README.md
+++ b/backend/tests/contract/README.md
@@ -1,0 +1,95 @@
+# Contract & characterization test guide
+
+This directory holds the **API contract** safety net for the v1.0.7 refactoring
+(PR-1, phase 0). It exists to mechanically prove that refactoring PRs do **not**
+change the public API surface or observable behavior.
+
+## What lives here
+
+- `test_openapi_contract.py` — compares the live `app.openapi()` document against
+  the committed snapshot `openapi_snapshot.json`. Any change to paths, methods,
+  or request/response schemas fails the test with a concise diff summary.
+- `openapi_snapshot.json` — the frozen OpenAPI document. **Generated inside the
+  test environment**, not by hand (see below).
+
+Characterization tests that pin *behavior* (not just the schema) live alongside
+the existing integration tests in `backend/tests/integration/`:
+
+- `test_characterization_auth.py`
+- `test_characterization_plugin_upload.py`
+- `test_characterization_workflow_compile.py`
+- `test_characterization_task_status.py`
+- `test_characterization_file_upload.py`
+
+## Generating / updating the OpenAPI snapshot
+
+`app.main` runs Alembic migrations at import time (main.py:84), so the snapshot
+**must** be generated where a database is reachable. Use the test compose stack:
+
+```bash
+# 1. Build the backend app image once (arm64 example; pick your platform/Dockerfile),
+#    then the test image (app image + test deps from requirements-test.txt).
+docker build -f backend/Dockerfile.cpu \
+  --build-arg TARGETPLATFORM=linux/arm64 --platform linux/arm64 \
+  -t cellcraft-backend:refactor-test ./backend
+docker compose -f docker-compose.test.yml build backend-test
+
+# 2. Start the isolated test stack (own network + own DB).
+docker compose -f docker-compose.test.yml up -d
+
+# 3. Generate the snapshot inside the container.
+docker compose -f docker-compose.test.yml exec backend-test \
+    python scripts/update_openapi_snapshot.py
+
+# 4. The snapshot is written to backend/tests/contract/openapi_snapshot.json
+#    (the ./backend bind mount surfaces it on the host). Commit it.
+```
+
+Update the snapshot **only** when an API change is intentional, and describe the
+change in the PR body.
+
+## Running the tests
+
+The test suite talks to a PostgreSQL test database. The connection string is read
+from the `TEST_DATABASE_URI` environment variable (falling back to
+`postgresql://test_user:test_pass@localhost:5433/cellcraft_test`).
+
+### Using the test compose override (recommended)
+
+```bash
+# Build images (see above) + bring up test-db and backend-test.
+docker compose -f docker-compose.test.yml up -d
+
+# Run the whole suite inside the container (TESTING=1 and TEST_DATABASE_URI are
+# already set in the compose file, pointing at the in-network test-db).
+docker compose -f docker-compose.test.yml exec backend-test pytest
+
+# Run just the contract + characterization tests.
+docker compose -f docker-compose.test.yml exec backend-test \
+    pytest tests/contract tests/integration -m "contract or characterization"
+
+# Tear down when done.
+docker compose -f docker-compose.test.yml down
+```
+
+If host port 5433 is occupied, override it:
+
+```bash
+TEST_DB_PORT=5544 docker compose -f docker-compose.test.yml up -d
+```
+
+(The `backend-test` service reaches the DB over the internal network on port
+5432, so overriding the host port does not affect in-container test runs.)
+
+### Running against a local/dev test-db
+
+The existing `docker-compose.dev.yml` also defines a `test-db` service on host
+port 5433. To run the suite from a local checkout against it:
+
+```bash
+docker compose -f docker-compose.dev.yml up test-db -d
+cd backend && pytest
+```
+
+To point at a different host/port, set `TEST_DATABASE_URI` (and `TEST_DB_PORT`
+for compose) accordingly.

--- a/backend/tests/contract/__init__.py
+++ b/backend/tests/contract/__init__.py
@@ -1,0 +1,1 @@
+"""Contract tests: freeze the public API surface (OpenAPI schema)."""

--- a/backend/tests/contract/openapi_snapshot.json
+++ b/backend/tests/contract/openapi_snapshot.json
@@ -1,0 +1,5722 @@
+{
+  "components": {
+    "schemas": {
+      "Body_fileUpload_routes_files_upload_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
+          }
+        },
+        "required": [
+          "files"
+        ],
+        "title": "Body_fileUpload_routes_files_upload_post",
+        "type": "object"
+      },
+      "Body_login_access_token_routes_auth_login_access_token_post": {
+        "properties": {
+          "client_id": {
+            "title": "Client Id",
+            "type": "string"
+          },
+          "client_secret": {
+            "title": "Client Secret",
+            "type": "string"
+          },
+          "grant_type": {
+            "pattern": "password",
+            "title": "Grant Type",
+            "type": "string"
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          },
+          "scope": {
+            "default": "",
+            "title": "Scope",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_login_access_token_routes_auth_login_access_token_post",
+        "type": "object"
+      },
+      "Body_update_plugin_version_routes_plugin_versions__plugin_name__update_post": {
+        "properties": {
+          "version": {
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version"
+        ],
+        "title": "Body_update_plugin_version_routes_plugin_versions__plugin_name__update_post",
+        "type": "object"
+      },
+      "Body_upload_package_routes_plugin_upload_package_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "plugin_name": {
+            "title": "Plugin Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "plugin_name",
+          "files"
+        ],
+        "title": "Body_upload_package_routes_plugin_upload_package_post",
+        "type": "object"
+      },
+      "Body_upload_scripts_routes_plugin_upload_scripts_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "plugin_name": {
+            "title": "Plugin Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "plugin_name",
+          "files"
+        ],
+        "title": "Body_upload_scripts_routes_plugin_upload_scripts_post",
+        "type": "object"
+      },
+      "Body_upload_text_dependencies_routes_plugin_upload_text_dependencies_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "plugin_name": {
+            "title": "Plugin Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "plugin_name",
+          "files"
+        ],
+        "title": "Body_upload_text_dependencies_routes_plugin_upload_text_dependencies_post",
+        "type": "object"
+      },
+      "BuildDockerRequest": {
+        "properties": {
+          "use_gpu": {
+            "default": false,
+            "title": "Use Gpu",
+            "type": "boolean"
+          }
+        },
+        "title": "BuildDockerRequest",
+        "type": "object"
+      },
+      "DataTableEvent": {
+        "properties": {
+          "columnFilters": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Columnfilters",
+            "type": "object"
+          },
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "perPage": {
+            "title": "Perpage",
+            "type": "integer"
+          },
+          "sort": {
+            "items": {
+              "$ref": "#/components/schemas/Sort"
+            },
+            "title": "Sort",
+            "type": "array"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_name",
+          "page",
+          "perPage",
+          "columnFilters",
+          "sort"
+        ],
+        "title": "DataTableEvent",
+        "type": "object"
+      },
+      "DependencyFile": {
+        "properties": {
+          "file": {
+            "title": "File",
+            "type": "string"
+          },
+          "fileName": {
+            "title": "Filename",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file",
+          "fileName",
+          "type"
+        ],
+        "title": "DependencyFile",
+        "type": "object"
+      },
+      "FileDelete": {
+        "properties": {
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
+          "file_path": {
+            "title": "File Path",
+            "type": "string"
+          },
+          "file_size": {
+            "title": "File Size",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_name"
+        ],
+        "title": "FileDelete",
+        "type": "object"
+      },
+      "FileFind": {
+        "properties": {
+          "anno_column": {
+            "title": "Anno Column",
+            "type": "string"
+          },
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
+          "file_path": {
+            "title": "File Path",
+            "type": "string"
+          },
+          "file_size": {
+            "title": "File Size",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_name"
+        ],
+        "title": "FileFind",
+        "type": "object"
+      },
+      "FileResultFind": {
+        "properties": {
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
+          "file_path": {
+            "title": "File Path",
+            "type": "string"
+          },
+          "file_size": {
+            "title": "File Size",
+            "type": "string"
+          },
+          "option_file_name": {
+            "title": "Option File Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_name",
+          "option_file_name"
+        ],
+        "title": "FileResultFind",
+        "type": "object"
+      },
+      "FileUpdate": {
+        "properties": {
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
+          "file_path": {
+            "title": "File Path",
+            "type": "string"
+          },
+          "file_size": {
+            "title": "File Size",
+            "type": "string"
+          },
+          "update_name": {
+            "title": "Update Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_name",
+          "update_name"
+        ],
+        "title": "FileUpdate",
+        "type": "object"
+      },
+      "FolderFind": {
+        "properties": {
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
+          "file_path": {
+            "title": "File Path",
+            "type": "string"
+          },
+          "file_size": {
+            "title": "File Size",
+            "type": "string"
+          },
+          "folder_name": {
+            "title": "Folder Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "folder_name"
+        ],
+        "title": "FolderFind",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "Parameter": {
+        "properties": {
+          "defaultValue": {
+            "title": "Defaultvalue"
+          },
+          "fileExtension": {
+            "title": "Fileextension",
+            "type": "string"
+          },
+          "max": {
+            "title": "Max"
+          },
+          "min": {
+            "title": "Min"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "Parameter",
+        "type": "object"
+      },
+      "PluginAssociate": {
+        "properties": {
+          "plugin_id": {
+            "title": "Plugin Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "plugin_id"
+        ],
+        "title": "PluginAssociate",
+        "type": "object"
+      },
+      "PluginCreate": {
+        "properties": {
+          "author": {
+            "title": "Author",
+            "type": "string"
+          },
+          "dependencies": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Dependencies",
+            "type": "object"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "drawflow": {
+            "title": "Drawflow",
+            "type": "object"
+          },
+          "is_editable": {
+            "default": true,
+            "title": "Is Editable",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "plugin_path": {
+            "title": "Plugin Path",
+            "type": "string"
+          },
+          "plugin_type": {
+            "$ref": "#/components/schemas/PluginType"
+          },
+          "reference_folders": {
+            "title": "Reference Folders",
+            "type": "object"
+          },
+          "rules": {
+            "title": "Rules",
+            "type": "object"
+          },
+          "source": {
+            "default": "local",
+            "title": "Source",
+            "type": "string"
+          },
+          "submodule_path": {
+            "title": "Submodule Path",
+            "type": "string"
+          },
+          "use_gpu": {
+            "default": false,
+            "title": "Use Gpu",
+            "type": "boolean"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "author",
+          "plugin_path",
+          "drawflow",
+          "rules"
+        ],
+        "title": "PluginCreate",
+        "type": "object"
+      },
+      "PluginData": {
+        "properties": {
+          "drawflow": {
+            "title": "Drawflow",
+            "type": "object"
+          },
+          "plugin": {
+            "$ref": "#/components/schemas/app__database__schemas__plugin__PluginInfo"
+          },
+          "rules": {
+            "items": {
+              "$ref": "#/components/schemas/Rule"
+            },
+            "title": "Rules",
+            "type": "array"
+          }
+        },
+        "required": [
+          "plugin",
+          "rules",
+          "drawflow"
+        ],
+        "title": "PluginData",
+        "type": "object"
+      },
+      "PluginType": {
+        "description": "An enumeration.",
+        "enum": [
+          "analysis",
+          "visualization"
+        ],
+        "title": "PluginType",
+        "type": "string"
+      },
+      "ReferenceFolder": {
+        "properties": {
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/DependencyFile"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "folderName": {
+            "title": "Foldername",
+            "type": "string"
+          },
+          "subFolders": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/ReferenceFolder"
+            },
+            "title": "Subfolders",
+            "type": "array"
+          }
+        },
+        "required": [
+          "folderName",
+          "files"
+        ],
+        "title": "ReferenceFolder",
+        "type": "object"
+      },
+      "Rule": {
+        "properties": {
+          "input": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Input",
+            "type": "array"
+          },
+          "isVisualization": {
+            "default": false,
+            "title": "Isvisualization",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "nodeId": {
+            "title": "Nodeid",
+            "type": "integer"
+          },
+          "output": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Output",
+            "type": "array"
+          },
+          "parameters": {
+            "items": {
+              "$ref": "#/components/schemas/Parameter"
+            },
+            "title": "Parameters",
+            "type": "array"
+          },
+          "script": {
+            "title": "Script",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "input",
+          "output",
+          "parameters",
+          "nodeId"
+        ],
+        "title": "Rule",
+        "type": "object"
+      },
+      "Sort": {
+        "properties": {
+          "field": {
+            "title": "Field",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "field",
+          "type"
+        ],
+        "title": "Sort",
+        "type": "object"
+      },
+      "TaskMonitoringItem": {
+        "description": "Individual task item in task monitoring response.",
+        "properties": {
+          "end_time": {
+            "format": "date-time",
+            "title": "End Time",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "plugin": {
+            "$ref": "#/components/schemas/app__database__schemas__task__PluginInfo"
+          },
+          "plugin_name": {
+            "title": "Plugin Name",
+            "type": "string"
+          },
+          "start_time": {
+            "format": "date-time",
+            "title": "Start Time",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "task_id": {
+            "title": "Task Id",
+            "type": "string"
+          },
+          "task_title": {
+            "title": "Task Title",
+            "type": "string"
+          },
+          "task_type": {
+            "title": "Task Type",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          },
+          "workflow_id": {
+            "title": "Workflow Id",
+            "type": "integer"
+          },
+          "workflow_title": {
+            "title": "Workflow Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "task_id",
+          "user_id",
+          "status",
+          "start_time"
+        ],
+        "title": "TaskMonitoringItem",
+        "type": "object"
+      },
+      "Token": {
+        "properties": {
+          "access_token": {
+            "title": "Access Token",
+            "type": "string"
+          },
+          "token_type": {
+            "title": "Token Type",
+            "type": "string"
+          },
+          "user_info": {
+            "$ref": "#/components/schemas/UserInfo"
+          }
+        },
+        "required": [
+          "access_token",
+          "token_type",
+          "user_info"
+        ],
+        "title": "Token",
+        "type": "object"
+      },
+      "UserCreate": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "is_active": {
+            "default": true,
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "is_superuser": {
+            "default": false,
+            "title": "Is Superuser",
+            "type": "boolean"
+          },
+          "password": {
+            "minLength": 1,
+            "title": "Password",
+            "type": "string"
+          },
+          "username": {
+            "minLength": 1,
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "username",
+          "password"
+        ],
+        "title": "UserCreate",
+        "type": "object"
+      },
+      "UserInfo": {
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "is_superuser": {
+            "title": "Is Superuser",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "is_superuser",
+          "email",
+          "is_active"
+        ],
+        "title": "UserInfo",
+        "type": "object"
+      },
+      "UserProfile": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "default": true,
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "is_superuser": {
+            "title": "Is Superuser",
+            "type": "boolean"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "is_superuser",
+          "username",
+          "id"
+        ],
+        "title": "UserProfile",
+        "type": "object"
+      },
+      "UserUpdate": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "is_active": {
+            "default": true,
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "is_superuser": {
+            "default": false,
+            "title": "Is Superuser",
+            "type": "boolean"
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          },
+          "plugins": {
+            "items": {},
+            "title": "Plugins",
+            "type": "array"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "title": "UserUpdate",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "WorkflowCreate": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "thumbnail": {
+            "title": "Thumbnail",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "workflow_info": {
+            "title": "Workflow Info",
+            "type": "object"
+          }
+        },
+        "title": "WorkflowCreate",
+        "type": "object"
+      },
+      "WorkflowDelete": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "thumbnail": {
+            "title": "Thumbnail",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "workflow_info": {
+            "title": "Workflow Info",
+            "type": "object"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "WorkflowDelete",
+        "type": "object"
+      },
+      "WorkflowFind": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "thumbnail": {
+            "title": "Thumbnail",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "workflow_info": {
+            "title": "Workflow Info",
+            "type": "object"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "WorkflowFind",
+        "type": "object"
+      },
+      "WorkflowNodeFileCreate": {
+        "properties": {
+          "file_content": {
+            "items": {},
+            "title": "File Content",
+            "type": "array"
+          },
+          "file_extension": {
+            "title": "File Extension",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "node_id": {
+            "title": "Node Id",
+            "type": "string"
+          },
+          "node_name": {
+            "title": "Node Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "node_id",
+          "node_name",
+          "file_extension"
+        ],
+        "title": "WorkflowNodeFileCreate",
+        "type": "object"
+      },
+      "WorkflowNodeFileDelete": {
+        "properties": {
+          "file_content": {
+            "items": {},
+            "title": "File Content",
+            "type": "array"
+          },
+          "file_extension": {
+            "title": "File Extension",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "node_id": {
+            "title": "Node Id",
+            "type": "string"
+          },
+          "node_name": {
+            "title": "Node Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "node_id",
+          "node_name",
+          "file_extension"
+        ],
+        "title": "WorkflowNodeFileDelete",
+        "type": "object"
+      },
+      "WorkflowNodeFileRead": {
+        "properties": {
+          "file_content": {
+            "items": {},
+            "title": "File Content",
+            "type": "array"
+          },
+          "file_extension": {
+            "title": "File Extension",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "node_id": {
+            "title": "Node Id",
+            "type": "string"
+          },
+          "node_name": {
+            "title": "Node Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "node_id",
+          "node_name",
+          "file_extension"
+        ],
+        "title": "WorkflowNodeFileRead",
+        "type": "object"
+      },
+      "WorkflowResult": {
+        "properties": {
+          "algorithm_id": {
+            "title": "Algorithm Id",
+            "type": "integer"
+          },
+          "filename": {
+            "title": "Filename",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          }
+        },
+        "title": "WorkflowResult",
+        "type": "object"
+      },
+      "WorkflowVisualizationRequest": {
+        "properties": {
+          "algorithm_id": {
+            "title": "Algorithm Id",
+            "type": "string"
+          },
+          "availableFiles": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Availablefiles",
+            "type": "array"
+          },
+          "current_node_id": {
+            "title": "Current Node Id",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "selectedScript": {
+            "title": "Selectedscript",
+            "type": "object"
+          },
+          "selectedVisualizationParams": {
+            "items": {
+              "type": "object"
+            },
+            "title": "Selectedvisualizationparams",
+            "type": "array"
+          },
+          "selectedVisualizationPlugin": {
+            "title": "Selectedvisualizationplugin",
+            "type": "object"
+          },
+          "thumbnail": {
+            "title": "Thumbnail",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "workflow_info": {
+            "title": "Workflow Info",
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "current_node_id",
+          "selectedVisualizationPlugin",
+          "selectedScript",
+          "selectedVisualizationParams"
+        ],
+        "title": "WorkflowVisualizationRequest",
+        "type": "object"
+      },
+      "app__database__schemas__plugin__PluginInfo": {
+        "properties": {
+          "dependencyFiles": {
+            "items": {
+              "$ref": "#/components/schemas/DependencyFile"
+            },
+            "title": "Dependencyfiles",
+            "type": "array"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "pluginType": {
+            "$ref": "#/components/schemas/PluginType"
+          },
+          "referenceFolders": {
+            "items": {
+              "$ref": "#/components/schemas/ReferenceFolder"
+            },
+            "title": "Referencefolders",
+            "type": "array"
+          },
+          "useGpu": {
+            "default": false,
+            "title": "Usegpu",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "pluginType",
+          "referenceFolders"
+        ],
+        "title": "PluginInfo",
+        "type": "object"
+      },
+      "app__database__schemas__task__PluginInfo": {
+        "description": "Plugin information for task monitoring response.",
+        "properties": {
+          "plugin_type": {
+            "title": "Plugin Type",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "title": "PluginInfo",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordBearer": {
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "/routes/auth/login/access-token"
+          }
+        },
+        "type": "oauth2"
+      }
+    }
+  },
+  "info": {
+    "description": "Gene Regulatory Network reconstruction platform from scRNA-seq data",
+    "title": "CellCraft API",
+    "version": "1.0.7"
+  },
+  "openapi": "3.0.2",
+  "paths": {
+    "/routes/admin/container-manager/cleanup": {
+      "post": {
+        "description": "Container Manager stale 매핑 수동 정리\n\n실제로 존재하지 않는 Docker 컨테이너에 대한 매핑을 정리합니다.\n이 작업은 장시간 운영 후 메모리 누수 방지를 위해 주기적으로 수행할 수 있습니다.\n\nReturns:\n    - task_containers: 정리된 작업-컨테이너 매핑 수\n    - cleanup_set: 정리된 cleanup_in_progress 항목 수\n    - errors: 발생한 오류 목록 (있는 경우)",
+        "operationId": "cleanup_container_manager_routes_admin_container_manager_cleanup_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Cleanup Container Manager",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/container-manager/force-clear": {
+      "post": {
+        "description": "Container Manager 모든 매핑 강제 정리 (비상용)\n\nWARNING: 이 작업은 모든 매핑을 즉시 삭제합니다.\n실행 중인 작업의 추적이 불가능해질 수 있으므로,\n시스템 재시작 전이나 비상 상황에서만 사용하세요.\n\nReturns:\n    - cleared_tasks: 삭제된 작업-컨테이너 매핑 수\n    - cleared_cleanup_markers: 삭제된 cleanup 마커 수",
+        "operationId": "force_clear_container_manager_routes_admin_container_manager_force_clear_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Force Clear Container Manager",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/container-manager/status": {
+      "get": {
+        "description": "Container Manager 상태 조회\n\nReturns:\n    - tracked_tasks: 추적 중인 작업 수\n    - cleanup_in_progress_count: 정리 중인 컨테이너 수\n    - task_container_mapping: 작업-컨테이너 매핑\n    - container_task_mapping: 컨테이너-작업 매핑\n    - cleanup_in_progress: 정리 중인 컨테이너 ID 목록",
+        "operationId": "get_container_manager_status_routes_admin_container_manager_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Container Manager Status",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/files": {
+      "get": {
+        "operationId": "get_filtered_files_routes_admin_files_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "amount",
+            "required": true,
+            "schema": {
+              "title": "Amount",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_num",
+            "required": true,
+            "schema": {
+              "title": "Page Num",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "schema": {
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "title": "Order",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "searchTerm",
+            "required": true,
+            "schema": {
+              "title": "Searchterm",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Filtered Files Routes Admin Files Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Filtered Files",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/files/{file_id}": {
+      "delete": {
+        "operationId": "delete_file_routes_admin_files__file_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "title": "File Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete File",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/files_count": {
+      "get": {
+        "operationId": "get_files_count_routes_admin_files_count_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Files Count Routes Admin Files Count Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Files Count",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins": {
+      "get": {
+        "operationId": "get_filtered_plugins_routes_admin_plugins_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "amount",
+            "required": true,
+            "schema": {
+              "title": "Amount",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_num",
+            "required": true,
+            "schema": {
+              "title": "Page Num",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "schema": {
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "title": "Order",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "searchTerm",
+            "required": true,
+            "schema": {
+              "title": "Searchterm",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Filtered Plugins Routes Admin Plugins Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Filtered Plugins",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins/branch/{branch}": {
+      "post": {
+        "description": "Switch plugin repository branch and synchronize database",
+        "operationId": "switch_plugin_branch_routes_admin_plugins_branch__branch__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "branch",
+            "required": true,
+            "schema": {
+              "title": "Branch",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Switch Plugin Branch",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins/branches": {
+      "get": {
+        "description": "Get list of available plugin repository branches",
+        "operationId": "get_available_plugin_branches_routes_admin_plugins_branches_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Available Plugin Branches",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins/consistency": {
+      "get": {
+        "description": "Get plugin version consistency report",
+        "operationId": "get_plugin_consistency_report_routes_admin_plugins_consistency_get",
+        "parameters": [
+          {
+            "description": "Report format: json or text",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "description": "Report format: json or text",
+              "title": "Format",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Plugin Consistency Report",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins/consistency/quick": {
+      "get": {
+        "description": "Quick consistency check (returns boolean only)",
+        "operationId": "quick_consistency_check_routes_admin_plugins_consistency_quick_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Quick Consistency Check",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins/sync": {
+      "post": {
+        "description": "Manually trigger plugin synchronization from repository to database",
+        "operationId": "sync_plugins_from_repository_routes_admin_plugins_sync_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Sync Plugins From Repository",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins/sync/status": {
+      "get": {
+        "description": "Get current plugin synchronization status",
+        "operationId": "get_plugin_sync_status_routes_admin_plugins_sync_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Plugin Sync Status",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins/{plugin_id}/install-dependencies": {
+      "post": {
+        "operationId": "install_plugin_dependencies_routes_admin_plugins__plugin_id__install_dependencies_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_id",
+            "required": true,
+            "schema": {
+              "title": "Plugin Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Install Plugin Dependencies",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/plugins_count": {
+      "get": {
+        "operationId": "get_plugins_count_routes_admin_plugins_count_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Plugins Count Routes Admin Plugins Count Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Plugins Count",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/system/stats": {
+      "get": {
+        "operationId": "get_system_stats_routes_admin_system_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get System Stats Routes Admin System Stats Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get System Stats",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/tasks": {
+      "get": {
+        "operationId": "get_filtered_tasks_routes_admin_tasks_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "amount",
+            "required": true,
+            "schema": {
+              "title": "Amount",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_num",
+            "required": true,
+            "schema": {
+              "title": "Page Num",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "schema": {
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "title": "Order",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "searchTerm",
+            "required": true,
+            "schema": {
+              "title": "Searchterm",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Filtered Tasks Routes Admin Tasks Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Filtered Tasks",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/tasks/{task_id}/cancel": {
+      "post": {
+        "operationId": "cancel_task_routes_admin_tasks__task_id__cancel_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Cancel Task",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/tasks_count": {
+      "get": {
+        "operationId": "get_tasks_count_routes_admin_tasks_count_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Tasks Count Routes Admin Tasks Count Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tasks Count",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/users": {
+      "get": {
+        "operationId": "get_filtered_users_routes_admin_users_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "amount",
+            "required": true,
+            "schema": {
+              "title": "Amount",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_num",
+            "required": true,
+            "schema": {
+              "title": "Page Num",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "schema": {
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "title": "Order",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "searchTerm",
+            "required": true,
+            "schema": {
+              "title": "Searchterm",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Filtered Users Routes Admin Users Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Filtered Users",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/users/{user_id}": {
+      "delete": {
+        "operationId": "delete_user_routes_admin_users__user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete User",
+        "tags": [
+          "admin"
+        ]
+      },
+      "put": {
+        "operationId": "update_user_routes_admin_users__user_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "User Data",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Update User Routes Admin Users  User Id  Put"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update User",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/users_count": {
+      "get": {
+        "operationId": "get_users_count_routes_admin_users_count_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Users Count Routes Admin Users Count Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Users Count",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/workflows": {
+      "get": {
+        "operationId": "get_filtered_workflows_routes_admin_workflows_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "amount",
+            "required": true,
+            "schema": {
+              "title": "Amount",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_num",
+            "required": true,
+            "schema": {
+              "title": "Page Num",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "schema": {
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "title": "Order",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "searchTerm",
+            "required": true,
+            "schema": {
+              "title": "Searchterm",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Filtered Workflows Routes Admin Workflows Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Filtered Workflows",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/workflows/{workflow_id}": {
+      "delete": {
+        "operationId": "delete_workflow_routes_admin_workflows__workflow_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflow_id",
+            "required": true,
+            "schema": {
+              "title": "Workflow Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Workflow",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/admin/workflows_count": {
+      "get": {
+        "operationId": "get_workflows_count_routes_admin_workflows_count_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Workflows Count Routes Admin Workflows Count Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Workflows Count",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/routes/auth/login/access-token": {
+      "post": {
+        "operationId": "login_access_token_routes_auth_login_access_token_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_access_token_routes_auth_login_access_token_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Token"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Login Access Token",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/routes/auth/me": {
+      "get": {
+        "operationId": "read_user_me_routes_auth_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Read User Me",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/routes/auth/plugins": {
+      "post": {
+        "operationId": "update_user_plugins_routes_auth_plugins_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update User Plugins",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/routes/auth/register": {
+      "post": {
+        "operationId": "create_user_routes_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create User",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/routes/datatable/load_data": {
+      "post": {
+        "operationId": "load_data_routes_datatable_load_data_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DataTableEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Load Data",
+        "tags": [
+          "datatable"
+        ]
+      }
+    },
+    "/routes/files/check/{file_name}": {
+      "get": {
+        "operationId": "check_user_file_convert_routes_files_check__file_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_name",
+            "required": true,
+            "schema": {
+              "title": "File Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Check User File Convert Routes Files Check  File Name  Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Check User File Convert",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/clusters": {
+      "post": {
+        "operationId": "h5ad_cluster_routes_files_clusters_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileFind"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response H5Ad Cluster Routes Files Clusters Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "H5Ad Cluster",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/columns": {
+      "post": {
+        "operationId": "h5ad_columns_routes_files_columns_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileFind"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response H5Ad Columns Routes Files Columns Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "H5Ad Columns",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/convert": {
+      "post": {
+        "operationId": "user_file_convert_routes_files_convert_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileFind"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response User File Convert Routes Files Convert Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "User File Convert",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/data/{filename}": {
+      "get": {
+        "operationId": "download_data_file_routes_files_data__filename__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "title": "Filename",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "title": "Source",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Download Data File Routes Files Data  Filename  Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Download Data File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/delete": {
+      "post": {
+        "operationId": "delete_user_file_routes_files_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileDelete"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Delete User File Routes Files Delete Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete User File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/find": {
+      "post": {
+        "operationId": "find_user_file_routes_files_find_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileFind"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Find User File Routes Files Find Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Find User File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/folder": {
+      "post": {
+        "operationId": "find_user_folder_routes_files_folder_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FolderFind"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Find User Folder Routes Files Folder Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Find User Folder",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/html/{filename}": {
+      "get": {
+        "operationId": "read_html_file_routes_files_html__filename__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "title": "Filename",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Html File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/me": {
+      "get": {
+        "operationId": "read_user_folder_routes_files_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Read User Folder Routes Files Me Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Read User Folder",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/result": {
+      "post": {
+        "operationId": "read_result_file_routes_files_result_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileResultFind"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Read Result File Routes Files Result Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Read Result File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/result/{filename}": {
+      "get": {
+        "operationId": "download_result_file_routes_files_result__filename__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "title": "Filename",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Download Result File Routes Files Result  Filename  Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Download Result File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/setup/check": {
+      "get": {
+        "operationId": "algorithm_setup_check_routes_files_setup_check_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Algorithm Setup Check Routes Files Setup Check Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Algorithm Setup Check",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/setup/{file_name}": {
+      "get": {
+        "operationId": "read_user_file_routes_files_setup__file_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_name",
+            "required": true,
+            "schema": {
+              "title": "File Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Read User File Routes Files Setup  File Name  Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Read User File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/shared": {
+      "get": {
+        "description": "tutorials/ 디렉토리의 데이터 파일 목록 반환 (html 제외)",
+        "operationId": "get_shared_files_routes_files_shared_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Shared Files Routes Files Shared Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Shared Files",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/shared/find": {
+      "post": {
+        "description": "공용 파일 단건 조회 (InputFile.vue에서 사용)",
+        "operationId": "find_shared_file_routes_files_shared_find_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileFind"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Find Shared File Routes Files Shared Find Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Find Shared File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/tutorials/{filename}": {
+      "get": {
+        "operationId": "download_tutorial_file_routes_files_tutorials__filename__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "title": "Filename",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Download Tutorial File Routes Files Tutorials  Filename  Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Download Tutorial File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/update": {
+      "post": {
+        "operationId": "update_user_file_routes_files_update_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Update User File Routes Files Update Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update User File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/files/upload": {
+      "post": {
+        "operationId": "fileUpload_routes_files_upload_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_fileUpload_routes_files_upload_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Fileupload Routes Files Upload Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Fileupload",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/routes/plugin/associate": {
+      "post": {
+        "operationId": "associate_plugin_routes_plugin_associate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PluginAssociate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Associate Plugin",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/build/cancel/{task_id}": {
+      "post": {
+        "description": "실행 중인 플러그인 빌드 태스크를 취소합니다.",
+        "operationId": "cancel_build_task_routes_plugin_build_cancel__task_id__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Cancel Build Task",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/build/logs/{plugin_name}": {
+      "get": {
+        "description": "플러그인 빌드 로그를 조회합니다.",
+        "operationId": "get_build_logs_routes_plugin_build_logs__plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Build Logs",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/build/status/{task_id}": {
+      "get": {
+        "description": "플러그인 빌드 태스크의 상태를 조회합니다.",
+        "operationId": "get_build_status_routes_plugin_build_status__task_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Build Status",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/build/tasks": {
+      "get": {
+        "description": "플러그인 빌드 태스크 목록을 조회합니다.\nplugin_name이 제공되면 해당 플러그인의 태스크만 필터링합니다.",
+        "operationId": "get_build_tasks_routes_plugin_build_tasks_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plugin_name",
+            "required": false,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Build Tasks",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/build/{plugin_name}": {
+      "post": {
+        "description": "플러그인 Docker 이미지를 비동기적으로 빌드합니다.\nCelery task를 사용하여 백그라운드에서 처리됩니다.",
+        "operationId": "build_plugin_routes_plugin_build__plugin_name__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Build Plugin",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/build_docker/{plugin_name}": {
+      "post": {
+        "description": "플러그인의 Dockerfile 생성 및 Docker 이미지 빌드\n스크립트와 패키지 파일들이 모두 업로드된 후에 실행되어야 함",
+        "operationId": "build_plugin_docker_routes_plugin_build_docker__plugin_name__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BuildDockerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Build Plugin Docker",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/check_image/{plugin_name}": {
+      "get": {
+        "operationId": "check_plugin_image_routes_plugin_check_image__plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Check Plugin Image",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/dissociate": {
+      "post": {
+        "operationId": "dissociate_plugin_routes_plugin_dissociate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PluginAssociate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Dissociate Plugin",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/file/{plugin_name}/{file_name}": {
+      "get": {
+        "operationId": "get_plugin_file_routes_plugin_file__plugin_name___file_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "file_name",
+            "required": true,
+            "schema": {
+              "title": "File Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Plugin File",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/info/{plugin_name}": {
+      "get": {
+        "operationId": "get_plugin_info_routes_plugin_info__plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Plugin Info",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/list": {
+      "get": {
+        "operationId": "list_plugins_routes_plugin_list_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Plugins",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/package/{plugin_name}": {
+      "get": {
+        "operationId": "get_package_files_routes_plugin_package__plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Package Files",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/reference_folders/{plugin_name}": {
+      "get": {
+        "operationId": "get_reference_folders_routes_plugin_reference_folders__plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Reference Folders",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/template/{plugin_id}": {
+      "get": {
+        "operationId": "get_plugin_template_routes_plugin_template__plugin_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_id",
+            "required": true,
+            "schema": {
+              "title": "Plugin Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Plugin Template",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/update/{plugin_name}": {
+      "post": {
+        "description": "플러그인의 메타데이터를 물리적 파일에서 DB로 동기화하는 엔드포인트\n스크립트나 패키지 파일 업데이트 후 DB 정보를 최신화할 때 사용",
+        "operationId": "update_plugin_complete_routes_plugin_update__plugin_name__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Plugin Complete",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/upload": {
+      "post": {
+        "operationId": "upload_plugin_routes_plugin_upload_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PluginCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Plugin",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/upload_package": {
+      "post": {
+        "operationId": "upload_package_routes_plugin_upload_package_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_package_routes_plugin_upload_package_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Package",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/upload_scripts": {
+      "post": {
+        "operationId": "upload_scripts_routes_plugin_upload_scripts_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_scripts_routes_plugin_upload_scripts_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Scripts",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/upload_text_dependencies": {
+      "post": {
+        "description": "텍스트 의존성 파일들(requirements.txt, environment.yml, renv.lock)을 업로드하고 DB도 업데이트",
+        "operationId": "upload_text_dependencies_routes_plugin_upload_text_dependencies_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_text_dependencies_routes_plugin_upload_text_dependencies_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Text Dependencies",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/validation": {
+      "post": {
+        "operationId": "validate_plugin_routes_plugin_validation_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PluginData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Validate Plugin",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/version/{plugin_name}": {
+      "get": {
+        "description": "Get current version information for a plugin.",
+        "operationId": "get_plugin_current_version_routes_plugin_version__plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Plugin Current Version",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/versions/{plugin_name}": {
+      "get": {
+        "description": "Get available versions for an official plugin from GitHub Container Registry.",
+        "operationId": "get_plugin_versions_routes_plugin_versions__plugin_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Plugin Versions",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/plugin/versions/{plugin_name}/update": {
+      "post": {
+        "description": "Update the version of an official plugin.",
+        "operationId": "update_plugin_version_routes_plugin_versions__plugin_name__update_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plugin_name",
+            "required": true,
+            "schema": {
+              "title": "Plugin Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_update_plugin_version_routes_plugin_versions__plugin_name__update_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Plugin Version",
+        "tags": [
+          "plugin"
+        ]
+      }
+    },
+    "/routes/task/cache/clear": {
+      "delete": {
+        "description": "모든 DAG 파싱 캐시 초기화 (관리자 전용)",
+        "operationId": "clear_dag_caches_routes_task_cache_clear_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Clear Dag Caches Routes Task Cache Clear Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Clear Dag Caches",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/cache/stats": {
+      "get": {
+        "description": "DAG 파싱 캐시 통계 정보 조회 (관리자 전용)",
+        "operationId": "get_dag_cache_stats_routes_task_cache_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Dag Cache Stats Routes Task Cache Stats Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Dag Cache Stats",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/containers/status": {
+      "get": {
+        "description": "Get current container status for debugging",
+        "operationId": "get_container_status_routes_task_containers_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Container Status Routes Task Containers Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Container Status",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/delete/{task_id}": {
+      "delete": {
+        "description": "Delete the task",
+        "operationId": "delete_task_routes_task_delete__task_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Delete Task Routes Task Delete  Task Id  Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Task",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/info/{task_id}": {
+      "get": {
+        "description": "Return the status of the submitted Task.\nSSE 연결은 1시간 타임아웃 및 정리 로직이 적용됩니다.",
+        "operationId": "get_task_status_routes_task_info__task_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Task Status Routes Task Info  Task Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Task Status",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/logs/{task_id}": {
+      "get": {
+        "description": "특정 task의 로그 파일들을 조회합니다.",
+        "operationId": "get_task_logs_routes_task_logs__task_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Task Logs Routes Task Logs  Task Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Task Logs",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/logs/{task_id}/export/json": {
+      "get": {
+        "description": "특정 task의 모든 로그 파일들을 JSON 형식으로 export합니다.\nJSON 형태: {\"filename1.log\": \"content1\", \"filename2.log\": \"content2\"}",
+        "operationId": "export_task_logs_json_routes_task_logs__task_id__export_json_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Export Task Logs Json",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/logs/{task_id}/export/txt/{filename}": {
+      "get": {
+        "description": "특정 task의 개별 로그 파일을 TXT 형식으로 export합니다.",
+        "operationId": "export_task_log_txt_routes_task_logs__task_id__export_txt__filename__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "title": "Filename",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Export Task Log Txt",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/monitoring": {
+      "get": {
+        "description": "Return the status of all User Tasks with workflow information.\nExcludes plugin build tasks and returns only workflow-related tasks.\nUses optimized queries to prevent N+1 query problems.",
+        "operationId": "get_task_monitoring_routes_task_monitoring_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TaskMonitoringItem"
+                  },
+                  "title": "Response Get Task Monitoring Routes Task Monitoring Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Task Monitoring",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/resources": {
+      "get": {
+        "description": "리소스 할당 현황 및 실행 중 작업 목록 조회",
+        "operationId": "get_resources_routes_task_resources_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Resources",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/revoke/{task_id}": {
+      "delete": {
+        "description": "Revoke the task and cleanup associated containers",
+        "operationId": "revoke_task_routes_task_revoke__task_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Revoke Task Routes Task Revoke  Task Id  Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Revoke Task",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/status/{task_id}": {
+      "get": {
+        "description": "SSE 재연결 판단용 경량 상태 확인 엔드포인트.\nCelery AsyncResult 상태만 반환. 인증 불필요 (SSE 엔드포인트와 동일 패턴).",
+        "operationId": "get_task_status_simple_routes_task_status__task_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Task Status Simple Routes Task Status  Task Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Task Status Simple",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/{task_id}/dag-structure": {
+      "get": {
+        "description": "특정 Task의 Snakefile을 파싱하여 DAG 구조를 반환합니다.",
+        "operationId": "get_dag_structure_routes_task__task_id__dag_structure_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Dag Structure Routes Task  Task Id  Dag Structure Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Dag Structure",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/{task_id}/enhanced-progress": {
+      "get": {
+        "description": "특정 Task의 향상된 진행률 정보를 반환합니다.\n\n향상된 기능:\n- 타이밍 기반 분석\n- 예상 완료 시간\n- 병목 현상 감지\n- 정체 상황 감지\n- 상세 진행률 계산",
+        "operationId": "get_enhanced_progress_routes_task__task_id__enhanced_progress_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Enhanced Progress Routes Task  Task Id  Enhanced Progress Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Enhanced Progress",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/{task_id}/execution-manifest": {
+      "get": {
+        "description": "SUCCESS 상태이고 Analysis 타입 플러그인인 Task의 execution manifest를 JSON 형식으로 다운로드합니다.\n분석 재현을 위한 포괄적인 정보를 포함합니다.\n\n포함 정보:\n- Task, Plugin, Workflow 메타데이터\n- 모든 로그 파일 (run.log, *.stdout, *.stderr 등)\n- Snakefile 내용\n- Plugin metadata.json 내용\n- meta.yml 파일 내용 (있는 경우)",
+        "operationId": "get_execution_manifest_routes_task__task_id__execution_manifest_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Execution Manifest",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/{task_id}/rule-logs/{rule_name}": {
+      "get": {
+        "description": "특정 Rule의 로그 파일들(stdout, stderr)을 조회합니다.",
+        "operationId": "get_rule_logs_routes_task__task_id__rule_logs__rule_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rule_name",
+            "required": true,
+            "schema": {
+              "title": "Rule Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Rule Logs Routes Task  Task Id  Rule Logs  Rule Name  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Rule Logs",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/task/{task_id}/rule-status": {
+      "get": {
+        "description": "특정 Task의 각 Rule별 실행 상태를 로그 파일 기반으로 추적하여 반환합니다.",
+        "operationId": "get_rule_status_routes_task__task_id__rule_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "actual_status",
+            "required": false,
+            "schema": {
+              "title": "Actual Status",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Rule Status Routes Task  Task Id  Rule Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Rule Status",
+        "tags": [
+          "task"
+        ]
+      }
+    },
+    "/routes/version": {
+      "get": {
+        "description": "애플리케이션 버전 정보를 반환한다. 인증 불필요.",
+        "operationId": "get_version_routes_version_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Version",
+        "tags": [
+          "version"
+        ]
+      }
+    },
+    "/routes/workflow/compile": {
+      "post": {
+        "operationId": "compileWorkflow_routes_workflow_compile_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Compileworkflow",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/delete": {
+      "post": {
+        "operationId": "delete_user_workflow_routes_workflow_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowDelete"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Delete User Workflow Routes Workflow Delete Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete User Workflow",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/find": {
+      "post": {
+        "operationId": "find_user_workflow_routes_workflow_find_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowFind"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowCreate"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Find User Workflow",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/me": {
+      "get": {
+        "operationId": "get_user_workflow_routes_workflow_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get User Workflow Routes Workflow Me Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get User Workflow",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/node/delete": {
+      "post": {
+        "operationId": "deleteNodeData_routes_workflow_node_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowNodeFileDelete"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Deletenodedata",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/node/read": {
+      "post": {
+        "operationId": "readNodeData_routes_workflow_node_read_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowNodeFileRead"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Readnodedata",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/node/save": {
+      "post": {
+        "operationId": "saveNodeData_routes_workflow_node_save_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowNodeFileCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Savenodedata",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/result": {
+      "post": {
+        "operationId": "checkResult_routes_workflow_result_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowResult"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Checkresult",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/results": {
+      "post": {
+        "operationId": "getResults_routes_workflow_results_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowResult"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Getresults",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/save": {
+      "post": {
+        "operationId": "update_user_workflow_routes_workflow_save_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update User Workflow",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/visualization": {
+      "post": {
+        "description": "Create visualization from workflow data using the new self-contained visualization system.\n\nThis endpoint processes visualization requests using:\n- selectedVisualizationPlugin to get plugin information\n- selectedScript.name to identify the specific visualization rule\n- resolve_algorithm_path_from_files() for file resolution\n- generate_visualization_snakefile() for Snakefile generation\n\nRaises:\n    ValidationError: If required parameters are missing or invalid\n    WorkflowError: If workflow is not found or inaccessible\n    PluginNotFoundError: If specified plugin is not available\n    ScriptNotFoundError: If visualization script is not found\n    FileNotFoundError: If required files are missing\n    SnakefileGenerationError: If Snakefile generation fails\n    TaskSubmissionError: If task submission fails",
+        "operationId": "visualizeData_routes_workflow_visualization_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowVisualizationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Visualizedata",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/visualization/result": {
+      "post": {
+        "operationId": "checkVisualizationResult_routes_workflow_visualization_result_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowResult"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Checkvisualizationresult",
+        "tags": [
+          "workflow"
+        ]
+      }
+    },
+    "/routes/workflow/visualize/result": {
+      "post": {
+        "operationId": "getVisualizationResult_routes_workflow_visualize_result_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowResult"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Getvisualizationresult",
+        "tags": [
+          "workflow"
+        ]
+      }
+    }
+  }
+}

--- a/backend/tests/contract/test_openapi_contract.py
+++ b/backend/tests/contract/test_openapi_contract.py
@@ -1,0 +1,115 @@
+"""
+OpenAPI contract (snapshot) test.
+
+Freezes the API contract (paths, methods, request/response schemas) so that any
+refactoring PR that unintentionally changes the public API surface fails loudly.
+
+The snapshot itself (``openapi_snapshot.json``) is generated inside the test
+environment (which runs migrations on import) via::
+
+    python scripts/update_openapi_snapshot.py
+
+If the contract *intentionally* changes, regenerate the snapshot with that same
+command and describe the change in the PR body.
+
+Notes:
+- ``app.main`` runs ``run_migrations()`` at import time (main.py:84), so this
+  test relies on the conftest ``client`` fixture, which sets ``TESTING=1`` and
+  imports the app inside the configured test DB environment.
+- The diff summary intentionally avoids dumping the full schema; it lists only
+  the differing top-level keys and added/removed/changed paths.
+"""
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+SNAPSHOT = Path(__file__).parent / "openapi_snapshot.json"
+
+_MISSING_SNAPSHOT_MESSAGE = (
+    "OpenAPI snapshot not found at {path}.\n"
+    "Generate it inside the test environment (which applies migrations on import):\n"
+    "    cd backend && python scripts/update_openapi_snapshot.py\n"
+    "Then commit tests/contract/openapi_snapshot.json."
+).format(path=SNAPSHOT)
+
+
+def _summarize_diff(current: dict, expected: dict) -> str:
+    """Build a concise, human-readable summary of how two OpenAPI docs differ.
+
+    Deliberately does NOT dump the full schemas. Reports:
+    - top-level keys that were added / removed / changed
+    - path entries that were added / removed / changed (method-level)
+    - component schema names that were added / removed / changed
+    """
+    lines = []
+
+    cur_keys = set(current.keys())
+    exp_keys = set(expected.keys())
+    added_keys = sorted(cur_keys - exp_keys)
+    removed_keys = sorted(exp_keys - cur_keys)
+    changed_keys = sorted(
+        k for k in (cur_keys & exp_keys) if current[k] != expected[k]
+    )
+    if added_keys:
+        lines.append(f"  top-level keys added: {added_keys}")
+    if removed_keys:
+        lines.append(f"  top-level keys removed: {removed_keys}")
+    if changed_keys:
+        lines.append(f"  top-level keys changed: {changed_keys}")
+
+    cur_paths = current.get("paths", {})
+    exp_paths = expected.get("paths", {})
+    added_paths = sorted(set(cur_paths) - set(exp_paths))
+    removed_paths = sorted(set(exp_paths) - set(cur_paths))
+    changed_paths = sorted(
+        p for p in (set(cur_paths) & set(exp_paths)) if cur_paths[p] != exp_paths[p]
+    )
+    if added_paths:
+        lines.append(f"  paths added ({len(added_paths)}): {added_paths}")
+    if removed_paths:
+        lines.append(f"  paths removed ({len(removed_paths)}): {removed_paths}")
+    if changed_paths:
+        lines.append(f"  paths changed ({len(changed_paths)}): {changed_paths}")
+
+    cur_schemas = current.get("components", {}).get("schemas", {})
+    exp_schemas = expected.get("components", {}).get("schemas", {})
+    added_schemas = sorted(set(cur_schemas) - set(exp_schemas))
+    removed_schemas = sorted(set(exp_schemas) - set(cur_schemas))
+    changed_schemas = sorted(
+        s for s in (set(cur_schemas) & set(exp_schemas))
+        if cur_schemas[s] != exp_schemas[s]
+    )
+    if added_schemas:
+        lines.append(f"  component schemas added ({len(added_schemas)}): {added_schemas}")
+    if removed_schemas:
+        lines.append(f"  component schemas removed ({len(removed_schemas)}): {removed_schemas}")
+    if changed_schemas:
+        lines.append(f"  component schemas changed ({len(changed_schemas)}): {changed_schemas}")
+
+    if not lines:
+        # Difference exists but not captured by the coarse categories above.
+        lines.append("  (difference outside paths/components/top-level keys)")
+
+    return "\n".join(lines)
+
+
+@pytest.mark.contract
+def test_openapi_schema_unchanged(client: TestClient):
+    """The live OpenAPI document must match the committed snapshot exactly."""
+    if not SNAPSHOT.exists():
+        pytest.fail(_MISSING_SNAPSHOT_MESSAGE)
+
+    current = client.app.openapi()
+    expected = json.loads(SNAPSHOT.read_text())
+
+    if current != expected:
+        summary = _summarize_diff(current, expected)
+        pytest.fail(
+            "OpenAPI contract changed. If this change is intentional, regenerate "
+            "the snapshot and explain the change in the PR body:\n"
+            "    cd backend && python scripts/update_openapi_snapshot.py\n"
+            "Differences detected:\n"
+            f"{summary}"
+        )

--- a/backend/tests/integration/test_characterization_auth.py
+++ b/backend/tests/integration/test_characterization_auth.py
@@ -1,0 +1,111 @@
+"""
+Characterization tests for the auth login endpoint.
+
+Purpose: pin the CURRENT behavior of ``POST /routes/auth/login/access-token``
+exactly as it is today, so refactoring PRs (service extraction, etc.) can prove
+they did not change observable behavior. These tests describe reality, not the
+ideal — if something looks odd, it is preserved intentionally.
+
+Source of truth read while writing these tests:
+- app/routes/endpoints/auth.py :: login_access_token (lines 47-69)
+- app/routes/api.py mounts the auth router; app/main.py mounts api_router with
+  prefix settings.ROUTES_STR ("/routes"), and auth router is mounted at
+  "/auth" -> full prefix "/routes/auth".
+
+Pinned behavior:
+- Successful login returns 200 with keys: access_token, token_type ("bearer"),
+  and a nested user_info dict {is_superuser, email, is_active}.
+- Wrong password / unknown user -> 400 "Incorrect email or password".
+- Inactive user -> 400 "please login to activate".
+- OAuth2 form uses the 'username' field to carry the email.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import models
+from app.common.config import settings
+
+LOGIN_URL = f"{settings.ROUTES_STR}/auth/login/access-token"
+
+
+@pytest.mark.integration
+@pytest.mark.characterization
+@pytest.mark.auth
+class TestCharacterizationAuthLogin:
+    """Freeze the current token issuance response shape and error handling."""
+
+    def test_login_success_response_shape(
+        self,
+        client: TestClient,
+        sample_user: models.User,
+    ):
+        """Successful login returns the exact current token payload shape."""
+        response = client.post(
+            LOGIN_URL,
+            data={"username": sample_user.email, "password": "testpassword123"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Top-level keys are exactly these three (current contract).
+        assert set(data.keys()) == {"access_token", "token_type", "user_info"}
+        assert data["token_type"] == "bearer"
+        assert isinstance(data["access_token"], str) and data["access_token"]
+
+        # user_info is a nested dict with these three keys, in this shape.
+        user_info = data["user_info"]
+        assert set(user_info.keys()) == {"is_superuser", "email", "is_active"}
+        assert user_info["email"] == sample_user.email
+        assert user_info["is_active"] is True
+        assert user_info["is_superuser"] is False
+
+    def test_login_incorrect_password_returns_400(
+        self,
+        client: TestClient,
+        sample_user: models.User,
+    ):
+        """Wrong password yields 400 with the current fixed detail message."""
+        response = client.post(
+            LOGIN_URL,
+            data={"username": sample_user.email, "password": "wrongpassword"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Incorrect email or password"
+
+    def test_login_nonexistent_user_returns_400(
+        self,
+        client: TestClient,
+    ):
+        """Unknown user yields the same 400 message as a wrong password."""
+        response = client.post(
+            LOGIN_URL,
+            data={"username": "nobody@example.com", "password": "whatever"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Incorrect email or password"
+
+    def test_login_inactive_user_rejected(
+        self,
+        client: TestClient,
+        sample_inactive_user: models.User,
+    ):
+        """Inactive user (correct credentials) is rejected with 400 'activate'."""
+        response = client.post(
+            LOGIN_URL,
+            data={"username": sample_inactive_user.email, "password": "testpassword123"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "please login to activate"
+
+    def test_login_missing_form_fields_returns_422(
+        self,
+        client: TestClient,
+    ):
+        """Missing OAuth2 form fields fail FastAPI validation with 422."""
+        # No form body at all -> OAuth2PasswordRequestForm required fields missing.
+        response = client.post(LOGIN_URL)
+        assert response.status_code == 422

--- a/backend/tests/integration/test_characterization_file_upload.py
+++ b/backend/tests/integration/test_characterization_file_upload.py
@@ -1,0 +1,217 @@
+"""
+Characterization tests for the file upload + download-security surface.
+
+Purpose: pin the CURRENT behavior of the files endpoints so the later service +
+storage/security extraction refactor (PR-8) can prove behavior is unchanged.
+
+Endpoints covered (app/routes/endpoints/files.py):
+- POST /routes/files/upload           (fileUpload; lines 25-132)
+- GET  /routes/files/result/{filename} (download_result_file; lines 538-555)
+    -> exercises file_security.validate_file_path path-traversal rejection (403)
+
+Source of truth read while writing these tests:
+- app/routes/endpoints/files.py :: fileUpload, download_result_file
+- app/common/utils/file_security.py :: validate_file_upload, validate_file_path
+- app/common/config.py :: ALLOWED_EXTENSIONS ({.h5ad,.csv,.json,.txt}),
+  MAX_FILES_PER_UPLOAD (20)
+
+Pinned behavior:
+- Successful single upload returns the created File record (raw model fields:
+  id, file_name, file_size, file_path, folder, user_id) and a DB row exists.
+  Filename format "folder_actualname.ext" is split on the FIRST underscore.
+- Disallowed extension -> 400 "Invalid file type".
+- Empty file -> 400 "Empty file not allowed".
+- Duplicate filename (already in DB) -> 400 "already exists".
+- Path traversal on /result/{filename} -> 403 "Path traversal attempt detected".
+"""
+import os
+import shutil
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.database import models
+from app.database.crud import crud_file
+from app.common.config import settings
+
+UPLOAD_URL = f"{settings.ROUTES_STR}/files/upload"
+RESULT_URL = f"{settings.ROUTES_STR}/files/result"
+
+
+@pytest.mark.integration
+@pytest.mark.characterization
+class TestCharacterizationFileUpload:
+    """Freeze current upload success/reject behavior and DB persistence."""
+
+    def test_upload_single_file_success_record_and_db(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        upload_file_factory,
+        temp_user_file_directory: dict,
+        sample_user: models.User,
+        db_session: Session,
+    ):
+        """A valid .h5ad upload returns the raw File record and persists a DB row."""
+        upload_file = upload_file_factory(
+            filename="charfolder_char_data.h5ad",
+            content=b"mock_h5ad_content" * 50,
+        )
+
+        try:
+            response = client.post(
+                UPLOAD_URL,
+                headers=auth_headers,
+                files={"files": (
+                    upload_file.filename,
+                    upload_file.file,
+                    upload_file.content_type,
+                )},
+            )
+
+            assert response.status_code == 200, response.text
+            data = response.json()
+
+            # Endpoint returns the raw SQLAlchemy File object for a single upload.
+            # Filename splits on the FIRST underscore: folder="charfolder",
+            # file_name="char_data.h5ad".
+            assert data["file_name"] == "char_data.h5ad"
+            assert data["folder"] == "charfolder"
+            assert data["user_id"] == sample_user.id
+            assert "id" in data and "file_size" in data and "file_path" in data
+
+            # DB row created.
+            db_file = crud_file.get_user_file(db_session, sample_user.id, "char_data.h5ad")
+            assert db_file is not None
+            assert db_file.folder == "charfolder"
+        finally:
+            # The endpoint writes to the real relative path ./user/{username}/data.
+            user_dir = f"./user/{sample_user.username}"
+            if os.path.exists(user_dir):
+                shutil.rmtree(user_dir, ignore_errors=True)
+
+    def test_upload_disallowed_extension_rejected_400(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        upload_file_factory,
+    ):
+        """A .sh file is rejected by the extension whitelist with 400."""
+        upload_file = upload_file_factory(
+            filename="charfolder_evil.sh",
+            content=b"#!/bin/sh\necho hi\n" * 5,
+            content_type="application/x-sh",
+        )
+
+        response = client.post(
+            UPLOAD_URL,
+            headers=auth_headers,
+            files={"files": (
+                upload_file.filename,
+                upload_file.file,
+                upload_file.content_type,
+            )},
+        )
+
+        assert response.status_code == 400
+        assert "invalid file type" in response.json()["detail"].lower()
+
+    def test_upload_empty_file_rejected_400(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        upload_file_factory,
+    ):
+        """A zero-byte file is rejected with 400 'Empty file not allowed'."""
+        upload_file = upload_file_factory(
+            filename="charfolder_empty.h5ad",
+            content=b"",
+        )
+
+        response = client.post(
+            UPLOAD_URL,
+            headers=auth_headers,
+            files={"files": (
+                upload_file.filename,
+                upload_file.file,
+                upload_file.content_type,
+            )},
+        )
+
+        assert response.status_code == 400
+        assert "empty file" in response.json()["detail"].lower()
+
+    def test_upload_duplicate_filename_rejected_400(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        upload_file_factory,
+        sample_file_metadata: models.File,
+    ):
+        """Uploading a filename already present in the DB is rejected with 400."""
+        # sample_file_metadata.file_name is "test_data.h5ad"; prefix a folder so the
+        # split yields the same actual filename.
+        upload_file = upload_file_factory(
+            filename=f"charfolder_{sample_file_metadata.file_name}",
+            content=b"new_content" * 50,
+        )
+
+        response = client.post(
+            UPLOAD_URL,
+            headers=auth_headers,
+            files={"files": (
+                upload_file.filename,
+                upload_file.file,
+                upload_file.content_type,
+            )},
+        )
+
+        assert response.status_code == 400
+        assert "already exists" in response.json()["detail"]
+
+    def test_upload_requires_authentication(
+        self,
+        client: TestClient,
+        upload_file_factory,
+    ):
+        """Upload without auth headers is rejected with 401."""
+        upload_file = upload_file_factory(
+            filename="charfolder_x.h5ad",
+            content=b"data" * 10,
+        )
+        response = client.post(
+            UPLOAD_URL,
+            files={"files": (
+                upload_file.filename,
+                upload_file.file,
+                upload_file.content_type,
+            )},
+        )
+        assert response.status_code == 401
+
+
+@pytest.mark.integration
+@pytest.mark.characterization
+class TestCharacterizationFileSecurityRejection:
+    """Freeze file_security path-traversal rejection on the result download route."""
+
+    def test_download_result_path_traversal_returns_404(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+    ):
+        """URL-encoded path traversal on /result returns 404 today.
+
+        ANOMALY (pinned): Starlette normalises the URL-encoded ``%2E%2E%2F``
+        segments before the path parameter is matched, so the traversal string
+        never reaches ``validate_file_path``. The router returns 404 (no route
+        match) instead of the intended 403. The security check is therefore
+        unreachable via URL-encoded traversal at this endpoint today.
+        """
+        response = client.get(
+            f"{RESULT_URL}/%2E%2E%2F%2E%2E%2Fetc%2Fpasswd",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404

--- a/backend/tests/integration/test_characterization_plugin_upload.py
+++ b/backend/tests/integration/test_characterization_plugin_upload.py
@@ -1,0 +1,221 @@
+"""
+Characterization tests for the plugin upload endpoint.
+
+Purpose: pin the CURRENT behavior of ``POST /routes/plugin/upload`` exactly as it
+is today (upload_plugin, app/routes/endpoints/plugin.py lines 130-288). These
+tests describe reality so a later service-extraction refactor (PR-5) can prove it
+did not change observable behavior.
+
+The endpoint has heavy side effects (filesystem writes under ./plugin/local,
+metadata + Snakefile generation) followed by DB write + commit + rollback. To
+pin the HTTP/DB contract without touching the real filesystem, the
+``plugin_utils`` helpers and the cache invalidation call are mocked
+(consistent with the existing mocking style in test_plugin_api.py).
+
+Source of truth read while writing these tests:
+- app/routes/endpoints/plugin.py :: upload_plugin
+- app/database/schemas/plugin.py :: PluginCreate (flat schema this endpoint uses)
+
+Pinned behavior:
+- New local plugin: 200 with
+  {message: "플러그인 메타데이터 업로드 성공", plugin: {...}, success: True,
+   redirect_to: "plugin_list"} and a DB row created.
+- Uploading over an existing OFFICIAL plugin name: 403 (read-only official).
+- DB failure during create is rolled back (no row persists) and yields 500.
+- Invalid request body (missing required PluginCreate fields): 422.
+"""
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.database import models
+from app.common.config import settings
+from app.common.enums import PluginType
+
+UPLOAD_URL = f"{settings.ROUTES_STR}/plugin/upload"
+
+
+def _valid_plugin_create_payload(name: str = "CharPlugin") -> dict:
+    """A body matching the flat PluginCreate schema the /upload endpoint expects."""
+    return {
+        "name": name,
+        "description": "Characterization plugin",
+        "author": "char_author",
+        "plugin_path": f"./plugin/local/{name}/",
+        "plugin_type": "analysis",
+        "dependencies": {"requirements.txt": "numpy==1.24.0"},
+        "reference_folders": None,
+        "drawflow": {"drawflow": {"Home": {"data": {}}}},
+        "rules": {"0": {"name": "r", "script": "s.py"}},
+        "use_gpu": False,
+        "source": "local",
+        "is_editable": True,
+        "version": "1.0.0",
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.characterization
+class TestCharacterizationPluginUpload:
+    """Freeze current upload_plugin behavior (success, official reject, rollback)."""
+
+    @patch("app.routes.endpoints.plugin.invalidate_all_plugin_cache")
+    @patch("app.routes.endpoints.plugin.plugin_utils.generate_snakemake_code")
+    @patch("app.routes.endpoints.plugin.plugin_utils.create_metadata_file")
+    @patch("app.routes.endpoints.plugin.plugin_utils.create_dependency_folder")
+    @patch("app.routes.endpoints.plugin.plugin_utils.create_plugin_folder")
+    @patch("app.routes.endpoints.plugin.ensure_local_plugins_dir")
+    @patch("app.routes.endpoints.plugin.get_plugin_path")
+    @patch("app.routes.endpoints.plugin.os.path.exists", return_value=False)
+    @patch("app.routes.endpoints.plugin.os.makedirs")
+    def test_upload_new_plugin_success_response_and_db(
+        self,
+        _mock_makedirs,
+        _mock_exists,
+        mock_get_plugin_path,
+        _mock_ensure_dir,
+        _mock_create_folder,
+        _mock_create_dep,
+        _mock_create_meta,
+        _mock_gen_snake,
+        _mock_invalidate,
+        client: TestClient,
+        auth_headers: dict,
+        db_session: Session,
+    ):
+        """A brand-new local plugin uploads successfully with the current shape."""
+        # Plugin does not exist yet -> get_plugin_path raises (endpoint treats as new).
+        from fastapi import HTTPException
+        mock_get_plugin_path.side_effect = HTTPException(status_code=404, detail="not found")
+
+        payload = _valid_plugin_create_payload(name="CharNewPlugin")
+        response = client.post(UPLOAD_URL, json=payload, headers=auth_headers)
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["message"] == "플러그인 메타데이터 업로드 성공"
+        assert data["success"] is True
+        assert data["redirect_to"] == "plugin_list"
+        # FastAPI 0.78 serializes the SQLAlchemy Plugin model via jsonable_encoder
+        # which yields an empty dict {} (no Pydantic schema on this endpoint).
+        # Pin the actual observed shape: plugin field is present and is a dict.
+        assert isinstance(data["plugin"], dict)
+
+        # DB row was created and committed.
+        db_plugin = (
+            db_session.query(models.Plugin)
+            .filter(models.Plugin.name == "CharNewPlugin")
+            .first()
+        )
+        assert db_plugin is not None
+        assert db_plugin.source == "local"
+        assert db_plugin.plugin_type == PluginType.ANALYSIS
+
+    def test_upload_over_official_plugin_bypasses_guard_and_returns_500(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        db_session: Session,
+    ):
+        """Uploading a plugin whose name matches an official plugin returns 500 today.
+
+        ANOMALY: The intended 403 guard raises HTTPException inside a bare
+        ``except HTTPException: pass`` block, so the guard is silently bypassed
+        and the upload proceeds until it fails at Snakemake code generation (500).
+        This test pins the *actual* current behavior, not the intended behavior.
+        """
+        # Seed an official (read-only) plugin so get_plugin_path resolves to official.
+        official = models.Plugin(
+            name="OfficialCharPlugin",
+            description="official",
+            author="official",
+            plugin_path="./plugin/official/OfficialCharPlugin/",
+            plugin_type=PluginType.ANALYSIS,
+            dependencies={},
+            drawflow={},
+            rules={},
+            source="official",
+            is_editable=False,
+            version="1.0.0",
+        )
+        db_session.add(official)
+        db_session.commit()
+
+        payload = _valid_plugin_create_payload(name="OfficialCharPlugin")
+        response = client.post(UPLOAD_URL, json=payload, headers=auth_headers)
+
+        # ANOMALY (pinned): The 403 guard at lines 147-153 of upload_plugin raises
+        # HTTPException(403) when get_plugin_path returns "official", but it is
+        # immediately caught by ``except HTTPException: pass`` on line 152-153, so
+        # the upload proceeds and eventually fails at generate_snakemake_code (500).
+        # The official-plugin protection is therefore silently bypassed today.
+        assert response.status_code == 500
+
+    @patch("app.routes.endpoints.plugin.invalidate_all_plugin_cache")
+    @patch("app.routes.endpoints.plugin.crud_plugin.create_plugin")
+    @patch("app.routes.endpoints.plugin.plugin_utils.generate_snakemake_code")
+    @patch("app.routes.endpoints.plugin.plugin_utils.create_metadata_file")
+    @patch("app.routes.endpoints.plugin.plugin_utils.create_dependency_folder")
+    @patch("app.routes.endpoints.plugin.plugin_utils.create_plugin_folder")
+    @patch("app.routes.endpoints.plugin.ensure_local_plugins_dir")
+    @patch("app.routes.endpoints.plugin.get_plugin_path")
+    @patch("app.routes.endpoints.plugin.os.path.exists", return_value=False)
+    @patch("app.routes.endpoints.plugin.os.makedirs")
+    def test_upload_db_failure_rolls_back_and_returns_500(
+        self,
+        _mock_makedirs,
+        _mock_exists,
+        mock_get_plugin_path,
+        _mock_ensure_dir,
+        _mock_create_folder,
+        _mock_create_dep,
+        _mock_create_meta,
+        _mock_gen_snake,
+        mock_create_plugin,
+        _mock_invalidate,
+        client: TestClient,
+        auth_headers: dict,
+        db_session: Session,
+    ):
+        """A DB error during create triggers rollback (no row) and a 500 response."""
+        from fastapi import HTTPException
+        mock_get_plugin_path.side_effect = HTTPException(status_code=404, detail="not found")
+        mock_create_plugin.side_effect = Exception("DB write boom")
+
+        payload = _valid_plugin_create_payload(name="RollbackCharPlugin")
+        response = client.post(UPLOAD_URL, json=payload, headers=auth_headers)
+
+        assert response.status_code == 500
+
+        # Rollback means nothing persisted for this plugin name.
+        db_session.expire_all()
+        db_plugin = (
+            db_session.query(models.Plugin)
+            .filter(models.Plugin.name == "RollbackCharPlugin")
+            .first()
+        )
+        assert db_plugin is None
+
+    def test_upload_invalid_body_returns_422(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+    ):
+        """Missing required PluginCreate fields fails Pydantic validation (422)."""
+        # PluginData-style nested body is NOT what /upload expects (it wants flat
+        # PluginCreate). Missing name/author/plugin_path -> validation error.
+        response = client.post(
+            UPLOAD_URL,
+            json={"description": "no required fields"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
+
+    def test_upload_requires_authentication(
+        self,
+        client: TestClient,
+    ):
+        """Without auth headers the endpoint rejects with 401."""
+        response = client.post(UPLOAD_URL, json=_valid_plugin_create_payload())
+        assert response.status_code == 401

--- a/backend/tests/integration/test_characterization_task_status.py
+++ b/backend/tests/integration/test_characterization_task_status.py
@@ -1,0 +1,181 @@
+"""
+Characterization tests for task status / monitoring endpoints.
+
+Purpose: pin the CURRENT behavior of the task status surface so the later
+service + SSE extraction refactor (PR-7) can prove behavior is unchanged.
+
+Endpoints covered (app/routes/endpoints/task.py):
+- GET  /routes/task/status/{task_id}   (lightweight, non-SSE; lines 82-95)
+- GET  /routes/task/monitoring         (list; lines 97-159)
+- DELETE /routes/task/delete/{task_id} (lines 276-287)
+- GET  /routes/task/info/{task_id}     (SSE stream; lines 41-80) — one case only
+
+External deps (Celery ``get_task_info``) are mocked, consistent with the
+existing task_api.py mocking style.
+
+Pinned behavior:
+- /status returns {"task_id": <id>, "status": <celery status>}; empty task_id
+  in the path resolves to a different route (404) rather than the 400 branch.
+- /monitoring returns [] (200) when the user has no tasks; otherwise a list with
+  the current item shape and plugin_build tasks filtered out.
+- /delete returns {"message": "Task Deleted", "task_id": <id>} even for an id
+  that does not belong to the user (current lenient behavior).
+- /info is an SSE endpoint: content-type text/event-stream and no auth required.
+"""
+import uuid
+from datetime import datetime
+
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.database import models
+from app.common.config import settings
+
+TASK_PREFIX = f"{settings.ROUTES_STR}/task"
+
+
+@pytest.mark.integration
+@pytest.mark.characterization
+class TestCharacterizationTaskStatus:
+    """Freeze non-SSE task status endpoints; minimal SSE smoke."""
+
+    @patch("app.routes.endpoints.task.get_task_info")
+    def test_status_simple_response_shape(
+        self,
+        mock_get_task_info,
+        client: TestClient,
+    ):
+        """/status returns {task_id, status} using the celery task_status value."""
+        mock_get_task_info.return_value = {"task_status": "SUCCESS"}
+
+        response = client.get(f"{TASK_PREFIX}/status/some-task-123")
+
+        assert response.status_code == 200
+        assert response.json() == {"task_id": "some-task-123", "status": "SUCCESS"}
+
+    @patch("app.routes.endpoints.task.get_task_info")
+    def test_status_missing_status_defaults_to_unknown(
+        self,
+        mock_get_task_info,
+        client: TestClient,
+    ):
+        """When celery returns no task_status key, status defaults to UNKNOWN."""
+        mock_get_task_info.return_value = {}
+
+        response = client.get(f"{TASK_PREFIX}/status/no-status-task")
+
+        assert response.status_code == 200
+        assert response.json() == {"task_id": "no-status-task", "status": "UNKNOWN"}
+
+    def test_monitoring_empty_returns_200_empty_list(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+    ):
+        """With no tasks, /monitoring returns an empty list and 200 (not 404)."""
+        response = client.get(f"{TASK_PREFIX}/monitoring", headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_monitoring_filters_plugin_build_and_shapes_items(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        multiple_user_tasks: list,
+    ):
+        """/monitoring excludes plugin_build tasks and pins the item key set."""
+        response = client.get(f"{TASK_PREFIX}/monitoring", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # multiple_user_tasks fixture creates compile + visualization + plugin_build.
+        # plugin_build must be filtered out -> 2 remain.
+        assert len(data) == 2
+        task_types = {t["task_type"] for t in data}
+        assert "plugin_build" not in task_types
+        assert task_types == {"compile", "visualization"}
+
+        # Pin the item key set (TaskMonitoringItem serialization).
+        for item in data:
+            for key in (
+                "id",
+                "task_id",
+                "workflow_id",
+                "user_id",
+                "status",
+                "start_time",
+                "task_type",
+                "plugin_name",
+                "plugin",
+            ):
+                assert key in item, f"missing key {key} in monitoring item"
+
+    def test_monitoring_requires_authentication(
+        self,
+        client: TestClient,
+    ):
+        """/monitoring requires auth -> 401 without a token."""
+        response = client.get(f"{TASK_PREFIX}/monitoring")
+        assert response.status_code == 401
+
+    def test_delete_task_returns_fixed_message(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        sample_task: models.Task,
+    ):
+        """/delete returns the current fixed message payload for an owned task."""
+        response = client.delete(
+            f"{TASK_PREFIX}/delete/{sample_task.task_id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "message": "Task Deleted",
+            "task_id": sample_task.task_id,
+        }
+
+    def test_delete_unknown_task_returns_404(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+    ):
+        """Deleting a non-existent task id returns 404 today.
+
+        crud_task.delete_user_task raises HTTPException(404) when the task is
+        not found (crud_task.py line 92-94), which propagates to the caller.
+        """
+        response = client.delete(
+            f"{TASK_PREFIX}/delete/does-not-exist-{uuid.uuid4().hex[:8]}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+    # NOTE: task.py binds get_task_info at import time
+    # (`from ...celery_utils import get_task_info`), so the patch must target
+    # the endpoint module namespace — patching celery_utils has no effect and
+    # the SSE loop would poll the real backend forever.
+    @patch("app.routes.endpoints.task.get_task_info")
+    def test_info_sse_stream_content_type(
+        self,
+        mock_get_task_info,
+        client: TestClient,
+    ):
+        """/info/{task_id} is an SSE stream (text/event-stream) and needs no auth.
+
+        Only the transport/content-type contract is pinned here; detailed event
+        framing is deferred to E2E (async SSE cannot be fully exercised via the
+        sync TestClient).
+        """
+        mock_get_task_info.return_value = {"task_status": "SUCCESS"}
+
+        response = client.get(f"{TASK_PREFIX}/info/sse-char-task")
+
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers.get("content-type", "")

--- a/backend/tests/integration/test_characterization_workflow_compile.py
+++ b/backend/tests/integration/test_characterization_workflow_compile.py
@@ -1,0 +1,229 @@
+"""
+Characterization tests for the workflow compile endpoint.
+
+Purpose: pin the CURRENT behavior of ``POST /routes/workflow/compile``
+(compileWorkflow, app/routes/endpoints/workflow.py lines 47-185) so the later
+service-extraction refactor (PR-6) can prove behavior is unchanged.
+
+IMPORTANT current-behavior note (preserved intentionally, do NOT "fix"):
+The entire endpoint body is wrapped in a single ``try/except Exception`` that
+re-raises as ``HTTPException(status_code=400, detail=str(e))`` (lines 181-185).
+There is NO ``except HTTPException`` guard before it, so inner HTTPExceptions
+(including the 404 "plugin not found" and the 400 "No algorithm nodes") are
+caught by the outer handler and surfaced as HTTP 400. These tests pin that
+observable 400 behavior rather than the status code named at the inner ``raise``.
+
+Source of truth read while writing these tests:
+- app/routes/endpoints/workflow.py :: compileWorkflow
+- app/database/schemas/workflow.py :: WorkflowCreate
+
+Pinned behavior:
+- Success returns 200 with keys: message, task_ids, algorithm_ids,
+  task_algorithm_mapping, results.
+- A workflow with no algorithm nodes -> 400.
+- A missing/unknown workflow id -> the ``if user_workflow:`` branch is skipped,
+  so the function returns None -> FastAPI serializes 200 null (pinned below).
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.database import models
+from app.common.config import settings
+
+COMPILE_URL = f"{settings.ROUTES_STR}/workflow/compile"
+
+
+def _algorithm_workflow_info(plugin_name: str = "TestPlugin") -> dict:
+    # extract_all_algorithms checks value.get("class") == "Algorithm" (capital A)
+    # and reads selectedPlugin from value.get("data", {}) — not from value directly.
+    return {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "algorithm",
+                        "class": "Algorithm",
+                        "data": {
+                            "selectedPlugin": {"name": plugin_name, "source": "local"},
+                            "selectedPluginInputOutput": {},
+                            "selectedPluginRules": {},
+                            "files": [],
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.characterization
+class TestCharacterizationWorkflowCompile:
+    """Freeze current compile behavior: success shape + error wrapping to 400."""
+
+    @patch("app.routes.endpoints.workflow.process_data_task.apply_async")
+    @patch("app.routes.endpoints.workflow.change_snakefile_parameter")
+    @patch("app.routes.endpoints.workflow.get_plugin_path")
+    @patch("app.routes.endpoints.workflow.get_task_info")
+    def test_compile_success_response_shape(
+        self,
+        mock_get_task_info,
+        mock_get_plugin_path,
+        mock_change_snakefile,
+        mock_apply_async,
+        client: TestClient,
+        auth_headers: dict,
+        sample_user: models.User,
+        db_session: Session,
+    ):
+        """A single-algorithm workflow compiles and returns the current response keys."""
+        workflow_info = _algorithm_workflow_info()
+        workflow = models.Workflow(
+            title="Char Compile Workflow",
+            workflow_info=workflow_info,
+            user_id=sample_user.id,
+        )
+        db_session.add(workflow)
+        db_session.commit()
+        db_session.refresh(workflow)
+
+        mock_get_plugin_path.return_value = ("./plugin/local/TestPlugin", "local")
+        mock_change_snakefile.return_value = "/tmp/char_snakefile"
+        mock_task = MagicMock()
+        mock_task.id = "char-task-id-1"
+        mock_apply_async.return_value = mock_task
+        mock_get_task_info.return_value = {"task_status": "PENDING"}
+
+        payload = {
+            "id": workflow.id,
+            "title": workflow.title,
+            "thumbnail": None,
+            "workflow_info": workflow_info,
+        }
+        response = client.post(COMPILE_URL, json=payload, headers=auth_headers)
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        # Current top-level keys (pinned exactly).
+        assert set(data.keys()) == {
+            "message",
+            "task_ids",
+            "algorithm_ids",
+            "task_algorithm_mapping",
+            "results",
+        }
+        assert data["message"] == "Multiple tasks added to queue"
+        assert data["task_ids"] == ["char-task-id-1"]
+        assert data["algorithm_ids"] == [1]
+        assert data["task_algorithm_mapping"] == {"char-task-id-1": 1}
+
+    def test_compile_no_algorithm_nodes_returns_400(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        sample_user: models.User,
+        db_session: Session,
+    ):
+        """A workflow with no algorithm nodes surfaces as HTTP 400 (outer wrapper)."""
+        workflow_info = {
+            "drawflow": {"Home": {"data": {"1": {"id": 1, "name": "data", "class": "data"}}}}
+        }
+        workflow = models.Workflow(
+            title="Char No-Algorithm Workflow",
+            workflow_info=workflow_info,
+            user_id=sample_user.id,
+        )
+        db_session.add(workflow)
+        db_session.commit()
+        db_session.refresh(workflow)
+
+        payload = {
+            "id": workflow.id,
+            "title": workflow.title,
+            "thumbnail": None,
+            "workflow_info": workflow_info,
+        }
+        response = client.post(COMPILE_URL, json=payload, headers=auth_headers)
+
+        # The inner HTTPException(400, "No algorithm nodes found...") is caught by
+        # the outer ``except Exception`` wrapper, which calls str(e) on the
+        # HTTPException object. str(HTTPException) yields an empty string in
+        # Starlette/FastAPI 0.78, so detail is "". Pin the actual observed shape.
+        assert response.status_code == 400
+        assert response.json()["detail"] == ""
+
+    @patch("app.routes.endpoints.workflow.get_plugin_path")
+    def test_compile_plugin_not_found_surfaces_as_400(
+        self,
+        mock_get_plugin_path,
+        client: TestClient,
+        auth_headers: dict,
+        sample_user: models.User,
+        db_session: Session,
+    ):
+        """Plugin resolution failure surfaces as HTTP 400 via the outer wrapper.
+
+        The inner code raises HTTPException(404,...), but there is no
+        ``except HTTPException`` guard, so the outer ``except Exception`` catches
+        it and re-raises as 400. This is the CURRENT behavior being pinned.
+        """
+        workflow_info = _algorithm_workflow_info(plugin_name="NoSuchPlugin")
+        workflow = models.Workflow(
+            title="Char Bad-Plugin Workflow",
+            workflow_info=workflow_info,
+            user_id=sample_user.id,
+        )
+        db_session.add(workflow)
+        db_session.commit()
+        db_session.refresh(workflow)
+
+        mock_get_plugin_path.side_effect = Exception("plugin missing")
+
+        payload = {
+            "id": workflow.id,
+            "title": workflow.title,
+            "thumbnail": None,
+            "workflow_info": workflow_info,
+        }
+        response = client.post(COMPILE_URL, json=payload, headers=auth_headers)
+
+        assert response.status_code == 400
+        assert "detail" in response.json()
+
+    def test_compile_unknown_workflow_returns_200_null(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+    ):
+        """When the workflow id is not owned/found, the ``if user_workflow`` branch
+        is skipped and the function returns None -> FastAPI serializes 200 null.
+
+        This pins a quirky-but-real current behavior (no explicit 404/400).
+        """
+        payload = {
+            "id": 999999,
+            "title": "ghost",
+            "thumbnail": None,
+            "workflow_info": {"drawflow": {"Home": {"data": {}}}},
+        }
+        response = client.post(COMPILE_URL, json=payload, headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.json() is None
+
+    def test_compile_requires_authentication(
+        self,
+        client: TestClient,
+    ):
+        """Without auth headers the endpoint rejects with 401."""
+        payload = {
+            "id": 1,
+            "title": "x",
+            "thumbnail": None,
+            "workflow_info": {"drawflow": {"Home": {"data": {}}}},
+        }
+        response = client.post(COMPILE_URL, json=payload)
+        assert response.status_code == 401

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,74 @@
+version: "3.8"
+
+# Test-only compose override for running the backend test suite in an isolated
+# environment. It does NOT depend on or interfere with the app-network stack in
+# docker-compose.dev.yml — it defines its own network and its own database.
+#
+# Usage (see backend/tests/contract/README.md for details):
+#   1. Build the backend test image:
+#        docker build -f backend/Dockerfile.dev -t cellcraft-backend:refactor-test ./backend
+#   2. Bring up the stack:
+#        docker compose -f docker-compose.test.yml up -d
+#   3. Exec pytest inside the backend-test container:
+#        docker compose -f docker-compose.test.yml exec backend-test pytest
+#   4. Tear down:
+#        docker compose -f docker-compose.test.yml down
+#
+# TEST_DB_PORT can be overridden if host port 5433 is already taken:
+#   TEST_DB_PORT=5544 docker compose -f docker-compose.test.yml up -d
+
+services:
+  test-db:
+    image: postgres:15
+    environment:
+      - TZ=Asia/Seoul
+      - POSTGRES_DB=cellcraft_test
+      - POSTGRES_USER=test_user
+      - POSTGRES_PASSWORD=test_pass
+    ports:
+      # Host port defaults to 5433 but is overridable for environments where
+      # 5433 is already occupied by another project.
+      - "${TEST_DB_PORT:-5433}:5432"
+    networks:
+      - test-network
+    # Ephemeral: no volumes, no restart. Minimal healthcheck so backend-test can
+    # wait for readiness.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U test_user -d cellcraft_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend-test:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.test
+    image: cellcraft-backend:test
+    environment:
+      - TZ=Asia/Seoul
+      - TESTING=1
+      # Point the test suite at the in-network test-db (container port 5432).
+      - TEST_DATABASE_URI=postgresql://test_user:test_pass@test-db:5432/cellcraft_test
+      # Settings requires POSTGRES_* (no defaults). Point them at test-db too so
+      # anything using settings.SQLALCHEMY_DATABASE_URI (e.g. alembic in
+      # main.run_migrations) targets the same ephemeral test database.
+      - POSTGRES_USER=test_user
+      - POSTGRES_PASSWORD=test_pass
+      - POSTGRES_HOST=test-db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=cellcraft_test
+    volumes:
+      # Mount the backend source so tests run against the working tree.
+      - ./backend:/app
+    working_dir: /app
+    depends_on:
+      test-db:
+        condition: service_healthy
+    networks:
+      - test-network
+    # Keep the container alive; the orchestrator runs pytest via `exec`.
+    command: ["sleep", "infinity"]
+
+networks:
+  test-network:
+    driver: bridge

--- a/docs/refactoring/v1.0.7/README.md
+++ b/docs/refactoring/v1.0.7/README.md
@@ -1,0 +1,141 @@
+# FastAPI 백엔드 리팩토링 마스터 플랜 (release/v1.0.7)
+
+작성일: 2026-07-11
+대상: `backend/app` (약 20,000 LOC, 60개 Python 파일, 8개 라우터 / 99개 엔드포인트)
+참고 아키텍처: [fastapi-best-architecture](https://github.com/fastapi-practices/fastapi-best-architecture), [Netflix Dispatch](https://github.com/Netflix/dispatch), [Onyx](https://github.com/onyx-dot-app/onyx)
+
+---
+
+## 1. 배경과 문제 정의
+
+### 현재 구조의 문제
+| # | 문제 | 근거 |
+|---|---|---|
+| 1 | **서비스 계층 부재** — 비즈니스 로직이 엔드포인트에 인라인 | `plugin.py` 1,616줄(upload_plugin 한 함수 250줄+: 파일 I/O·Docker 빌드·DB·Celery·롤백), `task.py` 1,447줄, `workflow.py` 988줄 |
+| 2 | **utils 잡동사니** — 도메인 경계 없는 26개 파일 11.5K LOC | `plugin_utils.py` 2,220줄, `snakefile_dag_parser.py` 2,227줄, utils 간 교차 의존 11건+, 함수 내부 지연 import 다수 |
+| 3 | **main.py 과부하 (337줄)** — import 시점 `run_migrations()` 실행, Celery 앱 생성, 시그널 핸들러, 플러그인 sync, Docker pull 혼재 | `app/main.py:84` |
+| 4 | **Celery 워커가 웹 앱 전체를 import** — 워커 부팅마다 마이그레이션 실행 | `Dockerfile.celery`: `celery -A app.main.celery worker` |
+| 5 | **애매한 위치의 코드** — 루트 `app/model.py`(auth 스키마), `routes/dep.py`(DB 세션 + 인증 혼재) | |
+| 6 | **전역 가변 싱글턴** — `docker_utils.container_manager` (스레드 안전성 없음) | |
+
+### 기술 스택 제약 (1.0.7에서 변경하지 않음)
+| 항목 | 버전 | 제약 |
+|---|---|---|
+| FastAPI | 0.78.0 | lifespan 파라미터 미지원 → `@app.on_event` 유지 |
+| Pydantic | 1.9.1 | v2 문법(`model_validate` 등) 사용 금지 |
+| SQLAlchemy | 1.4.36 | 동기 ORM 유지 |
+| Celery | 5.2.7 | 태스크 이름 하위호환 필수 |
+| Snakemake | 7.14.0 | conda 환경 고정 |
+
+### 유지할 자산 (건드리지 않음)
+- Alembic 단일 스키마 관리 + 3-상태 감지 부팅 로직
+- pytest 구조 (`tests/unit`, `tests/integration`, `tests/benchmarks`, conftest 격리)
+- CRUD 계층 분리 (`crud/base.py` 패턴)
+- 최근 보안 커밋 (CORS 제한, 환경 인지 앱 설정)
+
+---
+
+## 2. 아키텍처 결정 (ADR)
+
+### 결정: Dispatch식 도메인 패키지 + FBA식 계층 규율 + Onyx식 워커 분리
+
+| 레퍼런스 | 채택 | 비채택 | 이유 |
+|---|---|---|---|
+| **Netflix Dispatch** ★ | 도메인 플랫 패키지(도메인 폴더에 router/service/crud/models/schemas 동거), 서비스=평범한 함수 | ― | 동기 SQLAlchemy + 중간 규모 + 명확한 도메인 — cellcraft와 조건 최유사 |
+| **fastapi-best-architecture** | `router → service → crud` 단방향 계층 규율 | SQLAlchemy 2.0 async, Pydantic v2, Casbin RBAC, Snowflake ID | 스택 불일치·과설계 |
+| **Onyx** | 웹 계층 / Celery `worker/` 대분리 | 초대형 규모용 server/db 완전 분리 | 워커의 `app.main` import 문제 직접 해결 |
+
+### 설계 규칙 (모든 PR에 적용)
+1. **의존 방향**: `router → service → crud/모듈` 단방향. 신규 코드에서 router의 crud 직접 호출 금지.
+2. **service는 평범한 함수**: `def upload_plugin(*, db: Session, user: User, payload: PluginUpload) -> Plugin`. 클래스/DI 컨테이너 불필요.
+3. **HTTPException은 router에서만**. service는 `core/exceptions.py`의 도메인 예외를 raise.
+4. **도메인 간 참조는 상대 도메인의 service 경유** (crud 직접 접근 금지).
+5. **모델 분리 후에도 단일 `Base` metadata 유지**. relationship은 문자열 참조(`"User"`)로 순환 import 방지.
+6. **worker는 웹 계층(FastAPI) 미의존**.
+7. 파일당 800줄 이하, 함수당 50줄 이하 (신규/수정 코드 기준).
+
+### 목표 디렉터리 구조
+```
+backend/app/
+├── main.py                  # create_app() 팩토리 + 라우터 마운트 (~60줄)
+├── api.py                   # api_router 집계
+├── core/                    # config, security, exceptions, logging, startup, enums
+├── db/                      # session(engine/SessionLocal/get_db), base(Base/CRUDBase)
+├── auth/                    # router, service, schemas, deps(get_current_user)
+├── user/                    # models, crud, schemas, service
+├── plugin/                  # router, service, crud, models, schemas, builder, registry, sync, versioning, cache
+├── workflow/                # router, service, crud, models, schemas, compiler/{dag_parser,native_parser,snakefile}
+├── task/                    # router, service, crud, models, schemas, sse
+├── file/                    # router, service, crud, models, schemas, storage, security
+├── datatable/               # router, service, schemas, h5ad, cache
+├── admin/                   # router, service, crud, schemas
+├── version/                 # router
+├── shared/                  # docker, redis, cache, resources, archive (도메인 무관 인프라)
+└── worker/                  # app(create_celery), tasks (FastAPI 미의존)
+```
+
+---
+
+## 3. PR 로드맵 (총 10개 PR, 순차 머지)
+
+모든 PR의 base 브랜치는 **`release/v1.0.7`**. 브랜치 네이밍: `refactor/v107-<번호>-<이름>`.
+Phase 간 의존이 있으므로 **머지 순서 고정**, 병렬 진행은 Phase 3의 PR-5~8만 제한적으로 허용(충돌 범위가 도메인별로 분리되므로).
+
+| PR | 브랜치 | 내용 | 예상 규모 | 위험도 | 문서 |
+|---|---|---|---|---|---|
+| PR-1 | `refactor/v107-01-safety-net` | Phase 0: OpenAPI 스냅샷 + baseline 테스트 | +300줄 | 낮음 | [phase-0](./phase-0-safety-net.md) |
+| PR-2 | `refactor/v107-02-app-assembly` | Phase 1: main.py 분해, worker 분리 | ±500줄 | 낮음 | [phase-1](./phase-1-app-assembly.md) |
+| PR-3 | `refactor/v107-03-infra-skeleton` | Phase 2a: core/db/shared/worker 이동 | 이동 위주 | 낮음 | [phase-2](./phase-2-domain-skeleton.md) |
+| PR-4 | `refactor/v107-04-domain-skeleton` | Phase 2b: 도메인 이동 + models 분리 + shim 제거 | 이동 위주 | 중간 | [phase-2](./phase-2-domain-skeleton.md) |
+| PR-5 | `refactor/v107-05-plugin-service` | Phase 3a: plugin 서비스 추출 | ±1,600줄 | 중간 | [phase-3](./phase-3-service-layer.md) |
+| PR-6 | `refactor/v107-06-workflow-service` | Phase 3b: workflow 서비스 추출 | ±1,000줄 | 중간 | [phase-3](./phase-3-service-layer.md) |
+| PR-7 | `refactor/v107-07-task-service` | Phase 3c: task 서비스 + SSE 분리 + Celery kwargs 타입화 | ±1,400줄 | 중간 | [phase-3](./phase-3-service-layer.md) |
+| PR-8 | `refactor/v107-08-remaining-services` | Phase 3d: files/admin/auth/datatable + 전역 예외 핸들러 | ±1,500줄 | 중간 | [phase-3](./phase-3-service-layer.md) |
+| PR-9 | `refactor/v107-09-split-plugin-utils` | Phase 4a: plugin_utils.py(2,220줄) 분할 | ±2,200줄 | 중간 | [phase-4](./phase-4-monolith-split.md) |
+| PR-10 | `refactor/v107-10-split-dag-parser` | Phase 4b: snakefile_dag_parser.py(2,227줄) 분할 + 지연 import 제거 | ±2,300줄 | 중간 | [phase-4](./phase-4-monolith-split.md) |
+
+Phase 5(프레임워크 업그레이드 등)는 1.0.7 범위 밖 → [phase-5-backlog.md](./phase-5-backlog.md)
+
+### 진행 흐름
+```
+release/v1.0.7
+  ← PR-1 (안전망)          ─ 이후 모든 PR의 게이트 기준 확립
+  ← PR-2 (앱 조립부)        ─ 워커 진입점 변경 포함 (배포 주의)
+  ← PR-3 (인프라 골격)      ─┐ 기계적 이동
+  ← PR-4 (도메인 골격)      ─┘
+  ← PR-5 ~ PR-8 (서비스 추출) ─ 도메인별 독립, 5→8 순 권장 (병렬 가능)
+  ← PR-9 ~ PR-10 (모놀리스 분할)
+```
+
+---
+
+## 4. 공통 머지 게이트 (모든 PR 필수)
+
+머지 전 아래 4개를 전부 통과해야 한다. PR 본문에 결과 첨부.
+
+1. **테스트**: `pytest backend/tests` 전체 통과 (baseline 대비 실패 증가 0)
+2. **API 계약 동결**: OpenAPI 스냅샷 diff == 0 (PR-1에서 구축하는 테스트)
+   - 예외: 스키마 이름 변경 등 의도된 diff는 PR 본문에 명시하고 스냅샷 갱신 커밋 분리
+3. **DB 스키마 동결**: `alembic revision --autogenerate` 결과가 빈 마이그레이션 (모델 이동이 스키마를 바꾸지 않았음을 증명, 확인 후 파일 삭제)
+4. **스모크**: 웹 + Celery 워커 컨테이너 기동 확인 (`docker compose up` 후 `/routes/version` 응답, 워커 ready 로그)
+
+### 롤백 정책
+- PR 단위 `git revert`로 롤백 가능해야 함 → PR 간 커밋 섞임 금지, 순차 머지 유지
+- PR-2(워커 진입점 변경)만 배포 절차 필요: 큐 드레인 후 배포 (문서 내 상세)
+
+## 5. 비목표 (1.0.7에서 하지 않는 것)
+- API 경로·요청/응답 스키마 변경 (프론트엔드 호환 — OpenAPI diff 0)
+- DB 스키마 변경 (Alembic revision 생성 없음)
+- FastAPI/Pydantic/SQLAlchemy 업그레이드, async 전환 → Phase 5 백로그
+- 인증 개편 (refresh token 등) → Phase 5 백로그
+- 성능 최적화 (구조 개선과 분리)
+
+## 6. 일정 요약
+| Phase | PR | 예상 |
+|---|---|---|
+| 0 | PR-1 | 0.5~1일 |
+| 1 | PR-2 | 1일 |
+| 2 | PR-3, PR-4 | 1~2일 |
+| 3 | PR-5~8 | 3~5일 |
+| 4 | PR-9, PR-10 | 2~3일 |
+| **합계** | 10 PR | **8~12 작업일** |

--- a/docs/refactoring/v1.0.7/baseline-test-report.txt
+++ b/docs/refactoring/v1.0.7/baseline-test-report.txt
@@ -1,0 +1,86 @@
+# Backend pytest baseline report (PR-1, Phase 0)
+# Generated: 2026-07-12 | branch: refactor/v107-01-safety-net
+# Environment: docker-compose.test.yml (cellcraft-backend:test, linux/arm64, python 3.10)
+#   fastapi 0.92.0 / starlette 0.25.0 / pydantic 1.9.1 / SQLAlchemy 1.4.36
+#
+# PURPOSE: 이후 리팩토링 PR의 게이트 기준. 아래 68개 실패는 리팩토링 착수 전부터
+# 존재하던 실패다 (백엔드 CI 부재로 통합 테스트가 코드와 드리프트된 상태).
+# 게이트 판정: '실패 증가 0' — 아래 목록에 없는 새로운 실패가 생기면 리그레션.
+#
+# 실패 원인 분류:
+#  A. 상태코드/응답 드리프트 (~55건): 테스트 기대(403/200/detail 키 등)와 실제 동작(404/422/500) 불일치
+#  B. 테스트 자체 결함: 잘못된 patch 경로(app.routes.endpoints.plugin.docker), SameFileError 등
+#  C. asyncio 이벤트 루프 바인딩 오류 (~5건): session-scope 픽스처와 asyncio_mode=auto 충돌
+#
+## Summary
+= 68 failed, 448 passed, 3 skipped, 3 xpassed, 36 warnings in 264.03s (0:04:24) =
+
+## Failed tests (68)
+FAILED tests/integration/test_file_api.py::TestFileSecurityPathTraversal::test_download_result_path_traversal_blocked
+FAILED tests/integration/test_file_api.py::TestFileSecurityPathTraversal::test_download_data_path_traversal_blocked
+FAILED tests/integration/test_file_api.py::TestFileSecurityPathTraversal::test_download_tutorial_path_traversal_blocked
+FAILED tests/integration/test_file_api.py::TestFileSecurityPathTraversal::test_setup_file_path_traversal_blocked
+FAILED tests/integration/test_file_api.py::TestFileSecurityPathTraversal::test_case_sensitivity_bypass_attempts
+FAILED tests/integration/test_file_api.py::TestFileSecurityPathTraversal::test_path_traversal_sibling_directory_blocked
+FAILED tests/integration/test_file_api.py::TestFileUploadValidation::test_upload_exceeds_max_size
+FAILED tests/integration/test_file_api.py::TestFileUploadOperations::test_upload_single_file_success
+FAILED tests/integration/test_file_api.py::TestFileUploadOperations::test_upload_multiple_files_success
+FAILED tests/integration/test_file_api.py::TestFileDownloadOperations::test_download_data_file_success
+FAILED tests/integration/test_file_api.py::TestFileDownloadOperations::test_download_result_file_success
+FAILED tests/integration/test_file_api.py::TestFileDownloadOperations::test_download_tutorial_file_success
+FAILED tests/integration/test_file_api.py::TestFileDownloadOperations::test_download_data_file_h5ad_conversion
+FAILED tests/integration/test_file_api.py::TestFileUpdateDeleteOperations::test_delete_file_success
+FAILED tests/integration/test_file_api.py::TestH5ADConversion::test_convert_h5ad_to_csv_success
+FAILED tests/integration/test_file_api.py::TestH5ADConversion::test_convert_h5ad_already_exists
+FAILED tests/integration/test_file_api.py::TestH5ADDataExtraction::test_get_h5ad_columns_success
+FAILED tests/integration/test_file_api.py::TestH5ADDataExtraction::test_get_h5ad_clusters_success
+FAILED tests/integration/test_file_api.py::TestSetupResultOperations::test_setup_read_json_file
+FAILED tests/integration/test_file_api.py::TestSetupResultOperations::test_setup_read_binary_file
+FAILED tests/integration/test_file_api.py::TestSetupResultOperations::test_list_result_files_success
+FAILED tests/integration/test_plugin_api.py::TestPluginCRUD::test_get_plugin_list_success
+FAILED tests/integration/test_plugin_api.py::TestPluginCRUD::test_get_plugin_list_empty
+FAILED tests/integration/test_plugin_api.py::TestPluginCRUD::test_get_plugin_list_filter_by_type
+FAILED tests/integration/test_plugin_api.py::TestPluginCRUD::test_get_plugin_info_success
+FAILED tests/integration/test_plugin_api.py::TestPluginCRUD::test_get_plugin_info_not_found
+FAILED tests/integration/test_plugin_api.py::TestPluginCRUD::test_get_plugin_info_official_vs_local
+FAILED tests/integration/test_plugin_api.py::TestPluginUploadValidation::test_validate_plugin_success
+FAILED tests/integration/test_plugin_api.py::TestPluginUploadValidation::test_upload_plugin_success
+FAILED tests/integration/test_plugin_api.py::TestPluginFileManagement::test_get_reference_folders_success
+FAILED tests/integration/test_plugin_api.py::TestPluginFileManagement::test_download_plugin_package_success
+FAILED tests/integration/test_plugin_api.py::TestPluginFileManagement::test_download_plugin_file_success
+FAILED tests/integration/test_plugin_api.py::TestPluginAssociation::test_associate_plugin_success
+FAILED tests/integration/test_plugin_api.py::TestPluginAssociation::test_dissociate_plugin_success
+FAILED tests/integration/test_plugin_api.py::TestPluginAssociation::test_associate_plugin_not_found
+FAILED tests/integration/test_plugin_api.py::TestPluginAssociation::test_dissociate_plugin_not_associated
+FAILED tests/integration/test_plugin_api.py::TestPluginDockerBuild::test_build_plugin_success
+FAILED tests/integration/test_plugin_api.py::TestPluginDockerBuild::test_check_image_exists
+FAILED tests/integration/test_plugin_api.py::TestPluginDockerBuild::test_check_image_not_exists
+FAILED tests/integration/test_task_api.py::TestTaskRevocation::test_revoke_running_task_success
+FAILED tests/integration/test_task_api.py::TestTaskRevocation::test_revoke_with_container_cleanup
+FAILED tests/integration/test_task_api.py::TestTaskRevocation::test_revoke_without_container
+FAILED tests/integration/test_task_api.py::TestTaskRevocation::test_revoke_force_db_update
+FAILED tests/integration/test_task_api.py::TestTaskRevocation::test_revoke_unauthorized_user
+FAILED tests/integration/test_task_api.py::TestTaskRevocation::test_revoke_nonexistent_task
+FAILED tests/integration/test_task_api.py::TestDAGStructure::test_dag_structure_fallback_to_legacy
+FAILED tests/integration/test_task_api.py::TestDAGStructure::test_dag_structure_forbidden
+FAILED tests/integration/test_task_api.py::TestDAGStructure::test_rule_status_forbidden
+FAILED tests/integration/test_task_api.py::TestSSEStatusStream::test_sse_stream_status_updates
+FAILED tests/integration/test_task_api.py::TestSSEStatusStream::test_sse_stream_failure_status
+FAILED tests/integration/test_task_api.py::TestSSEStatusStream::test_sse_stream_revoked_status
+FAILED tests/integration/test_task_api.py::TestSSEStatusStream::test_sse_stream_running_status
+FAILED tests/integration/test_task_api.py::TestSSEStatusStream::test_sse_content_type_header
+FAILED tests/integration/test_task_api.py::TestTaskLogs::test_get_logs_file_read_error
+FAILED tests/integration/test_workflow_api.py::TestWorkflowCompilation::test_compile_workflow_single_algorithm
+FAILED tests/integration/test_workflow_api.py::TestWorkflowCompilation::test_compile_workflow_multiple_algorithms
+FAILED tests/integration/test_workflow_api.py::TestWorkflowCompilation::test_compile_workflow_no_algorithm
+FAILED tests/integration/test_workflow_api.py::TestWorkflowCompilation::test_compile_workflow_invalid_plugin
+FAILED tests/integration/test_workflow_api.py::TestWorkflowResults::test_download_workflow_result_file
+FAILED tests/integration/test_workflow_api.py::TestWorkflowResults::test_download_workflow_result_not_found
+FAILED tests/integration/test_workflow_api.py::TestWorkflowNodeData::test_save_node_data_json
+FAILED tests/integration/test_workflow_api.py::TestWorkflowNodeData::test_save_node_data_csv
+FAILED tests/integration/test_workflow_api.py::TestWorkflowNodeData::test_read_node_data_success
+FAILED tests/integration/test_workflow_api.py::TestWorkflowNodeData::test_delete_node_data_success
+FAILED tests/integration/test_workflow_api.py::TestWorkflowSecurity::test_workflow_access_other_user
+FAILED tests/unit/test_auth.py::TestUserLogin::test_login_success - Assertion...
+FAILED tests/unit/test_config.py::TestGetSettings::test_get_settings_returns_development_config
+FAILED tests/unit/test_file_security.py::TestValidateFileUploadWithMIME::test_validate_logs_file_size_exceeded

--- a/docs/refactoring/v1.0.7/phase-0-safety-net.md
+++ b/docs/refactoring/v1.0.7/phase-0-safety-net.md
@@ -12,9 +12,9 @@
 ### 1. OpenAPI 스냅샷 테스트
 API 계약(경로·메서드·요청/응답 스키마) 동결을 검증하는 테스트.
 
-- [ ] `backend/tests/contract/__init__.py` 생성
-- [ ] `backend/tests/contract/openapi_snapshot.json` — 현재 `app.openapi()` 출력 저장
-- [ ] `backend/tests/contract/test_openapi_contract.py` 작성:
+- [x] `backend/tests/contract/__init__.py` 생성
+- [x] `backend/tests/contract/openapi_snapshot.json` — 생성 완료 (paths 104개, schemas 40개)
+- [x] `backend/tests/contract/test_openapi_contract.py` 작성:
 
 ```python
 import json
@@ -32,13 +32,13 @@ def test_openapi_schema_unchanged(client):  # conftest의 기존 client 픽스�
     )
 ```
 
-- [ ] 스냅샷 갱신 헬퍼(`--update-snapshot` 옵션 또는 `scripts/update_openapi_snapshot.py`) 추가
-- [ ] **주의**: `app.main`은 import 시점에 `run_migrations()`를 실행하므로(main.py:84) 스냅샷 생성은 반드시 기존 테스트 환경(conftest의 DB 셋업) 안에서 수행한다. PR-2에서 이 부수효과가 제거되면 단순화 가능.
+- [x] 스냅샷 갱신 헬퍼(`scripts/update_openapi_snapshot.py`) 추가 — TESTING=1 설정 후 app import, `json.dump(sort_keys=True, indent=2)`
+- [x] **주의**: `app.main`은 import 시점에 `run_migrations()`를 실행하므로(main.py:84) 스냅샷 생성은 반드시 기존 테스트 환경(conftest의 DB 셋업) 안에서 수행한다. PR-2에서 이 부수효과가 제거되면 단순화 가능. (스크립트/테스트가 이 조건을 문서화 및 준수)
 
 ### 2. pytest baseline 고정
-- [ ] `pytest backend/tests -v` 전체 실행, 결과를 `docs/refactoring/v1.0.7/baseline-test-report.txt`로 저장
-- [ ] 현재 실패/스킵 테스트가 있으면 목록화 — 이후 PR에서 "이미 실패하던 테스트"와 "리팩토링이 깨뜨린 테스트"를 구분하는 기준
-- [ ] 커버리지 측정(`pytest --cov=app`)이 가능하면 수치 기록 (Phase 3에서 서비스 계층 커버리지 80% 목표의 기준점)
+- [x] 전체 실행 결과를 `docs/refactoring/v1.0.7/baseline-test-report.txt`로 저장 — **448 passed / 68 failed / 3 skipped / 3 xpassed**
+- [x] 실패 68건 목록화 및 원인 분류(A: 상태코드 드리프트, B: 테스트 자체 결함, C: asyncio 루프) — 리팩토링 이전부터 존재하던 실패 (백엔드 CI 부재로 드리프트). 게이트 판정 기준: "목록 외 새로운 실패 = 리그레션"
+- [ ] 커버리지 수치 기록 (Phase 3 착수 시 측정)
 
 ### 3. 핵심 경로 characterization 테스트 보강
 리팩토링 대상 중 테스트가 얇은 핵심 경로에 대해, **현재 동작 그대로**를 고정하는 테스트를 추가한다 (동작이 이상해 보여도 수정하지 않고 그대로 고정 — 수정은 Phase 3에서).
@@ -51,11 +51,11 @@ def test_openapi_schema_unchanged(client):  # conftest의 기존 client 픽스�
 | `POST /files` 업로드 | 경로 검증 거부 케이스(file_security), 성공 시 DB 레코드 |
 | `POST /auth/login/access-token` | 토큰 발급 형태, 비활성 유저 거부 |
 
-- [ ] 각 테스트는 `tests/integration/` 기존 구조와 픽스처를 따른다
-- [ ] Docker·GitHub 외부 의존은 모킹 (현재 모킹이 없다는 점이 확인됨 — 최소한 characterization 테스트에서는 모킹 도입)
+- [x] 각 테스트는 `tests/integration/` 기존 구조와 픽스처를 따른다 (5개 파일: auth/plugin_upload/workflow_compile/task_status/file_upload)
+- [x] Docker·GitHub 외부 의존은 모킹 (`unittest.mock.patch`로 `get_plugin_path`, `process_data_task.apply_async`, `plugin_utils.*`, `get_task_info` 등 모킹)
 
 ### 4. import 계약 린트 (선택이지만 권장)
-- [ ] `import-linter` 도입, `backend/.importlinter` 계약 정의 (Phase 2 이후 활성화할 계약을 미리 작성):
+- [x] `import-linter` 도입, `backend/.importlinter` 계약 정의 (Phase 2 이후 활성화할 계약을 미리 작성 — `no-web-in-worker` 계약을 주석으로 정의하고 PR-2 활성화 시점 명시):
 
 ```ini
 [importlinter]
@@ -70,13 +70,30 @@ forbidden_modules = app.main, app.api
 
 - 계약은 PR-2~4 진행에 맞춰 단계적으로 추가 (도메인 단방향 의존 등)
 
+### 5. 테스트 실행 방법 (compose 오버라이드)
+- [x] `docker-compose.test.yml` 신규 작성 — 격리된 `test-network` + `test-db`(postgres:15, `cellcraft_test`/`test_user`/`test_pass`, 호스트 포트 `${TEST_DB_PORT:-5433}`) + `backend-test`(image `cellcraft-backend:refactor-test`, `./backend` 마운트, `TESTING=1`/`TEST_DATABASE_URI` 설정, `command: sleep infinity` — 오케스트레이터가 `exec`으로 pytest 실행)
+- [x] `backend/tests/conftest.py`의 테스트 DB URI를 `os.environ.get("TEST_DATABASE_URI", <기존 기본값>)`으로 환경변수화 (기존 환경 호환)
+- 상세 실행/스냅샷 갱신 방법: `backend/tests/contract/README.md` 참조.
+
+```bash
+# 이미지 빌드 → 스택 기동 → 스냅샷 생성 → 테스트
+docker build -f backend/Dockerfile.dev -t cellcraft-backend:refactor-test ./backend
+docker compose -f docker-compose.test.yml up -d
+docker compose -f docker-compose.test.yml exec backend-test python scripts/update_openapi_snapshot.py
+docker compose -f docker-compose.test.yml exec backend-test pytest
+docker compose -f docker-compose.test.yml down
+# 호스트 5433 점유 시: TEST_DB_PORT=5544 docker compose -f docker-compose.test.yml up -d
+```
+
 ## 머지 게이트
 - [ ] `pytest backend/tests` 통과 (신규 테스트 포함)
 - [ ] 스냅샷 테스트가 의도적 변경 시 명확한 에러 메시지와 갱신 방법을 출력
 - [ ] baseline 리포트 커밋됨
 
 ## 산출물
-- `tests/contract/` (스냅샷 + 테스트)
-- `tests/integration/` characterization 테스트 5건+
-- `docs/refactoring/v1.0.7/baseline-test-report.txt`
-- (선택) `.importlinter`
+- [x] `tests/contract/` (계약 테스트 + `README.md`; 스냅샷 JSON은 컨테이너에서 생성)
+- [x] `backend/scripts/update_openapi_snapshot.py` (스냅샷 생성/갱신 헬퍼)
+- [x] `tests/integration/` characterization 테스트 5건 (auth/plugin_upload/workflow_compile/task_status/file_upload)
+- [x] `docker-compose.test.yml` (격리 테스트 스택)
+- [x] `backend/.importlinter` (PR-2 활성화 예정 계약 정의)
+- [x] `docs/refactoring/v1.0.7/baseline-test-report.txt`

--- a/docs/refactoring/v1.0.7/phase-0-safety-net.md
+++ b/docs/refactoring/v1.0.7/phase-0-safety-net.md
@@ -1,0 +1,82 @@
+# Phase 0 — 안전망 구축 (PR-1)
+
+> 브랜치: `refactor/v107-01-safety-net` → base: `release/v1.0.7`
+> 예상: 0.5~1일 | 위험도: 낮음 | 선행 조건: 없음 (모든 후속 PR의 게이트 기준)
+
+## 목적
+리팩토링 전 과정에서 "동작이 바뀌지 않았음"을 기계적으로 증명할 수단을 만든다.
+이 PR이 머지되기 전에는 어떤 리팩토링 PR도 머지하지 않는다.
+
+## 작업 항목
+
+### 1. OpenAPI 스냅샷 테스트
+API 계약(경로·메서드·요청/응답 스키마) 동결을 검증하는 테스트.
+
+- [ ] `backend/tests/contract/__init__.py` 생성
+- [ ] `backend/tests/contract/openapi_snapshot.json` — 현재 `app.openapi()` 출력 저장
+- [ ] `backend/tests/contract/test_openapi_contract.py` 작성:
+
+```python
+import json
+from pathlib import Path
+
+SNAPSHOT = Path(__file__).parent / "openapi_snapshot.json"
+
+def test_openapi_schema_unchanged(client):  # conftest의 기존 client 픽스처 재사용
+    current = client.app.openapi()
+    expected = json.loads(SNAPSHOT.read_text())
+    assert current == expected, (
+        "OpenAPI 계약이 변경되었습니다. 의도된 변경이면 스냅샷을 갱신하고 "
+        "PR 본문에 변경 사유를 명시하세요: "
+        "pytest tests/contract --update-snapshot"
+    )
+```
+
+- [ ] 스냅샷 갱신 헬퍼(`--update-snapshot` 옵션 또는 `scripts/update_openapi_snapshot.py`) 추가
+- [ ] **주의**: `app.main`은 import 시점에 `run_migrations()`를 실행하므로(main.py:84) 스냅샷 생성은 반드시 기존 테스트 환경(conftest의 DB 셋업) 안에서 수행한다. PR-2에서 이 부수효과가 제거되면 단순화 가능.
+
+### 2. pytest baseline 고정
+- [ ] `pytest backend/tests -v` 전체 실행, 결과를 `docs/refactoring/v1.0.7/baseline-test-report.txt`로 저장
+- [ ] 현재 실패/스킵 테스트가 있으면 목록화 — 이후 PR에서 "이미 실패하던 테스트"와 "리팩토링이 깨뜨린 테스트"를 구분하는 기준
+- [ ] 커버리지 측정(`pytest --cov=app`)이 가능하면 수치 기록 (Phase 3에서 서비스 계층 커버리지 80% 목표의 기준점)
+
+### 3. 핵심 경로 characterization 테스트 보강
+리팩토링 대상 중 테스트가 얇은 핵심 경로에 대해, **현재 동작 그대로**를 고정하는 테스트를 추가한다 (동작이 이상해 보여도 수정하지 않고 그대로 고정 — 수정은 Phase 3에서).
+
+| 대상 | 고정할 동작 |
+|---|---|
+| `POST /plugin` upload 경로 | 성공 응답 형태, 잘못된 입력 시 상태코드/에러 메시지, 롤백 후 DB 상태 |
+| `POST /workflow` compile 경로 | 컴파일 성공/실패 응답, 캐시 적중 시 응답 동일성 |
+| `GET /task` 상태 조회(SSE) | 이벤트 포맷, 종료 조건 (Docker/Celery는 conftest 패턴대로 모킹) |
+| `POST /files` 업로드 | 경로 검증 거부 케이스(file_security), 성공 시 DB 레코드 |
+| `POST /auth/login/access-token` | 토큰 발급 형태, 비활성 유저 거부 |
+
+- [ ] 각 테스트는 `tests/integration/` 기존 구조와 픽스처를 따른다
+- [ ] Docker·GitHub 외부 의존은 모킹 (현재 모킹이 없다는 점이 확인됨 — 최소한 characterization 테스트에서는 모킹 도입)
+
+### 4. import 계약 린트 (선택이지만 권장)
+- [ ] `import-linter` 도입, `backend/.importlinter` 계약 정의 (Phase 2 이후 활성화할 계약을 미리 작성):
+
+```ini
+[importlinter]
+root_package = app
+
+[importlinter:contract:no-web-in-worker]
+name = worker는 웹 계층에 의존하지 않는다
+type = forbidden
+source_modules = app.worker
+forbidden_modules = app.main, app.api
+```
+
+- 계약은 PR-2~4 진행에 맞춰 단계적으로 추가 (도메인 단방향 의존 등)
+
+## 머지 게이트
+- [ ] `pytest backend/tests` 통과 (신규 테스트 포함)
+- [ ] 스냅샷 테스트가 의도적 변경 시 명확한 에러 메시지와 갱신 방법을 출력
+- [ ] baseline 리포트 커밋됨
+
+## 산출물
+- `tests/contract/` (스냅샷 + 테스트)
+- `tests/integration/` characterization 테스트 5건+
+- `docs/refactoring/v1.0.7/baseline-test-report.txt`
+- (선택) `.importlinter`

--- a/docs/refactoring/v1.0.7/phase-1-app-assembly.md
+++ b/docs/refactoring/v1.0.7/phase-1-app-assembly.md
@@ -1,0 +1,88 @@
+# Phase 1 — 앱 조립부 정리 (PR-2)
+
+> 브랜치: `refactor/v107-02-app-assembly` → base: `release/v1.0.7`
+> 예상: 1일 | 위험도: 낮음(코드) / 중간(배포 — 워커 진입점 변경) | 선행: PR-1 머지
+
+## 목적
+`main.py`(337줄)를 순수 조립 코드(~60줄)로 축소하고, Celery 워커를 웹 계층에서 분리한다.
+**로직 자체는 옮기기만 하고 바꾸지 않는다.**
+
+## 현재 main.py의 책임 (분해 대상)
+| 현재 위치 | 내용 | 이동 목적지 |
+|---|---|---|
+| `main.py:84` | import 시점 `run_migrations()` 실행 | `core/startup.py` + 명시 호출 |
+| `main.py:25-38` | 시그널 핸들러 (컨테이너 정리) | `core/startup.py` |
+| `main.py:41-52, 112-118` | Celery 앱 생성 + worker_shutting_down 훅 | `worker/app.py` |
+| `main.py:130-219` | startup_event (플러그인 sync/버전 검증/CSV 초기화) | `core/startup.py` |
+| `main.py:221-338` | Docker 이미지 pull (_sync_pull_image 등) | `core/startup.py` (또는 `shared/docker.py`와 인접 배치) |
+
+## 작업 항목
+
+### 1. `app/core/startup.py` 신설
+- [ ] `run_migrations()` 이동 (내용 그대로)
+- [ ] `setup_signal_handlers()` 이동
+- [ ] `startup_event`의 본문 → `initialize_plugin_system(db)` / `check_and_pull_official_plugin_images()` 함수로 이동
+- [ ] print 기반 로깅은 이 단계에서 유지 (동작 변경 금지 — 로깅 정리는 별도)
+
+### 2. `app/worker/` 신설 — Celery 분리
+- [ ] `worker/__init__.py`, `worker/app.py` 생성
+- [ ] `common/utils/celery_utils.py`의 `create_celery()` → `worker/app.py`로 이동, 모듈 레벨에서 `celery = create_celery()` 인스턴스 노출
+- [ ] `worker_shutting_down` 훅(main.py:41)을 `worker/app.py`로 이동
+- [ ] `worker/app.py`는 FastAPI·`app.main`을 import하지 않을 것 (PR-1의 import-linter 계약 활성화)
+- [ ] 기존 `common/utils/celery_utils.py`는 re-export shim으로 유지 (`from app.worker.app import *`) — Phase 2에서 일괄 제거
+- [ ] **태스크 이름 고정**: `routes/celery_tasks.py`의 모든 `@shared_task`/`@celery.task`에 현재 등록 이름을 `name="..."`으로 명시 (`celery -A ... inspect registered`로 현재 이름 확인 후). 이후 파일 이동에도 브로커 메시지 호환 유지
+
+### 3. Dockerfile CMD 변경
+- [ ] `Dockerfile.celery`, `Dockerfile.celery.prod`, `Dockerfile.dev.celery`, `Dockerfile.cpu.celery`, `Dockerfile.gpu.celery`:
+  `celery -A app.main.celery worker` → **`celery -A app.worker.app worker`**
+- [ ] 워커가 더 이상 `run_migrations()`·웹 앱 조립을 실행하지 않음을 기동 로그로 확인
+- [ ] 워커에 필요한 startup 로직이 있는지 검토(현재 워커는 main.py import로 마이그레이션까지 얻고 있었음) — 마이그레이션은 **웹 컨테이너만** 수행하는 것으로 명시. 웹보다 워커가 먼저 뜨는 경우를 대비해 compose의 `depends_on` 확인
+
+### 4. `main.py` 재작성 (~60줄)
+```python
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+
+from app.routes.api import api_router          # PR-4에서 app.api로 이동
+from app.common.config import settings          # PR-3에서 app.core.config로 이동
+from app.core import startup
+
+def create_app() -> FastAPI:
+    startup.run_migrations()
+    is_production = settings.ENVIRONMENT == "production"
+    app = FastAPI(
+        title=settings.PROJECT_NAME,
+        version=settings.APP_VERSION,
+        description=settings.APP_DESCRIPTION,
+        docs_url=None if is_production else "/docs",
+        redoc_url=None if is_production else "/redoc",
+        openapi_url=None if is_production else "/openapi.json",
+    )
+    app.add_middleware(CORSMiddleware, ...)      # 기존 설정 그대로
+    app.include_router(api_router, prefix=settings.ROUTES_STR)
+    app.add_event_handler("startup", startup.on_startup)   # FastAPI 0.78: on_event 방식 유지
+    startup.setup_signal_handlers()
+    return app
+
+app = create_app()
+```
+- [ ] `run_migrations()`는 import 부수효과가 아니라 `create_app()` 내부의 명시 호출로 변경
+- [ ] uvicorn 진입점(`app.main:app`)은 그대로 유지 → 웹 Dockerfile 변경 불필요
+- [ ] `app.celery_app` 속성에 의존하는 코드가 있는지 검색(`grep -rn "app.celery_app\|get_celery_app"`) 후 `app.worker.app.celery` 참조로 교체
+
+### 5. 테스트 수정
+- [ ] conftest가 `app.main` import에 의존하는 부분 점검 — `create_app()` 팩토리 덕에 테스트에서 마이그레이션 시점 제어 가능해짐 (기존 동작 유지가 우선, 개선은 선택)
+
+## 머지 게이트 (공통 4종 + 추가)
+- [ ] 공통 게이트: pytest / OpenAPI diff 0 / alembic autogenerate 빈 결과 / 스모크
+- [ ] **워커 스모크 강화**: `docker compose up` 후 ① 워커 로그에 마이그레이션 출력이 없어야 함 ② `celery inspect registered`의 태스크 이름 목록이 변경 전과 동일 ③ 실제 태스크 1건 실행 확인
+- [ ] import-linter `no-web-in-worker` 계약 통과
+
+## 배포 주의사항 (이 PR만 해당)
+워커 진입점이 바뀌므로 운영 배포 시:
+1. 이전 버전 워커의 큐 드레인(진행 중 태스크 완료 대기)
+2. 웹(마이그레이션 담당) → 워커 순으로 기동
+3. 태스크 이름이 `name=`으로 고정되었으므로 드레인 실패한 잔여 메시지도 신버전 워커가 처리 가능
+
+## 롤백
+`git revert` + Dockerfile CMD 원복. DB/스키마 변경이 없으므로 데이터 롤백 불필요.

--- a/docs/refactoring/v1.0.7/phase-2-domain-skeleton.md
+++ b/docs/refactoring/v1.0.7/phase-2-domain-skeleton.md
@@ -1,0 +1,132 @@
+# Phase 2 — 도메인 골격 이동 (PR-3, PR-4)
+
+> 예상: 1~2일 | 위험도: 낮음(PR-3) / 중간(PR-4) | 선행: PR-2 머지
+> **원칙: 로직 변경 0. 파일 이동 + import 경로 갱신만.** diff는 커도 리뷰 부담은 낮다 — 리뷰어는 "이동 매핑표와 일치하는가"만 확인.
+
+## 이동 절차 (두 PR 공통)
+1. 새 경로에 파일 이동 (`git mv` — 히스토리 보존)
+2. 구 경로에 re-export shim 생성: `from app.<new>.<module> import *  # noqa — v1.0.7 리팩토링 shim, PR-4에서 제거`
+3. `app/` 전체 import 일괄 갱신 (구 경로 참조 제거)
+4. shim 제거 (PR-4 마지막 커밋)
+5. 커밋 분리: "이동 커밋"(git mv만)과 "import 갱신 커밋"을 나누면 리뷰가 쉬워짐
+
+---
+
+## PR-3: 인프라 골격 (`refactor/v107-03-infra-skeleton`)
+
+도메인과 무관한 공용 계층을 먼저 옮긴다. 도메인 코드는 건드리지 않음.
+
+### 이동 매핑
+| 현재 | 이동 후 | 비고 |
+|---|---|---|
+| `common/config.py` | `core/config.py` | |
+| `common/security.py` | `core/security.py` | |
+| `common/enums.py` | `core/enums.py` | |
+| `common/utils/error_utils.py` | `core/exceptions.py` | 내용 그대로, 예외 계층 재설계는 PR-8 |
+| `common/utils/security_logging.py` | `core/logging.py` | |
+| `common/utils/docker_utils.py` | `shared/docker.py` | `container_manager` 싱글턴 그대로 (DI화는 Phase 5) |
+| `common/utils/redis_cache.py` | `shared/redis.py` | |
+| `common/utils/cache_utils.py` | `shared/cache.py` | |
+| `common/utils/resource_manager.py` | `shared/resources.py` | |
+| `common/utils/log_archive_utils.py` | `shared/archive.py` | |
+| `database/conn.py` | `db/session.py` | `initialize_plugins_from_csv()`는 임시로 함께 이동, PR-4에서 `plugin/sync.py`로 재배치 |
+| `database/crud/base.py` | `db/base.py` | `Base`(declarative_base)와 `CRUDBase` 함께 |
+| `routes/dep.py`의 `get_db` | `db/session.py` | 인증 dependency는 PR-4에서 auth로 |
+| `common/utils/celery_utils.py` (shim) | 삭제 → `worker/app.py` | PR-2에서 이동 완료, shim만 제거 |
+| `routes/celery_tasks.py` | `worker/tasks.py` | `name=` 고정 완료 상태(PR-2)라 안전. Dockerfile의 `include`/autodiscover 경로 확인 |
+
+### 체크리스트
+- [ ] 위 매핑대로 `git mv` + shim + import 갱신
+- [ ] `grep -rn "from app.common\|from app.database.conn\|from app.routes.celery_tasks" backend/app` 결과 0 (shim 파일 제외)
+- [ ] 공통 머지 게이트 4종 통과
+
+---
+
+## PR-4: 도메인 골격 + models 분리 (`refactor/v107-04-domain-skeleton`)
+
+### 이동 매핑 — 라우터/CRUD/스키마
+| 도메인 | 현재 | 이동 후 |
+|---|---|---|
+| api 집계 | `routes/api.py` | `api.py` (app 루트) |
+| auth | `routes/endpoints/auth.py` | `auth/router.py` |
+| | `routes/dep.py`의 `get_current_user`, `get_current_active_user`, `reusable_oauth2` | `auth/deps.py` |
+| | `app/model.py` (Token, TokenPayload, UserInfo) | `auth/schemas.py` |
+| user | `database/crud/crud_user.py` | `user/crud.py` |
+| | `database/schemas/user.py` | `user/schemas.py` |
+| plugin | `routes/endpoints/plugin.py` | `plugin/router.py` |
+| | `database/crud/crud_plugin.py` | `plugin/crud.py` |
+| | `database/schemas/plugin.py` | `plugin/schemas.py` |
+| | `common/utils/plugin_utils.py` | `plugin/utils.py` (분할은 PR-9) |
+| | `common/utils/github_registry_client.py` | `plugin/registry.py` |
+| | `common/utils/plugin_sync_manager.py` | `plugin/sync.py` |
+| | `common/utils/plugin_version_validator.py` | `plugin/versioning.py` |
+| | `common/utils/plugin_cache.py` | `plugin/cache.py` |
+| | `db/session.py`의 `initialize_plugins_from_csv` | `plugin/sync.py` |
+| workflow | `routes/endpoints/workflow.py` | `workflow/router.py` |
+| | `database/crud/crud_workflow.py` | `workflow/crud.py` |
+| | `database/schemas/workflow.py` | `workflow/schemas.py` |
+| | `common/utils/snakefile_dag_parser.py` | `workflow/compiler/dag_parser.py` (분할은 PR-10) |
+| | `common/utils/snakemake_native_parser.py` | `workflow/compiler/native_parser.py` |
+| | `common/utils/snakemake_utils.py` | `workflow/compiler/snakefile.py` |
+| | `common/utils/workflow_utils.py` | `workflow/utils.py` |
+| task | `routes/endpoints/task.py` | `task/router.py` |
+| | `database/crud/crud_task.py` | `task/crud.py` |
+| | `database/schemas/task.py` | `task/schemas.py` |
+| file | `routes/endpoints/files.py` | `file/router.py` |
+| | `database/crud/crud_file.py` | `file/crud.py` |
+| | `database/schemas/file.py` | `file/schemas.py` |
+| | `common/utils/file_security.py` | `file/security.py` |
+| | `common/utils/path_utils.py` | `file/storage.py` |
+| | `common/utils/file_path_resolver.py` | `file/path_resolver.py` (storage와 통합은 PR-10에서 검토) |
+| datatable | `routes/endpoints/datatable.py` | `datatable/router.py` |
+| | `common/utils/datatable_utils.py` | `datatable/utils.py` |
+| | `common/utils/h5ad_utils.py` | `datatable/h5ad.py` |
+| | `common/utils/h5ad_compression.py` | `datatable/h5ad_compression.py` |
+| | `common/utils/h5ad_metadata_cache.py` + `datatable_cache.py` | `datatable/cache.py` (단순 병합 — 두 파일을 한 모듈로, 코드 수정 없이) |
+| admin | `routes/endpoints/admin.py` | `admin/router.py` |
+| | `database/crud/crud_admin.py` | `admin/crud.py` |
+| | `database/schemas/admin.py` | `admin/schemas.py` |
+| version | `routes/endpoints/version.py` | `version/router.py` |
+
+### models 분리 (`database/models.py` → 도메인별)
+| 모델 | 이동 후 |
+|---|---|
+| `User` | `user/models.py` |
+| `File` | `file/models.py` |
+| `Workflow` | `workflow/models.py` |
+| `Task` | `task/models.py` |
+| `Plugin` | `plugin/models.py` |
+
+**필수 규칙**:
+- [ ] 모든 모델은 `db/base.py`의 단일 `Base`를 상속 (metadata 하나 유지)
+- [ ] `relationship()`은 문자열 참조(`relationship("Task", ...)`)로 통일 → 도메인 간 순환 import 방지
+- [ ] FK의 `ForeignKey("users.id")` 등 테이블명 문자열은 그대로 (변경 없음)
+- [ ] `db/base.py`(또는 `db/base_registry.py`)에서 전 도메인 models를 import — Alembic `env.py`와 `create_all` 계열이 전체 메타데이터를 보도록:
+```python
+# db/base.py 하단 또는 별도 registry 모듈
+from app.user.models import User        # noqa
+from app.file.models import File        # noqa
+from app.workflow.models import Workflow  # noqa
+from app.task.models import Task        # noqa
+from app.plugin.models import Plugin    # noqa
+```
+- [ ] `alembic/env.py`의 `target_metadata` import 경로 갱신
+- [ ] 구 `database/models.py`는 shim으로 유지 후 이 PR 마지막 커밋에서 제거
+
+### 마무리
+- [ ] `api.py`의 라우터 import를 새 경로로 갱신 (`from app.plugin.router import router as plugin_router` 등) — **prefix/tags 변경 금지**
+- [ ] PR-3·PR-4에서 만든 모든 shim 제거, `routes/`·`database/`·`common/` 빈 디렉터리 삭제
+- [ ] 테스트 코드의 import 경로 일괄 갱신
+- [ ] import-linter에 도메인 계약 추가 (예: `app.shared`는 도메인 모듈 import 금지)
+
+### 머지 게이트 (공통 4종 + 추가)
+- [ ] **alembic 게이트가 특히 중요**: `alembic revision --autogenerate`가 빈 마이그레이션 → 모델 분리가 스키마에 영향 없음 증명
+- [ ] `celery inspect registered` 태스크 이름 불변
+- [ ] `grep -rn "app.common\|app.database\|app.routes" backend/app backend/tests` 결과 0
+
+### 리스크
+| 리스크 | 완화 |
+|---|---|
+| 모델 간 순환 import | 문자열 relationship + `db/base.py` 중앙 registry |
+| conftest/픽스처의 구 경로 import | 테스트 갱신을 같은 PR에 포함, baseline과 대조 |
+| 숨은 동적 import(문자열 기반) | `grep -rn "importlib\|__import__\|import_module" backend/app`으로 사전 확인 |

--- a/docs/refactoring/v1.0.7/phase-3-service-layer.md
+++ b/docs/refactoring/v1.0.7/phase-3-service-layer.md
@@ -1,0 +1,151 @@
+# Phase 3 — 서비스 계층 추출 (PR-5 ~ PR-8)
+
+> 예상: 3~5일 | 위험도: 중간 | 선행: PR-4 머지
+> 이 Phase가 리팩토링의 핵심 가치. 도메인별 1 PR, **PR-5 → 8 순서 권장이나 도메인이 겹치지 않으므로 병렬 진행 가능.**
+
+## 공통 규칙 (모든 PR 적용)
+
+### 서비스 함수 형태 (Dispatch식)
+```python
+# app/plugin/service.py
+def upload_plugin(*, db: Session, user: User, payload: PluginUploadRequest) -> Plugin:
+    """비즈니스 로직만. HTTP 관심사 없음."""
+```
+- 키워드 전용 인자(`*`), 첫 인자로 `db: Session`
+- 반환은 모델 또는 도메인 객체 — `JSONResponse`/`HTTPException` 금지
+- 실패는 `core/exceptions.py`의 도메인 예외로 raise
+
+### 라우터의 역할 (이것만 남긴다)
+1. 요청 파싱/검증 (pydantic 스키마)
+2. 인증/인가 dependency
+3. service 호출
+4. 응답 변환 (+ 도메인 예외 → HTTPException 매핑은 전역 핸들러가 담당)
+
+### 추출 방법 (동작 보존)
+1. 엔드포인트 본문을 그대로 service 함수로 복사-이동 (copy-paste refactoring)
+2. HTTP 관심사(HTTPException, status_code, Response 객체)를 경계 밖으로 밀어내기
+3. characterization 테스트(PR-1)로 전후 동일성 확인
+4. service 단위 테스트 신규 작성 — **이 단계에서 커버리지를 만든다** (도메인 service 80% 목표)
+5. 한 엔드포인트씩 커밋 — 커밋당 리뷰 가능 단위 유지
+
+### 응답 형태 절대 불변
+JSON 키, 상태코드, 에러 메시지 문자열까지 유지 (OpenAPI diff 0 + characterization 테스트로 검증).
+
+---
+
+## PR-5: plugin 서비스 (`refactor/v107-05-plugin-service`)
+
+대상: `plugin/router.py` 1,616줄 → 목표 ~400줄
+
+### 추출 대상 (엔드포인트 → 서비스 함수)
+| 현재 엔드포인트 로직 | 서비스 함수 | 비고 |
+|---|---|---|
+| `upload_plugin()` 250줄+ | `service.upload_plugin()` — 내부를 단계 함수로 분해: `_save_plugin_files()`, `_build_image()`(→ `builder.py` 위임), `_upsert_plugin()`, `_rollback_upload()` | 파일 I/O·Docker 빌드·DB upsert·Celery 디스패치·롤백이 한 함수에 있음 |
+| 플러그인 목록/상세/삭제 | `service.list_plugins()`, `get_plugin()`, `delete_plugin()` | CRUD 위임 위주 |
+| 빌드 상태/로그 조회 | `service.get_build_status()` | |
+| 공식 플러그인 sync 관련 | 기존 `plugin/sync.py` 재사용, router에서 직접 로직 금지 |
+
+### 체크리스트
+- [ ] Docker 빌드 로직을 `plugin/builder.py`로 위임 (utils.py에서 빌드 관련 호출부만 — utils 내부 분할은 PR-9)
+- [ ] 롤백 로직을 명시적 함수로 분리하고 단위 테스트 (실패 주입 테스트: 빌드 실패 시 파일/DB 원복)
+- [ ] `plugin/router.py` 400줄 이하 확인
+- [ ] service 단위 테스트 (Docker 모킹)
+
+---
+
+## PR-6: workflow 서비스 (`refactor/v107-06-workflow-service`)
+
+대상: `workflow/router.py` 988줄
+
+### 추출 대상
+| 현재 | 서비스 함수 |
+|---|---|
+| `compileWorkflow()` 200줄+ (DAG 파싱→경로 해석→Snakefile 생성→캐싱 인라인) | `service.compile_workflow()` — 파이프라인 단계 함수: `_parse_dag()`, `_resolve_paths()`, `_generate_snakefile()`, `_cache_result()` (compiler/ 모듈 위임) |
+| 워크플로우 CRUD 엔드포인트 | `service.create/get/list/update/delete_workflow()` |
+
+### 체크리스트
+- [ ] compile 파이프라인의 각 단계가 `workflow/compiler/*`를 호출하는 구조로 정리 (파서 내부 수정은 PR-10)
+- [ ] 캐시 적중/미적중 경로 characterization 테스트 통과
+- [ ] service 단위 테스트 (파서는 실제, 파일시스템은 tmp_path)
+
+---
+
+## PR-7: task 서비스 + SSE 분리 (`refactor/v107-07-task-service`)
+
+대상: `task/router.py` 1,447줄
+
+### 추출 대상
+| 현재 | 이동 후 |
+|---|---|
+| `get_task_status()` SSE 루프 80줄+ (수동 타임아웃·리소스 정리) | `task/sse.py` — 제너레이터/스트리밍 유틸로 분리, router는 `EventSourceResponse(sse.stream_task_status(...))` 형태 |
+| 태스크 생성·Celery 디스패치 (15+ kwargs 인라인) | `service.submit_task()` + **kwargs를 pydantic 스키마로 타입화**: `task/schemas.py`에 `TaskSubmission(BaseModel)` 정의, `.dict()`로 디스패치 |
+| 태스크 취소/재시도/결과 조회 | `service.cancel_task()`, `get_task_result()` 등 |
+
+### Celery 디스패치 타입화 (이 PR의 핵심 개선)
+```python
+# task/schemas.py (pydantic v1 문법)
+class TaskSubmission(BaseModel):
+    user_id: int
+    workflow_id: int
+    algorithm_id: Optional[int]
+    plugin_name: str
+    cache_key: Optional[str]
+    # ... 현재 celery_tasks.py 태스크 시그니처의 kwargs 전부 명시
+
+# task/service.py
+def submit_task(*, db: Session, user: User, payload: ...) -> Task:
+    submission = TaskSubmission(...)
+    celery_task = run_pipeline.apply_async(kwargs=submission.dict(), ...)
+```
+- [ ] `worker/tasks.py` 쪽에서도 수신 시 같은 스키마로 파싱 → 런타임 검증
+- [ ] **와이어 포맷(kwargs 키 이름) 불변** — 구버전 워커/신버전 웹 혼재 배포 호환
+
+### 체크리스트
+- [ ] SSE 이벤트 포맷·종료 조건 characterization 테스트 통과
+- [ ] 타임아웃/정리(finally) 로직이 sse.py로 이동 후에도 동일 동작
+- [ ] service + sse 단위 테스트
+
+---
+
+## PR-8: 나머지 도메인 + 전역 예외 처리 (`refactor/v107-08-remaining-services`)
+
+### 1. 전역 예외 핸들러 (이 PR에서 도입 — 이후 전 도메인에 적용됨)
+- [ ] `core/exceptions.py`에 도메인 예외 계층 정의:
+```python
+class CellcraftError(Exception):
+    """도메인 예외 베이스"""
+class NotFoundError(CellcraftError): ...
+class PermissionDeniedError(CellcraftError): ...
+class ValidationFailedError(CellcraftError): ...
+class ExternalServiceError(CellcraftError): ...   # Docker/GitHub/Redis
+```
+- [ ] `main.py`(create_app)에 `app.add_exception_handler(...)` 등록 — 기존 엔드포인트가 내던 상태코드·응답 형태와 동일하게 매핑
+- [ ] PR-5~7에서 추출한 서비스들의 HTTPException 잔재를 도메인 예외로 교체 (응답 불변 확인)
+
+### 2. file 서비스
+| 현재 | 이동 후 |
+|---|---|
+| `file/router.py` 598줄의 업로드/다운로드/삭제 인라인 로직 | `file/service.py` (`save_upload()`, `resolve_download()`, `delete_file()`) |
+| 경로 검증 산재 | `file/security.py` 호출을 service 경유로 일원화 |
+
+### 3. admin 서비스
+- [ ] `admin/router.py` 760줄 → 통계/사용자 관리/시스템 관리 로직을 `admin/service.py`로
+- [ ] 타 도메인 데이터 접근은 해당 도메인 service 경유 (admin이 crud 직접 접근하는 부분 정리)
+
+### 4. auth·user·datatable 서비스
+- [ ] `auth/service.py`: 로그인/토큰 발급 (`security.py` 활용), router는 OAuth2 폼 처리만
+- [ ] `user/service.py`: 가입/조회/수정
+- [ ] `datatable/service.py`: h5ad 조회·캐싱 오케스트레이션 (h5ad.py/cache.py 위임)
+
+### 체크리스트
+- [ ] 전 도메인 router에서 `try/except + HTTPException` 반복 패턴 제거 (전역 핸들러로 대체)
+- [ ] 에러 응답 본문·상태코드 불변 (characterization + OpenAPI diff)
+- [ ] import-linter 계약 추가: `router는 crud를 직접 import하지 않는다` (가능한 도메인부터 단계 적용)
+
+---
+
+## Phase 3 완료 기준
+- [ ] 8개 router 파일 각각 500줄 이하
+- [ ] 모든 도메인에 `service.py` 존재, 신규 service 단위 테스트 커버리지 80%+
+- [ ] router에 남은 것: 파싱/deps/service 호출/응답 변환뿐
+- [ ] 공통 머지 게이트 4종 (PR별)

--- a/docs/refactoring/v1.0.7/phase-4-monolith-split.md
+++ b/docs/refactoring/v1.0.7/phase-4-monolith-split.md
@@ -1,0 +1,75 @@
+# Phase 4 — 모놀리스 utils 내부 분할 (PR-9, PR-10)
+
+> 예상: 2~3일 | 위험도: 중간 | 선행: PR-5(plugin), PR-6(workflow) 머지 (각 해당 PR만)
+> **원칙: 함수 시그니처·동작 불변. 파일 내부를 책임별 모듈로 쪼개는 것이 전부.** 파일당 800줄 이하 목표.
+
+---
+
+## PR-9: plugin_utils.py 분할 (`refactor/v107-09-split-plugin-utils`)
+
+대상: `plugin/utils.py` (구 `common/utils/plugin_utils.py`, 2,220줄)
+
+### 절차
+1. 파일 내 함수/클래스를 책임별로 그룹핑 (착수 시 실제 코드 기준으로 확정 — 아래는 예상 분류)
+2. 그룹별로 새 모듈로 이동:
+
+| 예상 그룹 | 이동 후 |
+|---|---|
+| Docker 이미지 빌드/태깅/푸시 | `plugin/builder.py` (PR-5에서 생성된 파일에 통합) |
+| 플러그인 파일 저장/검증/압축 해제 | `plugin/files.py` |
+| 플러그인 메타데이터 파싱(config/schema) | `plugin/metadata.py` |
+| 플러그인 실행 준비(컨테이너 인자 조립 등) | `plugin/runtime.py` |
+| 나머지 순수 헬퍼 | `plugin/utils.py`에 잔류 (300줄 이하 목표) |
+
+3. `plugin/service.py`·`worker/tasks.py` 등 호출부 import 갱신
+4. 각 모듈 단위 테스트 보강 (분할 과정에서 발견되는 죽은 코드는 **삭제하지 말고 목록만 기록** — 삭제는 별도 PR)
+
+### 체크리스트
+- [ ] 모든 신규 모듈 800줄 이하
+- [ ] `plugin/` 내부 지연 import(함수 내부 import) 제거 — 순환이 있으면 모듈 경계 재조정으로 해결
+- [ ] 공통 머지 게이트 4종 + plugin characterization 테스트 통과
+
+---
+
+## PR-10: snakefile_dag_parser 분할 + 지연 import 정리 (`refactor/v107-10-split-dag-parser`)
+
+### 1. `workflow/compiler/dag_parser.py` (2,227줄) 분할
+| 예상 그룹 | 이동 후 |
+|---|---|
+| Snakefile 토크나이징/파싱 코어 | `workflow/compiler/parsing.py` |
+| DAG 구성/노드·엣지 모델 | `workflow/compiler/dag.py` |
+| 규칙(rule) 해석/와일드카드 처리 | `workflow/compiler/rules.py` |
+| 출력 직렬화(프론트용 그래프 변환) | `workflow/compiler/serialize.py` |
+| 공개 API (기존 함수 시그니처 유지) | `workflow/compiler/dag_parser.py` — 파사드로 잔류, 내부 모듈 위임 |
+
+- **파사드 유지**: 외부 호출부는 `dag_parser`의 기존 함수명을 그대로 사용 → 호출부 수정 최소화
+
+### 2. `workflow/utils.py` (1,215줄) 검토
+- [ ] compile 파이프라인 관련은 `compiler/`로, 나머지는 service로 흡수 가능한지 분류
+- [ ] 800줄 초과 시 분할, 이하로 정리되면 유지
+
+### 3. `file/storage.py` + `file/path_resolver.py` 통합 검토 (PR-4에서 보류한 항목)
+- [ ] 중복 로직 확인 후 `file/storage.py`로 통합 또는 역할 명확화
+
+### 4. 지연 import 제거 (전역)
+PR-2~9를 거치며 대부분 해소되지만 잔여분 일괄 정리:
+- [ ] `grep -rn "^\s\+import \|^\s\+from " backend/app --include="*.py"`로 함수 내부 import 전수 조사
+- [ ] 각 건에 대해: (a) 순환 의존이 원인이면 모듈 경계 수정, (b) 무거운 모듈 지연 로딩이 목적이면 주석으로 사유 명시 후 유지
+- [ ] import-linter 최종 계약 활성화:
+  - 도메인 간 직접 crud 접근 금지
+  - `shared/` → 도메인 import 금지
+  - `worker/` → `main`/`api` import 금지
+
+### 체크리스트
+- [ ] workflow compile characterization 테스트 통과 (파싱 결과 스냅샷 비교 권장 — 대표 Snakefile 3~5개에 대한 파서 출력 고정)
+- [ ] 공통 머지 게이트 4종
+
+---
+
+## Phase 4 완료 = v1.0.7 리팩토링 완료 기준
+- [ ] `backend/app` 내 800줄 초과 파일 0개
+- [ ] 함수 내부 지연 import 0건 (사유 명시된 예외 제외)
+- [ ] import-linter 전 계약 통과
+- [ ] OpenAPI 스냅샷: Phase 0 대비 diff 0
+- [ ] DB 스키마: Phase 0 대비 revision 0개
+- [ ] 최종 회귀: 전체 pytest + docker compose 스모크 + 실제 워크플로우 1건 end-to-end 실행

--- a/docs/refactoring/v1.0.7/phase-5-backlog.md
+++ b/docs/refactoring/v1.0.7/phase-5-backlog.md
@@ -1,0 +1,47 @@
+# Phase 5 — 백로그 (v1.0.7 범위 제외)
+
+v1.0.7 리팩토링(Phase 0~4)이 완료된 후, 별도 릴리즈에서 진행할 항목.
+Phase 0~4가 만든 구조(서비스 계층, 도메인 경계, 계약 테스트) 덕분에 아래 작업들의 위험이 크게 줄어든다.
+
+## 1. 프레임워크 업그레이드 (최우선 백로그, 일괄 진행 필요)
+
+| 항목 | 현재 | 목표 | 비고 |
+|---|---|---|---|
+| FastAPI | 0.78.0 (2022) | 최신 | Pydantic v2와 함께 올려야 함 |
+| Pydantic | 1.9.1 | 2.x | 전 스키마 마이그레이션 (`bump-pydantic` 도구 활용). Phase 2~3에서 스키마가 도메인별로 분리되어 있어 도메인 단위 진행 가능 |
+| SQLAlchemy | 1.4.36 | 2.0 | 1.4는 2.0 스타일 과도기 지원 → 먼저 1.4에서 `future=True`로 2.0 스타일 쿼리로 전환 후 버전 업 |
+| Starlette/uvicorn | 0.19/0.17 | FastAPI에 종속 | |
+
+**순서 권고**: SQLAlchemy 2.0 스타일 전환(1.4 유지) → Pydantic v2 + FastAPI 동시 업그레이드 → `@app.on_event` → lifespan 전환
+
+**주의**: conda `environment.yml`(snakemake 7.14 고정)과의 의존성 충돌 사전 검증 필요.
+
+## 2. 비동기 전환 (선택적·부분적)
+- 파일 업로드, SSE, 외부 API(GitHub registry) 호출 등 I/O 바운드 경로부터 부분 적용
+- DB 비동기(asyncpg + SQLAlchemy async)는 전면 전환 비용이 크므로 실측(응답 지연·동시성 병목) 후 결정 — "Measure First"
+- 현재 sync Celery 구조와의 일관성 고려
+
+## 3. 인증 강화
+- [ ] Refresh token 도입 (현재 32시간 단일 액세스 토큰)
+- [ ] 토큰 폐기(revocation) — Redis 블랙리스트
+- [ ] 로그인 rate limiting
+- [ ] `SECRET_KEY` 로테이션 절차 문서화
+
+## 4. 전역 상태 제거
+- [ ] `shared/docker.py`의 `container_manager` 싱글턴 → 명시적 수명주기 관리 (app.state 또는 dependency 주입, 스레드 안전성 확보)
+- [ ] Redis 커넥션 풀 lazy 생성 → 앱 기동 시 초기화 + 헬스체크
+
+## 5. 관측성(Observability)
+- [ ] `core/startup.py`의 print 로깅 → 구조화 로깅(logging + JSON formatter) 통일
+- [ ] 요청 ID 미들웨어 + Celery 태스크 상관관계 ID
+- [ ] Sentry 또는 동급 에러 트래킹 (uptime-kuma 모니터링과 연계)
+
+## 6. Celery 파이프라인 개선
+- [ ] 태스크 멱등성 보장 (재시도 안전)
+- [ ] 엔드포인트 트랜잭션과 태스크 디스패치 사이 원자성 (transactional outbox 또는 커밋 후 디스패치 패턴)
+- [ ] 죽은 코드/미사용 태스크 정리 (PR-9~10에서 기록한 죽은 코드 목록 처리)
+
+## 7. 테스트 인프라
+- [ ] Docker/GitHub 통합 테스트용 공식 모킹 레이어 (현재 개별 테스트에서 임시 모킹)
+- [ ] E2E: 대표 워크플로우 실행 시나리오 자동화 (CI nightly)
+- [ ] 커버리지 게이트 CI 통합 (80% 기준)

--- a/docs/refactoring/v1.0.7/pr-template.md
+++ b/docs/refactoring/v1.0.7/pr-template.md
@@ -1,0 +1,45 @@
+# 리팩토링 PR 본문 템플릿
+
+모든 `refactor/v107-*` PR은 아래 템플릿을 사용한다. base 브랜치: `release/v1.0.7`.
+
+```markdown
+## refactor(v1.0.7): <PR 제목>
+
+**Phase**: <0~4> | **PR 번호**: PR-<n> | **계획 문서**: docs/refactoring/v1.0.7/phase-<n>-*.md
+**선행 PR**: PR-<n-1> (머지 완료 여부: ✅/⬜)
+
+### 범위
+- <이 PR이 하는 것>
+
+### 범위 아님
+- <이 PR이 의도적으로 하지 않는 것 — 후속 PR 번호 명시>
+
+### 변경 유형
+- [ ] 파일 이동만 (로직 변경 0)
+- [ ] 서비스 추출 (동작 보존)
+- [ ] 모듈 분할 (시그니처 보존)
+- [ ] 신규 테스트/도구
+
+### 머지 게이트 결과 (필수 첨부)
+| 게이트 | 결과 |
+|---|---|
+| 1. pytest 전체 (baseline 대비 실패 증가 0) | ⬜ 통과 / 로그: |
+| 2. OpenAPI 스냅샷 diff == 0 | ⬜ 통과 (의도된 diff 있으면 사유:) |
+| 3. alembic autogenerate == 빈 마이그레이션 | ⬜ 통과 |
+| 4. docker compose 스모크 (웹 + 워커 기동) | ⬜ 통과 |
+| (해당 시) celery inspect registered 이름 불변 | ⬜ 통과 |
+| (해당 시) import-linter 계약 | ⬜ 통과 |
+
+### 리뷰 가이드
+- 이동 커밋과 로직 커밋이 분리되어 있음: <커밋 해시 안내>
+- 이동 매핑표: <phase 문서 링크 또는 표>
+
+### 롤백
+- `git revert <merge commit>` 로 롤백 가능 (DB 스키마 변경 없음)
+- <PR-2만: Dockerfile CMD 원복 절차>
+```
+
+## 커밋 규칙
+- 타입: `refactor:` (도구/테스트 추가는 `test:`, `chore:`)
+- 이동 커밋은 `git mv`만 포함, 메시지에 `[move-only]` 표기
+- 예: `refactor: [move-only] common/utils 플러그인 모듈을 plugin/ 도메인으로 이동`


### PR DESCRIPTION
## refactor(v1.0.7): 안전망 구축 (PR-1)

**Phase**: 0 | **PR 번호**: PR-1 | **계획 문서**: docs/refactoring/v1.0.7/phase-0-safety-net.md
**선행 PR**: 없음 (모든 후속 리팩토링 PR의 게이트 기준)

### 범위
- v1.0.7 리팩토링 마스터 플랜 + Phase별 실행 계획 문서 (docs/refactoring/v1.0.7/)
- OpenAPI 계약 스냅샷 테스트 (paths 104, schemas 40) + 갱신 스크립트
- 핵심 경로 characterization 테스트 5종 30건 (auth / plugin upload / workflow compile / task status / file upload) — 현재 동작 실측 고정
- 격리 테스트 스택 (docker-compose.test.yml + Dockerfile.test + requirements-test.txt)
- pytest baseline 리포트 (게이트 기준: 목록 외 신규 실패 = 리그레션)
- import-linter 계약 사전 정의 (PR-2 활성화)
- **버그 수정**: 빈 DB에서 alembic 초기 마이그레이션 실패 (plugintype enum 중복 생성) — create_all 제거(709042e) 이후 신규 설치 차단 버그

### 범위 아님
- 앱 코드 리팩토링 (PR-2~10), 프레임워크 업그레이드 (Phase 5 백로그)

### 변경 유형
- [x] 신규 테스트/도구
- [x] 버그 수정 1건 (alembic 마이그레이션 — 기존 배포 DB는 stamp만 되어 있어 영향 없음)

### 머지 게이트 결과
| 게이트 | 결과 |
|---|---|
| 1. pytest 전체 | ✅ 448 passed / 68 failed(기존 드리프트, baseline에 분류 기록) / 3 skipped — 신규 테스트 30건 전부 통과 |
| 2. OpenAPI 스냅샷 | ✅ 생성 및 계약 테스트 통과 |
| 3. alembic | ✅ 스키마 변경 없음 (마이그레이션 수정은 fresh-install 경로만 영향) |
| 4. 스모크 | ✅ 격리 스택에서 앱 import + 마이그레이션 + 테스트 실행 검증 |

### 리뷰 가이드
- 커밋 5개가 논리 단위로 분리됨 (계획 문서 / db fix / 테스트 / 테스트 인프라 / baseline)
- baseline 68건 실패는 이 PR이 만든 것이 아니라 **이전부터 존재하던 실패의 최초 기록** (백엔드 CI 부재로 드리프트). 상세: docs/refactoring/v1.0.7/baseline-test-report.txt

### 롤백
- `git revert` 로 롤백 가능 (DB 스키마 변경 없음)