### PR TITLE
refactor(v1.0.7) PR-7: task 서비스 추출 + SSE 분리 — router 1,449줄 → 245줄

### DIFF
--- a/backend/app/task/router.py
+++ b/backend/app/task/router.py
@@ -1,30 +1,23 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 from sse_starlette.sse import EventSourceResponse
 from typing import Any, List, Dict, Optional
 from sqlalchemy.orm import Session
-import asyncio
-from datetime import datetime
-import json
-import io
 
-from app.worker.utils import get_task_info
-from app.shared.docker import container_manager
-from app.workflow.compiler.dag_parser import SnakemakeDAGParser, SnakemakeRuleStatusTracker
-from app.workflow.compiler.native_parser import (
-    parse_snakefile_native, 
-    SnakemakeNativeError
-)
-from app.task import crud as crud_task
-from app.workflow import crud as crud_workflow
-from app.plugin import crud as crud_plugin
-from app.task.schemas import TaskMonitoringResponse, TaskMonitoringItem, PluginInfo
+from app.task.schemas import TaskMonitoringItem
 from app.auth import deps as dep
 from app import models
-from app.core.enums import PluginType
-import os
-from pathlib import Path
-import time
+from app.task import service
+from app.task import sse
+
+# --- Test-patch compatibility re-exports ---------------------------------
+# The business logic now lives in ``app.task.service`` and the SSE streaming in
+# ``app.task.sse``; the router only wires HTTP concerns to them. Existing tests
+# patch these symbols on the service/sse namespaces (e.g.
+# ``app.task.service.parse_snakefile_native``, ``app.task.sse.get_task_info``).
+# A couple of symbols are re-exported here for historical patch compatibility.
+# noqa: F401 imports below are intentional re-exports for test compatibility.
+from app.worker.utils import get_task_info  # noqa: F401
 
 router = APIRouter()
 
@@ -32,12 +25,7 @@ router = APIRouter()
 @router.get("/resources")
 async def get_resources():
     """리소스 할당 현황 및 실행 중 작업 목록 조회"""
-    from app.shared.resources import get_resource_status
-
-    status = get_resource_status()
-    if status is None:
-        raise HTTPException(status_code=503, detail="Resource monitoring unavailable")
-    return status
+    return service.get_resources()
 
 
 @router.get("/info/{task_id}")
@@ -46,40 +34,8 @@ async def get_task_status(task_id: str) -> dict:
     Return the status of the submitted Task.
     SSE 연결은 1시간 타임아웃 및 정리 로직이 적용됩니다.
     """
-    async def event_generator():
-        timeout = 3600  # 1시간 타임아웃 (메모리 누수 방지)
-        start_time = time.time()
-        try:
-            while True:
-                # 타임아웃 체크
-                if time.time() - start_time > timeout:
-                    print(f"SSE timeout reached for task {task_id}")
-                    yield f"TIMEOUT"
-                    break
+    return EventSourceResponse(sse.stream_task_status(task_id))
 
-                if task_id:
-                    task = get_task_info(task_id)
-                    task_status = task.get('task_status', 'UNKNOWN')
-
-                    if task_status in ['SUCCESS', 'FAILURE', 'REVOKED']:
-                        yield f"{task_status}"
-                        break
-
-                    print(f"Task {task_id} status: {task_status}")
-                    yield f"{task_status}"
-                    await asyncio.sleep(5)
-                else:
-                    break
-        except asyncio.CancelledError:
-            # 클라이언트 연결 끊김 처리
-            print(f"SSE connection cancelled for task {task_id}")
-        except Exception as e:
-            print(f"SSE error for task {task_id}: {e}")
-        finally:
-            # 정리 로직 - 리소스 해제
-            print(f"SSE generator cleanup for task {task_id}")
-
-    return EventSourceResponse(event_generator())
 
 @router.get("/status/{task_id}")
 async def get_task_status_simple(task_id: str) -> dict:
@@ -87,14 +43,8 @@ async def get_task_status_simple(task_id: str) -> dict:
     SSE 재연결 판단용 경량 상태 확인 엔드포인트.
     Celery AsyncResult 상태만 반환. 인증 불필요 (SSE 엔드포인트와 동일 패턴).
     """
-    if not task_id or not task_id.strip():
-        raise HTTPException(status_code=400, detail="Invalid task_id")
+    return service.get_task_status_simple(task_id=task_id)
 
-    task = get_task_info(task_id)
-    return {
-        "task_id": task_id,
-        "status": task.get("task_status", "UNKNOWN")
-    }
 
 @router.get("/monitoring", response_model=List[TaskMonitoringItem])
 async def get_task_monitoring(
@@ -107,58 +57,8 @@ async def get_task_monitoring(
     Excludes plugin build tasks and returns only workflow-related tasks.
     Uses optimized queries to prevent N+1 query problems.
     """
-    # Get user tasks with eager-loaded plugin and workflow data (single query)
-    user_tasks = crud_task.get_user_task_with_plugin(db, current_user.id)
-    
-    # Return empty list with 200 OK if no tasks (RESTful response)
-    if not user_tasks:
-        return []
-    
-    # Filter out plugin build tasks, keep only workflow-related tasks
-    workflow_tasks = [task for task in user_tasks if task.task_type != "plugin_build"]
-    
-    # Build response using eager-loaded data (no additional queries needed)
-    tasks_with_workflow = []
-    for task in workflow_tasks:
-        # task_title generation logic
-        task_title = None
-        if task.plugin_name:
-            if task.task_type == 'compile':
-                task_title = task.plugin_name
-            elif task.task_type == 'visualization':
-                task_title = f"{task.plugin_name}-visualization"
-            else:
-                task_title = task.plugin_name  # default value
-        
-        # Plugin information - use eager-loaded data
-        plugin_info = None
-        if task.plugin:
-            plugin_info = PluginInfo(
-                version=task.plugin.version,
-                source=task.plugin.source,
-                plugin_type=task.plugin.plugin_type.value if task.plugin.plugin_type else None
-            )
-        
-        # Use eager-loaded workflow data (no additional query)
-        workflow_title = task.workflows.title if task.workflows else None
-        
-        task_item = TaskMonitoringItem(
-            id=task.id,
-            task_id=task.task_id,
-            workflow_id=task.workflow_id,
-            user_id=task.user_id,
-            status=task.status,
-            start_time=task.start_time,
-            end_time=task.end_time,
-            workflow_title=workflow_title,
-            task_title=task_title,
-            plugin_name=task.plugin_name,
-            task_type=task.task_type,
-            plugin=plugin_info
-        )
-        tasks_with_workflow.append(task_item)
-    
-    return tasks_with_workflow
+    return service.get_task_monitoring(db=db, current_user=current_user)
+
 
 @router.delete("/revoke/{task_id}")
 def revoke_task(
@@ -170,110 +70,8 @@ def revoke_task(
     """
     Revoke the task and cleanup associated containers
     """
-    try:
-        from app.main import get_celery_app
-        celery = get_celery_app()
-        
-        print(f"Attempting to revoke task {task_id}")
-        
-        # 1. 먼저 관련 컨테이너 정보 확인
-        container_id = container_manager.get_container_id(task_id)
-        if container_id:
-            print(f"Found associated container {container_id} for task {task_id}")
-        
-        # 2. Celery 작업 취소
-        celery.control.revoke(task_id, terminate=True, signal='SIGTERM')
-        print(f"Celery revoke command sent for task {task_id}")
-        
-        # 3. 컨테이너 매니저를 통한 컨테이너 강제 정리
-        container_cleanup_success = False
-        if container_id:
-            print(f"Attempting to stop container {container_id}")
-            container_cleanup_success = container_manager.stop_task_container(task_id, timeout=10)
-        
-        # 4. 컨테이너 이름 패턴으로도 정리 시도 (백업 방법)
-        if not container_cleanup_success:
-            print("Attempting container cleanup by name pattern")
-            try:
-                # task_id의 앞 8자리를 사용하여 컨테이너 이름 패턴 매칭
-                task_short_id = task_id[:8]
-                container_name_pattern = f"*task-{task_short_id}*"
-                container_manager.stop_container_by_name(container_name_pattern)
-            except Exception as pattern_error:
-                print(f"Pattern-based container cleanup failed: {pattern_error}")
+    return service.revoke_task(db=db, current_user=current_user, task_id=task_id)
 
-        # 5. Results 폴더 정리 (재실행 시 Snakemake 스킵 방지)
-        results_cleanup_success = False
-        try:
-            task_record = crud_task.get_task_by_task_id(db, task_id)
-            if task_record:
-                if task_record.task_type == 'visualization':
-                    task_folder = f"./user/{current_user.username}/workflow_{task_record.workflow_id}/visualization_{task_record.algorithm_id}"
-                else:
-                    task_folder = f"./user/{current_user.username}/workflow_{task_record.workflow_id}/algorithm_{task_record.algorithm_id}"
-
-                from app.shared.archive import cleanup_task_results
-                cleanup_result = cleanup_task_results(Path(task_folder), preserve_folder=True)
-                results_cleanup_success = cleanup_result["success"]
-
-                if results_cleanup_success:
-                    print(f"Results cleanup completed: {len(cleanup_result.get('files_removed', []))} files removed")
-                else:
-                    print(f"Results cleanup failed: {cleanup_result.get('error')}")
-        except Exception as cleanup_error:
-            print(f"Results cleanup failed: {cleanup_error}")
-
-        # 6. 작업 상태 확인 및 DB 업데이트
-        task = get_task_info(task_id)
-        print(f"Task info after revoke: {task}")
-
-        task_status = task.get("status")
-        if task_status == 'REVOKED':
-            return {
-                "message": "Task Revoked Successfully",
-                "task_id": task_id,
-                "container_cleanup": container_cleanup_success,
-                "results_cleanup": results_cleanup_success
-            }
-        else:
-            # 태스크 상태를 'REVOKED'로 강제 업데이트
-            crud_task.end_task(current_user.id, task_id, datetime.now(), 'REVOKED')
-            print(f"Forced task status update to REVOKED for task {task_id}")
-
-            # 업데이트 후 다시 확인
-            task = get_task_info(task_id)
-            task_status = task.get("status")
-
-            if task_status == 'REVOKED':
-                return {
-                    "message": "Task Revoked Successfully (Forced Update)",
-                    "task_id": task_id,
-                    "container_cleanup": container_cleanup_success,
-                    "results_cleanup": results_cleanup_success
-                }
-            else:
-                return {
-                    "message": "Task Revoke Completed with Warnings",
-                    "task_id": task_id,
-                    "warning": "Task status update may be delayed",
-                    "container_cleanup": container_cleanup_success,
-                    "results_cleanup": results_cleanup_success
-                }
-    
-    except Exception as e:
-        print(f"Error during task revocation: {str(e)}")
-        
-        # 오류 발생 시에도 컨테이너 정리 시도
-        try:
-            container_manager.stop_task_container(task_id, timeout=5)
-        except Exception as cleanup_error:
-            print(f"Emergency container cleanup failed: {cleanup_error}")
-        
-        return {
-            "message": "Task Revoke Failed", 
-            "task_id": task_id,
-            "error": str(e)
-        }
 
 @router.delete("/delete/{task_id}")
 def delete_task(
@@ -285,8 +83,8 @@ def delete_task(
     """
     Delete the task
     """
-    task = crud_task.delete_user_task(db, current_user.id, task_id)
-    return {"message": "Task Deleted", "task_id": task_id}
+    return service.delete_task(db=db, current_user=current_user, task_id=task_id)
+
 
 @router.get("/containers/status")
 def get_container_status(
@@ -295,63 +93,8 @@ def get_container_status(
     """
     Get current container status for debugging
     """
-    client = None  # Docker 클라이언트 누수 방지를 위해 초기화
-    try:
-        import docker
-        client = docker.from_env()
+    return service.get_container_status(current_user=current_user)
 
-        # 실행 중인 플러그인 컨테이너 조회
-        containers = client.containers.list(
-            filters={"label": "container.type=plugin-execution"}
-        )
-
-        container_info = []
-        for container in containers:
-            labels = container.labels
-
-            # 환경변수에서 CELERY_TASK_ID 찾기
-            env_task_id = "unknown"
-            env_vars = container.attrs.get('Config', {}).get('Env', [])
-            for env in env_vars:
-                if env.startswith('CELERY_TASK_ID='):
-                    env_task_id = env.split('=', 1)[1]
-                    break
-
-            container_info.append({
-                "id": container.id[:12],
-                "name": container.name,
-                "status": container.status,
-                "task_id_label": labels.get("celery.task_id", "unknown"),
-                "task_id_env": env_task_id,
-                "plugin_name": labels.get("plugin.name", "unknown"),
-                "created": str(container.attrs["Created"]),
-                "is_tracked": container.id in container_manager._container_tasks
-            })
-
-        # 컨테이너 매니저 상태 추가
-        manager_status = container_manager.get_status()
-
-        return {
-            "running_containers": len(container_info),
-            "containers": container_info,
-            "container_manager": manager_status,
-            "orphaned_containers": [
-                c for c in container_info
-                if not c["is_tracked"] and c["task_id_label"] != "unknown"
-            ]
-        }
-
-    except Exception as e:
-        return {
-            "error": f"Failed to get container status: {str(e)}"
-        }
-    finally:
-        # Docker 클라이언트 연결 해제 - TCP 소켓 누수 방지
-        if client:
-            try:
-                client.close()
-            except Exception:
-                pass
 
 @router.get("/logs/{task_id}")
 def get_task_logs(
@@ -363,82 +106,8 @@ def get_task_logs(
     """
     특정 task의 로그 파일들을 조회합니다.
     """
-    from app.file.storage import construct_logs_path, is_safe_path, get_logs_base_path
+    return service.get_task_logs(db=db, current_user=current_user, task_id=task_id)
 
-    try:
-        # task_id로 task 정보 조회
-        task = crud_task.get_task_by_task_id(db, task_id)
-        if not task:
-            raise HTTPException(status_code=404, detail="Task not found")
-
-        # 권한 확인 (해당 유저의 task인지 확인)
-        if task.user_id != current_user.id:
-            raise HTTPException(status_code=403, detail="Access denied")
-
-        # 로그 폴더 경로 구성 (centralized utility 사용)
-        # task_id를 전달하여 아카이브된 로그가 있으면 해당 경로 사용
-        logs_folder_path = construct_logs_path(
-            username=current_user.username,
-            workflow_id=task.workflow_id,
-            algorithm_id=task.algorithm_id,
-            task_type=task.task_type,
-            task_id=task.task_id
-        )
-
-        # 보안 검증: path traversal 방지
-        if not is_safe_path(logs_folder_path, get_logs_base_path()):
-            raise HTTPException(status_code=400, detail="Invalid path")
-
-        if not os.path.exists(logs_folder_path):
-            raise HTTPException(status_code=404, detail="Logs folder not found")
-
-        # 로그 파일들 읽기
-        log_files = []
-        logs_path = Path(logs_folder_path)
-
-        for log_file_path in logs_path.glob("*"):
-            if log_file_path.is_file():
-                # 각 파일도 안전성 검증
-                if not is_safe_path(str(log_file_path), get_logs_base_path()):
-                    continue  # Skip unsafe files (e.g., symlinks outside base dir)
-
-                try:
-                    with open(log_file_path, 'r', encoding='utf-8') as f:
-                        content = f.read()
-                    log_files.append({
-                        "filename": log_file_path.name,
-                        "content": content,
-                        "size": log_file_path.stat().st_size,
-                        "modified_time": str(log_file_path.stat().st_mtime)
-                    })
-                except Exception as e:
-                    # 파일 읽기 실패 시에도 파일 정보는 포함
-                    log_files.append({
-                        "filename": log_file_path.name,
-                        "content": f"Error reading file: {str(e)}",
-                        "size": log_file_path.stat().st_size,
-                        "modified_time": str(log_file_path.stat().st_mtime)
-                    })
-
-        # run.log 파일을 맨 앞으로 정렬
-        log_files.sort(key=lambda x: (x["filename"] != "run.log", x["filename"]))
-
-        return {
-            "logs": log_files,
-            "task_info": {
-                "task_id": task.task_id,
-                "workflow_id": task.workflow_id,
-                "algorithm_id": task.algorithm_id,
-                "status": task.status,
-                "start_time": str(task.start_time),
-                "end_time": str(task.end_time) if task.end_time else None
-            }
-        }
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error retrieving logs: {str(e)}")
 
 @router.get("/logs/{task_id}/export/json")
 def export_task_logs_json(
@@ -451,75 +120,8 @@ def export_task_logs_json(
     특정 task의 모든 로그 파일들을 JSON 형식으로 export합니다.
     JSON 형태: {"filename1.log": "content1", "filename2.log": "content2"}
     """
-    from app.file.storage import construct_logs_path, is_safe_path, get_logs_base_path
+    return service.export_task_logs_json(db=db, current_user=current_user, task_id=task_id)
 
-    try:
-        # task_id로 task 정보 조회
-        task = crud_task.get_task_by_task_id(db, task_id)
-        if not task:
-            raise HTTPException(status_code=404, detail="Task not found")
-
-        # 권한 확인 (해당 유저의 task인지 확인)
-        if task.user_id != current_user.id:
-            raise HTTPException(status_code=403, detail="Access denied")
-
-        # 로그 폴더 경로 구성
-        # task_id를 전달하여 아카이브된 로그가 있으면 해당 경로 사용
-        logs_folder_path = construct_logs_path(
-            username=current_user.username,
-            workflow_id=task.workflow_id,
-            algorithm_id=task.algorithm_id,
-            task_type=task.task_type,
-            task_id=task.task_id
-        )
-
-        # 보안 검증
-        if not is_safe_path(logs_folder_path, get_logs_base_path()):
-            raise HTTPException(status_code=400, detail="Invalid path")
-
-        if not os.path.exists(logs_folder_path):
-            raise HTTPException(status_code=404, detail="Logs folder not found")
-
-        # 모든 로그 파일을 JSON 형태로 수집
-        logs_data = {}
-        logs_path = Path(logs_folder_path)
-
-        for log_file_path in logs_path.glob("*"):
-            if log_file_path.is_file():
-                # 보안 검증: 각 파일이 안전한지 확인
-                if not is_safe_path(str(log_file_path), get_logs_base_path()):
-                    continue  # Skip unsafe files
-
-                try:
-                    with open(log_file_path, 'r', encoding='utf-8') as f:
-                        content = f.read()
-                    logs_data[log_file_path.name] = content
-                except Exception as e:
-                    # 파일 읽기 실패 시 에러 정보 포함
-                    logs_data[log_file_path.name] = f"Error reading file: {str(e)}"
-
-        if not logs_data:
-            raise HTTPException(status_code=404, detail="No log files found")
-
-        # JSON으로 변환
-        json_content = json.dumps(logs_data, indent=2, ensure_ascii=False)
-
-        # 파일명 생성 (타임스탬프 포함)
-        from datetime import datetime
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"task_{task_id[:8]}_logs_{timestamp}.json"
-
-        # StreamingResponse로 다운로드 제공
-        return StreamingResponse(
-            io.StringIO(json_content),
-            media_type="application/json",
-            headers={"Content-Disposition": f"attachment; filename={filename}"}
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error exporting logs as JSON: {str(e)}")
 
 @router.get("/logs/{task_id}/export/txt/{filename}")
 def export_task_log_txt(
@@ -532,79 +134,9 @@ def export_task_log_txt(
     """
     특정 task의 개별 로그 파일을 TXT 형식으로 export합니다.
     """
-    from app.file.storage import (
-        construct_logs_path,
-        is_safe_path,
-        get_logs_base_path,
-        validate_export_filename
+    return service.export_task_log_txt(
+        db=db, current_user=current_user, task_id=task_id, filename=filename
     )
-
-    try:
-        # 파일명 보안 검증 (path traversal 방지)
-        if not validate_export_filename(filename, task_id):
-            raise HTTPException(status_code=400, detail="Invalid filename")
-
-        # task_id로 task 정보 조회
-        task = crud_task.get_task_by_task_id(db, task_id)
-        if not task:
-            raise HTTPException(status_code=404, detail="Task not found")
-
-        # 권한 확인 (해당 유저의 task인지 확인)
-        if task.user_id != current_user.id:
-            raise HTTPException(status_code=403, detail="Access denied")
-
-        # 로그 폴더 경로 구성
-        # task_id를 전달하여 아카이브된 로그가 있으면 해당 경로 사용
-        logs_folder_path = construct_logs_path(
-            username=current_user.username,
-            workflow_id=task.workflow_id,
-            algorithm_id=task.algorithm_id,
-            task_type=task.task_type,
-            task_id=task.task_id
-        )
-
-        # 보안 검증: 폴더 경로
-        if not is_safe_path(logs_folder_path, get_logs_base_path()):
-            raise HTTPException(status_code=400, detail="Invalid path")
-
-        # 요청된 로그 파일 경로
-        log_file_path = Path(logs_folder_path) / filename
-
-        # 보안 검증: 최종 파일 경로
-        if not is_safe_path(str(log_file_path), get_logs_base_path()):
-            raise HTTPException(status_code=400, detail="Invalid file path")
-
-        if not log_file_path.exists():
-            raise HTTPException(status_code=404, detail=f"Log file '{filename}' not found")
-
-        if not log_file_path.is_file():
-            raise HTTPException(status_code=400, detail=f"'{filename}' is not a valid file")
-
-        # 파일 읽기
-        try:
-            with open(log_file_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Error reading file: {str(e)}")
-
-        # 다운로드용 파일명 생성 (타임스탬프 포함)
-        from datetime import datetime
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        base_name = Path(filename).stem
-        extension = Path(filename).suffix or ".txt"
-        download_filename = f"task_{task_id[:8]}_{base_name}_{timestamp}{extension}"
-
-        # StreamingResponse로 다운로드 제공
-        return StreamingResponse(
-            io.StringIO(content),
-            media_type="text/plain",
-            headers={"Content-Disposition": f"attachment; filename={download_filename}"}
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error exporting log file as TXT: {str(e)}")
 
 
 @router.get("/{task_id}/dag-structure")
@@ -617,102 +149,7 @@ async def get_dag_structure(
     """
     특정 Task의 Snakefile을 파싱하여 DAG 구조를 반환합니다.
     """
-    import logging
-    from app.workflow.compiler.dag_parser import DAGParsingError
-    
-    logger = logging.getLogger(__name__)
-    
-    try:
-        # 입력 검증
-        if not task_id or not task_id.strip():
-            raise HTTPException(status_code=400, detail="Invalid task_id")
-        
-        # Task 정보 조회
-        task = crud_task.get_task_by_task_id(db, task_id)
-        if not task:
-            logger.warning(f"Task not found: {task_id}")
-            raise HTTPException(status_code=404, detail="Task not found")
-        
-        # 권한 확인
-        if task.user_id != current_user.id:
-            logger.warning(f"Access denied for user {current_user.id} to task {task_id}")
-            raise HTTPException(status_code=403, detail="Access denied")
-        
-        # Snakefile 경로 구성
-        try:
-            if task.task_type == 'visualization':
-                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}/Snakefile"
-            else:
-                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}/Snakefile"
-        except AttributeError as e:
-            logger.error(f"Missing task attributes for DAG structure: {e}")
-            raise HTTPException(status_code=400, detail="Invalid task data")
-        
-        logger.info(f"Parsing DAG structure for task {task_id}, snakefile: {snakefile_path}")
-        
-        # Snakefile 파싱 (네이티브 파서 우선 사용, 실패 시 레거시 파서로 fallback)
-        dag_data = None
-        parsing_method = "unknown"
-        
-        try:
-            # 1단계: Snakemake 네이티브 파서 시도 (실시간 파싱)
-            logger.info(f"Attempting native Snakemake parsing for task {task_id}")
-            dag_data = parse_snakefile_native(snakefile_path, method='auto')
-            parsing_method = f"native_{dag_data.get('method', 'unknown')}"
-            
-            # DAG 데이터 유효성 검증
-            if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
-                raise ValueError("Invalid DAG data structure from native parser")
-            
-            logger.info(f"Successfully parsed {len(dag_data.get('nodes', []))} rules using native parser ({parsing_method}) for task {task_id}")
-            
-        except (SnakemakeNativeError, ValueError, Exception) as native_error:
-            logger.warning(f"Native parser failed for task {task_id}: {native_error}")
-            
-            try:
-                # 2단계: 레거시 파서로 fallback
-                logger.info(f"Falling back to legacy parser for task {task_id}")
-                parser = SnakemakeDAGParser()
-                dag_data = parser.parse_snakefile_with_logs(snakefile_path)
-                parsing_method = "legacy"
-                
-                # DAG 데이터 유효성 검증
-                if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
-                    logger.error(f"Invalid DAG data structure from legacy parser for task {task_id}")
-                    raise HTTPException(status_code=500, detail="Invalid DAG structure")
-                
-                logger.info(f"Successfully parsed {len(dag_data.get('nodes', []))} rules using legacy parser for task {task_id}")
-                
-            except Exception as legacy_error:
-                # 두 파서 모두 실패한 경우
-                logger.error(f"Both native and legacy parsers failed for task {task_id}. Native: {native_error}, Legacy: {legacy_error}")
-                raise HTTPException(
-                    status_code=500, 
-                    detail=f"Failed to parse workflow with both native and legacy parsers. Last error: {str(legacy_error)}"
-                )
-        
-        # 파싱 방법 정보 추가
-        if dag_data and isinstance(dag_data, dict):
-            dag_data['parsing_method'] = parsing_method
-        
-        return {
-            "task_info": {
-                "task_id": task.task_id,
-                "workflow_id": task.workflow_id,
-                "algorithm_id": task.algorithm_id,
-                "task_type": task.task_type,
-                "plugin_name": task.plugin_name,
-                "status": task.status
-            },
-            "dag_structure": dag_data,
-            "snakefile_path": snakefile_path
-        }
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Unexpected error getting DAG structure for task {task_id}: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error while processing DAG structure")
+    return service.get_dag_structure(db=db, current_user=current_user, task_id=task_id)
 
 
 @router.get("/{task_id}/rule-status")
@@ -726,166 +163,9 @@ async def get_rule_status(
     """
     특정 Task의 각 Rule별 실행 상태를 로그 파일 기반으로 추적하여 반환합니다.
     """
-    import logging
-    from app.workflow.compiler.dag_parser import DAGParsingError
-    
-    logger = logging.getLogger(__name__)
-    
-    try:
-        # 입력 검증
-        if not task_id or not task_id.strip():
-            raise HTTPException(status_code=400, detail="Invalid task_id")
-        
-        # Task 정보 조회
-        task = crud_task.get_task_by_task_id(db, task_id)
-        if not task:
-            logger.warning(f"Task not found for rule status: {task_id}")
-            raise HTTPException(status_code=404, detail="Task not found")
-        
-        # 권한 확인
-        if task.user_id != current_user.id:
-            logger.warning(f"Access denied for user {current_user.id} to task rule status {task_id}")
-            raise HTTPException(status_code=403, detail="Access denied")
-        
-        # Snakefile 경로 구성
-        try:
-            if task.task_type == 'visualization':
-                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}/Snakefile"
-            else:
-                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}/Snakefile"
-        except AttributeError as e:
-            logger.error(f"Missing task attributes for rule status: {e}")
-            raise HTTPException(status_code=400, detail="Invalid task data")
-        
-        logger.info(f"Getting rule status for task {task_id}, snakefile: {snakefile_path}")
-        
-        # Snakefile 파싱 (네이티브 파서 우선 사용)
-        dag_data = None
-        parsing_method = "unknown"
-        
-        try:
-            # 1단계: Snakemake 네이티브 파서 시도 (실시간 파싱)
-            dag_data = parse_snakefile_native(snakefile_path, method='auto')
-            parsing_method = f"native_{dag_data.get('method', 'unknown')}"
-            
-            # DAG 데이터 유효성 검증
-            if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
-                raise ValueError("Invalid DAG data structure from native parser")
-                
-        except (SnakemakeNativeError, ValueError, Exception) as native_error:
-            logger.warning(f"Native parser failed for rule status {task_id}: {native_error}")
-            
-            try:
-                # 2단계: 레거시 파서로 fallback
-                parser = SnakemakeDAGParser()
-                dag_data = parser.parse_snakefile_with_logs(snakefile_path)
-                parsing_method = "legacy"
-                
-                # DAG 데이터 유효성 검증
-                if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
-                    logger.error(f"Invalid DAG data structure for rule status {task_id}")
-                    raise HTTPException(status_code=500, detail="Invalid workflow structure")
-                    
-            except Exception as legacy_error:
-                logger.error(f"Both parsers failed for rule status {task_id}. Native: {native_error}, Legacy: {legacy_error}")
-                raise HTTPException(
-                    status_code=500, 
-                    detail=f"Cannot parse workflow: {str(legacy_error)}"
-                )
-        
-        
-        # 상태 추적기 초기화 및 향상된 진행률 계산
-        try:
-            # Use actual_status if provided, otherwise use task.status
-            effective_task_status = actual_status if actual_status else task.status
-            logger.info(f"Using task status for rule tracking: {effective_task_status} (actual_status: {actual_status}, db_status: {task.status})")
-            
-            tracker = SnakemakeRuleStatusTracker(
-                workflow_path=snakefile_path,
-                task_status=effective_task_status
-            )
-            tracker.rules = dag_data['nodes']
-            
-            # 향상된 진행률 정보 가져오기
-            enhanced_progress = tracker.get_enhanced_progress_info()
-            
-            # 기본 진행률 정보 추출
-            basic_progress = enhanced_progress.get('basic_progress', {})
-            rule_statuses = enhanced_progress.get('rule_statuses', {})
-            
-            # 기존 변수들 설정 (하위 호환성)
-            total_rules = basic_progress.get('total_rules', len(dag_data.get('execution_sequence', [])))
-            completed_rules = basic_progress.get('completed_rules', 0)
-            failed_rules = basic_progress.get('failed_rules', 0)
-            running_rules = basic_progress.get('running_rules', 0)
-            pending_rules = basic_progress.get('pending_rules', 0)
-            progress_percentage = basic_progress.get('percentage', 0.0)
-            
-            logger.info(f"Enhanced rule status calculated for task {task_id}: {completed_rules}/{total_rules} completed")
-            logger.info(f"Rule statuses for task {task_id}: {rule_statuses}")
-            logger.info(f"Rule statuses type: {type(rule_statuses)}, keys: {list(rule_statuses.keys()) if isinstance(rule_statuses, dict) else 'Not a dict'}")
-            
-        except Exception as e:
-            logger.error(f"Error tracking rule statuses for task {task_id}: {e}")
-            # 기본 상태로 모든 룰을 pending으로 설정
-            rule_statuses = {rule['id']: 'pending' for rule in dag_data.get('nodes', [])}
-            
-            # 폴백 진행률 계산
-            try:
-                total_rules = len(dag_data.get('execution_sequence', []))
-                completed_rules = failed_rules = running_rules = 0
-                pending_rules = total_rules
-                progress_percentage = 0
-                enhanced_progress = None
-            except Exception:
-                total_rules = len(rule_statuses)
-                completed_rules = failed_rules = running_rules = 0
-                pending_rules = total_rules
-                progress_percentage = 0
-                enhanced_progress = None
-        
-        # 응답 구성
-        response = {
-            "task_info": {
-                "task_id": task.task_id,
-                "workflow_id": task.workflow_id,
-                "algorithm_id": task.algorithm_id,
-                "task_type": task.task_type,
-                "plugin_name": task.plugin_name,
-                "status": task.status
-            },
-            "rule_statuses": rule_statuses,
-            "execution_sequence": dag_data.get('execution_sequence', []),
-            "progress": {
-                "total_rules": total_rules,
-                "completed_rules": completed_rules,
-                "failed_rules": failed_rules,
-                "running_rules": running_rules,
-                "pending_rules": pending_rules,
-                "percentage": round(progress_percentage, 1)
-            },
-            "snakefile_path": snakefile_path
-        }
-        
-        logger.info(f"Final API response rule_statuses for task {task_id}: {response['rule_statuses']}")
-        logger.info(f"Final API response type check - rule_statuses is dict: {isinstance(response['rule_statuses'], dict)}")
-        
-        # 향상된 진행률 정보 추가 (사용 가능한 경우)
-        if 'enhanced_progress' in locals() and enhanced_progress:
-            response["enhanced_progress"] = {
-                "timing_info": enhanced_progress.get('timing_info', {}),
-                "estimated_completion": enhanced_progress.get('estimated_completion', {}),
-                "bottleneck_analysis": enhanced_progress.get('bottleneck_analysis', {}),
-                "completion_percentage": enhanced_progress.get('basic_progress', {}).get('completion_percentage', 0.0),
-                "is_stalled": enhanced_progress.get('basic_progress', {}).get('is_stalled', False)
-            }
-        
-        return response
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error getting rule status: {str(e)}")
+    return service.get_rule_status(
+        db=db, current_user=current_user, task_id=task_id, actual_status=actual_status
+    )
 
 
 @router.get("/{task_id}/enhanced-progress")
@@ -897,7 +177,7 @@ async def get_enhanced_progress(
 ) -> Dict[str, Any]:
     """
     특정 Task의 향상된 진행률 정보를 반환합니다.
-    
+
     향상된 기능:
     - 타이밍 기반 분석
     - 예상 완료 시간
@@ -905,103 +185,7 @@ async def get_enhanced_progress(
     - 정체 상황 감지
     - 상세 진행률 계산
     """
-    import logging
-    import time
-    from app.workflow.compiler.dag_parser import DAGParsingError
-    
-    logger = logging.getLogger(__name__)
-    
-    try:
-        # 입력 검증
-        if not task_id or not task_id.strip():
-            raise HTTPException(status_code=400, detail="Invalid task_id")
-        
-        # Task 정보 조회
-        task = crud_task.get_task_by_task_id(db, task_id)
-        if not task:
-            logger.warning(f"Task not found for enhanced progress: {task_id}")
-            raise HTTPException(status_code=404, detail="Task not found")
-        
-        # 권한 확인
-        if task.user_id != current_user.id:
-            logger.warning(f"Access denied for user {current_user.id} to enhanced progress {task_id}")
-            raise HTTPException(status_code=403, detail="Access denied")
-        
-        # Snakefile 경로 구성
-        try:
-            if task.task_type == 'visualization':
-                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}/Snakefile"
-            else:
-                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}/Snakefile"
-        except AttributeError as e:
-            logger.error(f"Missing task attributes for enhanced progress: {e}")
-            raise HTTPException(status_code=400, detail="Invalid task data")
-        
-        logger.info(f"Getting enhanced progress for task {task_id}, snakefile: {snakefile_path}")
-        
-        # Snakefile 파싱 및 향상된 진행률 계산 (네이티브 파서 우선 사용)
-        dag_data = None
-        
-        try:
-            # 1단계: Snakemake 네이티브 파서 시도 (실시간 파싱)
-            dag_data = parse_snakefile_native(snakefile_path, method='auto')
-            
-            # DAG 데이터 유효성 검증
-            if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
-                raise ValueError("Invalid DAG data structure from native parser")
-                
-        except (SnakemakeNativeError, ValueError, Exception) as native_error:
-            logger.warning(f"Native parser failed for enhanced progress {task_id}: {native_error}")
-            
-            try:
-                # 2단계: 레거시 파서로 fallback
-                parser = SnakemakeDAGParser()
-                dag_data = parser.parse_snakefile_with_logs(snakefile_path)
-                
-                # DAG 데이터 유효성 검증
-                if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
-                    logger.error(f"Invalid DAG data structure for enhanced progress {task_id}")
-                    raise HTTPException(status_code=500, detail="Invalid workflow structure")
-                    
-            except Exception as legacy_error:
-                logger.error(f"Both parsers failed for enhanced progress {task_id}. Native: {native_error}, Legacy: {legacy_error}")
-                raise HTTPException(
-                    status_code=500, 
-                    detail=f"Cannot parse workflow: {str(legacy_error)}"
-                )
-        
-        # 상태 추적기 초기화
-        tracker = SnakemakeRuleStatusTracker(
-            workflow_path=snakefile_path,
-            task_status=task.status
-        )
-        tracker.rules = dag_data['nodes']
-        
-        # 향상된 진행률 정보 계산
-        enhanced_progress = tracker.get_enhanced_progress_info()
-        
-        logger.info(f"Enhanced progress calculated for task {task_id}")
-            
-        
-        return {
-            "task_info": {
-                "task_id": task.task_id,
-                "workflow_id": task.workflow_id,
-                "algorithm_id": task.algorithm_id,
-                "task_type": task.task_type,
-                "plugin_name": task.plugin_name,
-                "status": task.status
-            },
-            "enhanced_progress": enhanced_progress,
-            "snakefile_path": snakefile_path,
-            "timestamp": time.time()
-        }
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Unexpected error getting enhanced progress for task {task_id}: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error while processing enhanced progress")
+    return service.get_enhanced_progress(db=db, current_user=current_user, task_id=task_id)
 
 
 @router.get("/{task_id}/rule-logs/{rule_name}")
@@ -1015,118 +199,9 @@ async def get_rule_logs(
     """
     특정 Rule의 로그 파일들(stdout, stderr)을 조회합니다.
     """
-    try:
-        # Task 정보 조회
-        task = crud_task.get_task_by_task_id(db, task_id)
-        if not task:
-            raise HTTPException(status_code=404, detail="Task not found")
-        
-        # 권한 확인
-        if task.user_id != current_user.id:
-            raise HTTPException(status_code=403, detail="Access denied")
-        
-        # Snakefile 파싱하여 해당 Rule의 로그 경로 찾기
-        if task.task_type == 'visualization':
-            snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}/Snakefile"
-        else:
-            snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}/Snakefile"
-        
-        if not os.path.exists(snakefile_path):
-            raise HTTPException(status_code=404, detail="Snakefile not found")
-        
-        # 네이티브 파서 우선 사용
-        try:
-            dag_data = parse_snakefile_native(snakefile_path, method='auto')
-        except (SnakemakeNativeError, Exception) as native_error:
-            logger.warning(f"Native parser failed for rule logs {task_id}: {native_error}")
-            # 레거시 파서로 fallback
-            parser = SnakemakeDAGParser()
-            dag_data = parser.parse_snakefile_with_logs(snakefile_path)
-        
-        # 해당 Rule 찾기
-        target_rule = None
-        for node in dag_data['nodes']:
-            if node['id'] == rule_name:
-                target_rule = node
-                break
-        
-        if not target_rule:
-            raise HTTPException(status_code=404, detail=f"Rule '{rule_name}' not found")
-
-        # 아카이브된 로그 경로 확인을 위한 기본 경로 구성
-        if task.task_type == 'visualization':
-            base_task_folder = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}"
-        else:
-            base_task_folder = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}"
-
-        archived_logs_folder = os.path.join(base_task_folder, "executions", task.task_id, "logs")
-        use_archived_logs = os.path.exists(archived_logs_folder)
-
-        # 로그 파일들 읽기
-        rule_logs = {}
-        for log_type, log_path in target_rule['log_paths'].items():
-            # 아카이브된 로그가 있으면 해당 경로로 변환
-            actual_log_path = log_path
-            if use_archived_logs:
-                log_filename = os.path.basename(log_path)
-                archived_log_path = os.path.join(archived_logs_folder, log_filename)
-                if os.path.exists(archived_log_path):
-                    actual_log_path = archived_log_path
-
-            if os.path.exists(actual_log_path):
-                try:
-                    with open(actual_log_path, 'r', encoding='utf-8') as f:
-                        content = f.read()
-
-                    # 파일 정보 포함
-                    file_stat = os.stat(actual_log_path)
-                    rule_logs[log_type] = {
-                        "content": content,
-                        "file_path": actual_log_path,
-                        "size": file_stat.st_size,
-                        "modified_time": file_stat.st_mtime,
-                        "exists": True
-                    }
-                except Exception as e:
-                    rule_logs[log_type] = {
-                        "content": f"Error reading file: {str(e)}",
-                        "file_path": actual_log_path,
-                        "size": 0,
-                        "modified_time": 0,
-                        "exists": True,
-                        "error": str(e)
-                    }
-            else:
-                rule_logs[log_type] = {
-                    "content": "",
-                    "file_path": actual_log_path,
-                    "size": 0,
-                    "modified_time": 0,
-                    "exists": False
-                }
-        
-        return {
-            "task_info": {
-                "task_id": task.task_id,
-                "workflow_id": task.workflow_id,
-                "algorithm_id": task.algorithm_id,
-                "task_type": task.task_type
-            },
-            "rule_info": {
-                "rule_name": rule_name,
-                "label": target_rule['label'],
-                "description": target_rule['description'],
-                "inputs": target_rule['inputs'],
-                "outputs": target_rule['outputs'],
-                "params": target_rule['params']
-            },
-            "logs": rule_logs
-        }
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error getting rule logs: {str(e)}")
+    return service.get_rule_logs(
+        db=db, current_user=current_user, task_id=task_id, rule_name=rule_name
+    )
 
 
 @router.get("/cache/stats")
@@ -1136,25 +211,8 @@ def get_dag_cache_stats(
     """
     DAG 파싱 캐시 통계 정보 조회 (관리자 전용)
     """
-    try:
-        # 레거시 파서의 캐시 통계만 수집 (네이티브 파서는 캐시 제거됨)
-        from app.workflow.compiler.dag_parser import get_cache_stats as get_legacy_stats
-        
-        legacy_stats = get_legacy_stats()
-        
-        return {
-            "native_parser_cache": {"message": "Cache removed for simplification"},
-            "legacy_parser_cache": legacy_stats,
-            "timestamp": time.time(),
-            "message": "Cache statistics retrieved successfully"
-        }
-        
-    except Exception as e:
-        logger.error(f"Error getting cache stats: {e}")
-        return {
-            "error": f"Failed to get cache statistics: {str(e)}",
-            "timestamp": time.time()
-        }
+    return service.get_dag_cache_stats(current_user=current_user)
+
 
 @router.delete("/cache/clear")
 def clear_dag_caches(
@@ -1163,27 +221,8 @@ def clear_dag_caches(
     """
     모든 DAG 파싱 캐시 초기화 (관리자 전용)
     """
-    try:
-        # 레거시 파서의 캐시만 초기화 (네이티브 파서는 캐시 제거됨)
-        from app.workflow.compiler.dag_parser import clear_all_caches
-        
-        # 레거시 파서 캐시 초기화
-        clear_all_caches()
-        
-        logger.info(f"Legacy DAG cache cleared by user {current_user.id} (native cache removed)")
-        
-        return {
-            "message": "Legacy DAG parsing cache cleared successfully (native cache removed for simplification)",
-            "timestamp": time.time(),
-            "cleared_by": current_user.username
-        }
-        
-    except Exception as e:
-        logger.error(f"Error clearing caches: {e}")
-        return {
-            "error": f"Failed to clear caches: {str(e)}",
-            "timestamp": time.time()
-        }
+    return service.clear_dag_caches(current_user=current_user)
+
 
 @router.get("/{task_id}/execution-manifest")
 def get_execution_manifest(
@@ -1195,7 +234,7 @@ def get_execution_manifest(
     """
     SUCCESS 상태이고 Analysis 타입 플러그인인 Task의 execution manifest를 JSON 형식으로 다운로드합니다.
     분석 재현을 위한 포괄적인 정보를 포함합니다.
-    
+
     포함 정보:
     - Task, Plugin, Workflow 메타데이터
     - 모든 로그 파일 (run.log, *.stdout, *.stderr 등)
@@ -1203,247 +242,4 @@ def get_execution_manifest(
     - Plugin metadata.json 내용
     - meta.yml 파일 내용 (있는 경우)
     """
-    import logging
-    
-    logger = logging.getLogger(__name__)
-    
-    try:
-        # task_id로 task 정보 조회
-        task = crud_task.get_task_by_task_id(db, task_id)
-        if not task:
-            raise HTTPException(status_code=404, detail="Task not found")
-        
-        # 권한 확인 (해당 유저의 task인지 확인)
-        if task.user_id != current_user.id:
-            raise HTTPException(status_code=403, detail="Access denied")
-        
-        # Task 상태 검증 - SUCCESS 상태만 허용
-        if task.status != 'SUCCESS':
-            raise HTTPException(
-                status_code=400, 
-                detail=f"Execution manifest is only available for tasks with SUCCESS status. Current status: {task.status}"
-            )
-        
-        # Plugin 정보 확인 및 타입 검증 - Analysis 타입만 허용
-        if not task.plugin:
-            raise HTTPException(status_code=400, detail="Plugin information not found for this task")
-        
-        if task.plugin.plugin_type != PluginType.ANALYSIS:
-            raise HTTPException(
-                status_code=400, 
-                detail=f"Execution manifest is only available for Analysis type plugins. Current plugin type: {task.plugin.plugin_type.value if task.plugin.plugin_type else 'unknown'}"
-            )
-        
-        # Workflow 정보 조회
-        workflow = crud_workflow.get_workflow_by_id(db, task.workflow_id)
-        
-        # 로그 폴더 경로 구성 - task_type에 따라 다른 경로 사용
-        if task.task_type == 'visualization':
-            task_folder_path = f"./user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}"
-        else:
-            task_folder_path = f"./user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}"
-
-        # 아카이브된 로그가 있으면 해당 경로 사용 (task_id별 분리된 로그)
-        archived_logs_folder_path = os.path.join(task_folder_path, "executions", task.task_id, "logs")
-        if os.path.exists(archived_logs_folder_path):
-            logs_folder_path = archived_logs_folder_path
-        else:
-            logs_folder_path = os.path.join(task_folder_path, "logs")
-        
-        # Execution manifest 데이터 구성
-        manifest_data = {
-            "manifest_info": {
-                "format_version": "1.0",
-                "generated_at": datetime.now().isoformat(),
-                "generated_by": current_user.username,
-                "description": "CellCraft execution manifest for analysis reproducibility"
-            },
-            "task_metadata": {
-                "task_id": task.task_id,
-                "workflow_id": task.workflow_id,
-                "algorithm_id": task.algorithm_id,
-                "plugin_name": task.plugin_name,
-                "task_type": task.task_type,
-                "status": task.status,
-                "start_time": str(task.start_time) if task.start_time else None,
-                "end_time": str(task.end_time) if task.end_time else None,
-                "plugin_image_uri": task.plugin_image_uri
-            },
-            "plugin_metadata": {
-                "id": task.plugin.id,
-                "name": task.plugin.name,
-                "description": task.plugin.description,
-                "author": task.plugin.author,
-                "version": task.plugin.version,
-                "plugin_type": task.plugin.plugin_type.value if task.plugin.plugin_type else None,
-                "source": task.plugin.source,
-                "use_gpu": task.plugin.use_gpu,
-                "created_at": str(task.plugin.created_at),
-                "updated_at": str(task.plugin.updated_at),
-                "dependencies": task.plugin.dependencies,
-                "drawflow": task.plugin.drawflow,
-                "rules": task.plugin.rules
-            },
-            "workflow_metadata": {
-                "id": workflow.id if workflow else None,
-                "title": workflow.title if workflow else None,
-                "workflow_info": workflow.workflow_info if workflow else None,
-                "created_at": str(workflow.created_at) if workflow else None,
-                "updated_at": str(workflow.updated_at) if workflow else None
-            },
-            "execution_files": {
-                "logs": {},
-                "snakefile": None,
-                "plugin_metadata": None,
-                "meta_yml": None,
-                "results": {}
-            }
-        }
-        
-        # 로그 파일들 수집
-        if os.path.exists(logs_folder_path):
-            logs_path = Path(logs_folder_path)
-            
-            for log_file_path in logs_path.glob("*"):
-                if log_file_path.is_file():
-                    try:
-                        with open(log_file_path, 'r', encoding='utf-8') as f:
-                            content = f.read()
-                        manifest_data["execution_files"]["logs"][log_file_path.name] = {
-                            "content": content,
-                            "size": log_file_path.stat().st_size,
-                            "modified_time": str(log_file_path.stat().st_mtime)
-                        }
-                    except Exception as e:
-                        # 파일 읽기 실패 시에도 에러 정보 포함
-                        manifest_data["execution_files"]["logs"][log_file_path.name] = {
-                            "content": f"Error reading file: {str(e)}",
-                            "size": log_file_path.stat().st_size if log_file_path.exists() else 0,
-                            "modified_time": str(log_file_path.stat().st_mtime) if log_file_path.exists() else None,
-                            "error": str(e)
-                        }
-        
-        # Snakefile 내용 포함
-        snakefile_path = os.path.join(task_folder_path, "Snakefile")
-        if os.path.exists(snakefile_path):
-            try:
-                with open(snakefile_path, 'r', encoding='utf-8') as f:
-                    manifest_data["execution_files"]["snakefile"] = {
-                        "content": f.read(),
-                        "path": snakefile_path
-                    }
-            except Exception as e:
-                manifest_data["execution_files"]["snakefile"] = {
-                    "content": f"Error reading Snakefile: {str(e)}",
-                    "path": snakefile_path,
-                    "error": str(e)
-                }
-        
-        # Plugin metadata.json 파일 내용 포함
-        plugin_metadata_path = os.path.join(task.plugin.plugin_path, "metadata.json")
-        if os.path.exists(plugin_metadata_path):
-            try:
-                with open(plugin_metadata_path, 'r', encoding='utf-8') as f:
-                    import json as json_lib
-                    manifest_data["execution_files"]["plugin_metadata"] = {
-                        "content": json_lib.load(f),
-                        "path": plugin_metadata_path
-                    }
-            except Exception as e:
-                manifest_data["execution_files"]["plugin_metadata"] = {
-                    "content": f"Error reading plugin metadata.json: {str(e)}",
-                    "path": plugin_metadata_path,
-                    "error": str(e)
-                }
-        
-        # meta.yml 파일 내용 포함 (있는 경우)
-        # 아카이브된 로그를 사용하는 경우 아카이브된 meta.yml도 확인
-        archived_meta_yml_path = os.path.join(task_folder_path, "executions", task.task_id, "meta.yml")
-        if os.path.exists(archived_meta_yml_path):
-            meta_yml_path = archived_meta_yml_path
-        else:
-            meta_yml_path = os.path.join(task_folder_path, "meta.yml")
-
-        if os.path.exists(meta_yml_path):
-            try:
-                with open(meta_yml_path, 'r', encoding='utf-8') as f:
-                    manifest_data["execution_files"]["meta_yml"] = {
-                        "content": f.read(),
-                        "path": meta_yml_path
-                    }
-            except Exception as e:
-                manifest_data["execution_files"]["meta_yml"] = {
-                    "content": f"Error reading meta.yml: {str(e)}",
-                    "path": meta_yml_path,
-                    "error": str(e)
-                }
-        
-        # Results 디렉토리의 파일들 메타데이터 수집
-        results_folder_path = os.path.join(task_folder_path, "results")
-        if os.path.exists(results_folder_path) and os.path.isdir(results_folder_path):
-            results_path = Path(results_folder_path)
-            
-            # 파일 타입 분류 함수
-            def get_file_type(extension):
-                file_type_mapping = {
-                    '.sif': 'network',
-                    '.txt': 'text',
-                    '.csv': 'tabular',
-                    '.tsv': 'tabular',
-                    '.json': 'visualization',
-                    '.npy': 'numpy_array',
-                    '.h5ad': 'anndata',
-                    '.png': 'image',
-                    '.jpg': 'image',
-                    '.jpeg': 'image',
-                    '.pdf': 'document'
-                }
-                return file_type_mapping.get(extension.lower(), 'unknown')
-            
-            for result_file_path in results_path.glob("*"):
-                if result_file_path.is_file():
-                    try:
-                        file_stat = result_file_path.stat()
-                        file_extension = result_file_path.suffix
-                        
-                        manifest_data["execution_files"]["results"][result_file_path.name] = {
-                            "size": file_stat.st_size,
-                            "modified_time": str(file_stat.st_mtime),
-                            "extension": file_extension,
-                            "file_type": get_file_type(file_extension),
-                            "path": str(result_file_path)
-                        }
-                    except Exception as e:
-                        # 파일 정보 읽기 실패 시에도 기본 정보는 포함
-                        manifest_data["execution_files"]["results"][result_file_path.name] = {
-                            "size": 0,
-                            "modified_time": None,
-                            "extension": result_file_path.suffix,
-                            "file_type": "error",
-                            "error": str(e)
-                        }
-            
-            # 결과 파일이 없는 경우 정보 표시
-            if not manifest_data["execution_files"]["results"]:
-                logger.warning(f"No result files found in {results_folder_path}")
-        else:
-            logger.info(f"Results directory not found or not accessible: {results_folder_path}")
-        
-        # JSON으로 변환
-        json_content = json.dumps(manifest_data, indent=2, ensure_ascii=False)
-        
-        # 파일명 생성 (타임스탬프 포함)
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"execution_manifest_{task.plugin_name}_{task_id[:8]}_{timestamp}.json"
-        
-        # StreamingResponse로 다운로드 제공
-        return StreamingResponse(
-            io.StringIO(json_content),
-            media_type="application/json",
-            headers={"Content-Disposition": f"attachment; filename={filename}"}
-        )
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error generating execution manifest: {str(e)}")
+    return service.get_execution_manifest(db=db, current_user=current_user, task_id=task_id)

--- a/backend/app/task/schemas.py
+++ b/backend/app/task/schemas.py
@@ -3,6 +3,38 @@ from pydantic import BaseModel
 from datetime import datetime
 
 
+class TaskSubmission(BaseModel):
+    """Typed representation of the ``process_data_task`` Celery dispatch kwargs.
+
+    Extracted in PR-7 (Phase 3c). This model types the keyword payload sent to
+    ``app.worker.tasks.process_data_task`` so the dispatch site can build the
+    ``kwargs`` dict from a validated schema instead of an inline literal.
+
+    Wire-format contract (IMPORTANT): the on-the-wire ``kwargs`` keys, their
+    names, and their value shapes are preserved exactly for old-worker /
+    new-web compatibility. ``resource_type`` / ``resource_slots`` carry the same
+    defaults as the worker signature (``'cpu'`` / ``4``). ``cache_key`` and
+    ``cache_info`` are the visualization-only extras absorbed by the worker's
+    ``**kwargs``; they are ``None`` for compile tasks. Callers therefore emit
+    the exact legacy dict via ``submission.dict(exclude_none=True)``:
+
+    - compile:       user_id, workflow_id, algorithm_id, plugin_name,
+                     task_type, resource_type, resource_slots
+    - visualization: the above + cache_key, cache_info
+
+    pydantic v1 syntax only.
+    """
+    user_id: int
+    workflow_id: int
+    algorithm_id: Any
+    plugin_name: str
+    task_type: str
+    resource_type: str = 'cpu'
+    resource_slots: int = 4
+    cache_key: Optional[str] = None
+    cache_info: Optional[Dict[str, Any]] = None
+
+
 class PluginInfo(BaseModel):
     """Plugin information for task monitoring response."""
     version: Optional[str] = None

--- a/backend/app/task/service.py
+++ b/backend/app/task/service.py
@@ -1,0 +1,1291 @@
+"""
+Task domain service layer.
+
+Extracted from ``task/router.py`` in PR-7 (Phase 3c). This module holds the
+business logic that previously lived inline in the endpoints: resource status,
+lightweight task status, task monitoring, revoke/delete, container status, log
+retrieval + export, DAG structure / rule-status / enhanced-progress / rule-logs
+parsing, DAG cache stats/clear, and execution manifest generation. The router
+now only parses requests, resolves dependencies, calls a service function, and
+returns its result. SSE streaming lives in ``task/sse.py``.
+
+Transitional exception policy (PR-7): the global domain-exception layer arrives
+in PR-8. Until then, service functions may ``raise HTTPException`` directly
+(copy-move fidelity first, exception translation later). Response shapes — JSON
+keys, status codes, and error message strings — are preserved exactly.
+
+Snakefile parser modules (``workflow/compiler/dag_parser``,
+``workflow/compiler/native_parser``) are invoked, never modified (PR-10).
+"""
+import io
+import json
+import logging
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from app import models
+from app.core.enums import PluginType
+from app.shared.docker import container_manager
+from app.task import crud as crud_task
+from app.task.schemas import TaskMonitoringItem, PluginInfo
+from app.workflow import crud as crud_workflow
+from app.workflow.compiler.dag_parser import (
+    SnakemakeDAGParser, SnakemakeRuleStatusTracker
+)
+from app.workflow.compiler.native_parser import (
+    parse_snakefile_native, SnakemakeNativeError
+)
+from app.worker.utils import get_task_info
+
+logger = logging.getLogger(__name__)
+
+
+def get_resources() -> dict:
+    """리소스 할당 현황 및 실행 중 작업 목록 조회."""
+    from app.shared.resources import get_resource_status
+
+    status = get_resource_status()
+    if status is None:
+        raise HTTPException(status_code=503, detail="Resource monitoring unavailable")
+    return status
+
+
+def get_task_status_simple(*, task_id: str) -> dict:
+    """SSE 재연결 판단용 경량 상태 확인 (Celery AsyncResult 상태만 반환)."""
+    if not task_id or not task_id.strip():
+        raise HTTPException(status_code=400, detail="Invalid task_id")
+
+    task = get_task_info(task_id)
+    return {
+        "task_id": task_id,
+        "status": task.get("task_status", "UNKNOWN")
+    }
+
+
+def get_task_monitoring(*, db: Session, current_user: models.User) -> List[TaskMonitoringItem]:
+    """Return all of a user's workflow tasks (plugin_build filtered out).
+
+    Uses eager-loaded plugin/workflow data (single query) to avoid N+1.
+    """
+    # Get user tasks with eager-loaded plugin and workflow data (single query)
+    user_tasks = crud_task.get_user_task_with_plugin(db, current_user.id)
+
+    # Return empty list with 200 OK if no tasks (RESTful response)
+    if not user_tasks:
+        return []
+
+    # Filter out plugin build tasks, keep only workflow-related tasks
+    workflow_tasks = [task for task in user_tasks if task.task_type != "plugin_build"]
+
+    # Build response using eager-loaded data (no additional queries needed)
+    tasks_with_workflow = []
+    for task in workflow_tasks:
+        # task_title generation logic
+        task_title = None
+        if task.plugin_name:
+            if task.task_type == 'compile':
+                task_title = task.plugin_name
+            elif task.task_type == 'visualization':
+                task_title = f"{task.plugin_name}-visualization"
+            else:
+                task_title = task.plugin_name  # default value
+
+        # Plugin information - use eager-loaded data
+        plugin_info = None
+        if task.plugin:
+            plugin_info = PluginInfo(
+                version=task.plugin.version,
+                source=task.plugin.source,
+                plugin_type=task.plugin.plugin_type.value if task.plugin.plugin_type else None
+            )
+
+        # Use eager-loaded workflow data (no additional query)
+        workflow_title = task.workflows.title if task.workflows else None
+
+        task_item = TaskMonitoringItem(
+            id=task.id,
+            task_id=task.task_id,
+            workflow_id=task.workflow_id,
+            user_id=task.user_id,
+            status=task.status,
+            start_time=task.start_time,
+            end_time=task.end_time,
+            workflow_title=workflow_title,
+            task_title=task_title,
+            plugin_name=task.plugin_name,
+            task_type=task.task_type,
+            plugin=plugin_info
+        )
+        tasks_with_workflow.append(task_item)
+
+    return tasks_with_workflow
+
+
+def revoke_task(*, db: Session, current_user: models.User, task_id: str) -> dict:
+    """Revoke a Celery task and clean up its containers + results folder."""
+    try:
+        from app.main import get_celery_app
+        celery = get_celery_app()
+
+        print(f"Attempting to revoke task {task_id}")
+
+        # 1. 먼저 관련 컨테이너 정보 확인
+        container_id = container_manager.get_container_id(task_id)
+        if container_id:
+            print(f"Found associated container {container_id} for task {task_id}")
+
+        # 2. Celery 작업 취소
+        celery.control.revoke(task_id, terminate=True, signal='SIGTERM')
+        print(f"Celery revoke command sent for task {task_id}")
+
+        # 3. 컨테이너 매니저를 통한 컨테이너 강제 정리
+        container_cleanup_success = False
+        if container_id:
+            print(f"Attempting to stop container {container_id}")
+            container_cleanup_success = container_manager.stop_task_container(task_id, timeout=10)
+
+        # 4. 컨테이너 이름 패턴으로도 정리 시도 (백업 방법)
+        if not container_cleanup_success:
+            print("Attempting container cleanup by name pattern")
+            try:
+                # task_id의 앞 8자리를 사용하여 컨테이너 이름 패턴 매칭
+                task_short_id = task_id[:8]
+                container_name_pattern = f"*task-{task_short_id}*"
+                container_manager.stop_container_by_name(container_name_pattern)
+            except Exception as pattern_error:
+                print(f"Pattern-based container cleanup failed: {pattern_error}")
+
+        # 5. Results 폴더 정리 (재실행 시 Snakemake 스킵 방지)
+        results_cleanup_success = False
+        try:
+            task_record = crud_task.get_task_by_task_id(db, task_id)
+            if task_record:
+                if task_record.task_type == 'visualization':
+                    task_folder = f"./user/{current_user.username}/workflow_{task_record.workflow_id}/visualization_{task_record.algorithm_id}"
+                else:
+                    task_folder = f"./user/{current_user.username}/workflow_{task_record.workflow_id}/algorithm_{task_record.algorithm_id}"
+
+                from app.shared.archive import cleanup_task_results
+                cleanup_result = cleanup_task_results(Path(task_folder), preserve_folder=True)
+                results_cleanup_success = cleanup_result["success"]
+
+                if results_cleanup_success:
+                    print(f"Results cleanup completed: {len(cleanup_result.get('files_removed', []))} files removed")
+                else:
+                    print(f"Results cleanup failed: {cleanup_result.get('error')}")
+        except Exception as cleanup_error:
+            print(f"Results cleanup failed: {cleanup_error}")
+
+        # 6. 작업 상태 확인 및 DB 업데이트
+        task = get_task_info(task_id)
+        print(f"Task info after revoke: {task}")
+
+        task_status = task.get("status")
+        if task_status == 'REVOKED':
+            return {
+                "message": "Task Revoked Successfully",
+                "task_id": task_id,
+                "container_cleanup": container_cleanup_success,
+                "results_cleanup": results_cleanup_success
+            }
+        else:
+            # 태스크 상태를 'REVOKED'로 강제 업데이트
+            crud_task.end_task(current_user.id, task_id, datetime.now(), 'REVOKED')
+            print(f"Forced task status update to REVOKED for task {task_id}")
+
+            # 업데이트 후 다시 확인
+            task = get_task_info(task_id)
+            task_status = task.get("status")
+
+            if task_status == 'REVOKED':
+                return {
+                    "message": "Task Revoked Successfully (Forced Update)",
+                    "task_id": task_id,
+                    "container_cleanup": container_cleanup_success,
+                    "results_cleanup": results_cleanup_success
+                }
+            else:
+                return {
+                    "message": "Task Revoke Completed with Warnings",
+                    "task_id": task_id,
+                    "warning": "Task status update may be delayed",
+                    "container_cleanup": container_cleanup_success,
+                    "results_cleanup": results_cleanup_success
+                }
+
+    except Exception as e:
+        print(f"Error during task revocation: {str(e)}")
+
+        # 오류 발생 시에도 컨테이너 정리 시도
+        try:
+            container_manager.stop_task_container(task_id, timeout=5)
+        except Exception as cleanup_error:
+            print(f"Emergency container cleanup failed: {cleanup_error}")
+
+        return {
+            "message": "Task Revoke Failed",
+            "task_id": task_id,
+            "error": str(e)
+        }
+
+
+def delete_task(*, db: Session, current_user: models.User, task_id: str) -> dict:
+    """Delete a user's task record."""
+    task = crud_task.delete_user_task(db, current_user.id, task_id)
+    return {"message": "Task Deleted", "task_id": task_id}
+
+
+def get_container_status(*, current_user: models.User) -> dict:
+    """Get current plugin-execution container status for debugging."""
+    client = None  # Docker 클라이언트 누수 방지를 위해 초기화
+    try:
+        import docker
+        client = docker.from_env()
+
+        # 실행 중인 플러그인 컨테이너 조회
+        containers = client.containers.list(
+            filters={"label": "container.type=plugin-execution"}
+        )
+
+        container_info = []
+        for container in containers:
+            labels = container.labels
+
+            # 환경변수에서 CELERY_TASK_ID 찾기
+            env_task_id = "unknown"
+            env_vars = container.attrs.get('Config', {}).get('Env', [])
+            for env in env_vars:
+                if env.startswith('CELERY_TASK_ID='):
+                    env_task_id = env.split('=', 1)[1]
+                    break
+
+            container_info.append({
+                "id": container.id[:12],
+                "name": container.name,
+                "status": container.status,
+                "task_id_label": labels.get("celery.task_id", "unknown"),
+                "task_id_env": env_task_id,
+                "plugin_name": labels.get("plugin.name", "unknown"),
+                "created": str(container.attrs["Created"]),
+                "is_tracked": container.id in container_manager._container_tasks
+            })
+
+        # 컨테이너 매니저 상태 추가
+        manager_status = container_manager.get_status()
+
+        return {
+            "running_containers": len(container_info),
+            "containers": container_info,
+            "container_manager": manager_status,
+            "orphaned_containers": [
+                c for c in container_info
+                if not c["is_tracked"] and c["task_id_label"] != "unknown"
+            ]
+        }
+
+    except Exception as e:
+        return {
+            "error": f"Failed to get container status: {str(e)}"
+        }
+    finally:
+        # Docker 클라이언트 연결 해제 - TCP 소켓 누수 방지
+        if client:
+            try:
+                client.close()
+            except Exception:
+                pass
+
+
+def get_task_logs(*, db: Session, current_user: models.User, task_id: str) -> dict:
+    """특정 task의 로그 파일들을 조회합니다."""
+    from app.file.storage import construct_logs_path, is_safe_path, get_logs_base_path
+
+    try:
+        # task_id로 task 정보 조회
+        task = crud_task.get_task_by_task_id(db, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        # 권한 확인 (해당 유저의 task인지 확인)
+        if task.user_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        # 로그 폴더 경로 구성 (centralized utility 사용)
+        # task_id를 전달하여 아카이브된 로그가 있으면 해당 경로 사용
+        logs_folder_path = construct_logs_path(
+            username=current_user.username,
+            workflow_id=task.workflow_id,
+            algorithm_id=task.algorithm_id,
+            task_type=task.task_type,
+            task_id=task.task_id
+        )
+
+        # 보안 검증: path traversal 방지
+        if not is_safe_path(logs_folder_path, get_logs_base_path()):
+            raise HTTPException(status_code=400, detail="Invalid path")
+
+        if not os.path.exists(logs_folder_path):
+            raise HTTPException(status_code=404, detail="Logs folder not found")
+
+        # 로그 파일들 읽기
+        log_files = []
+        logs_path = Path(logs_folder_path)
+
+        for log_file_path in logs_path.glob("*"):
+            if log_file_path.is_file():
+                # 각 파일도 안전성 검증
+                if not is_safe_path(str(log_file_path), get_logs_base_path()):
+                    continue  # Skip unsafe files (e.g., symlinks outside base dir)
+
+                try:
+                    with open(log_file_path, 'r', encoding='utf-8') as f:
+                        content = f.read()
+                    log_files.append({
+                        "filename": log_file_path.name,
+                        "content": content,
+                        "size": log_file_path.stat().st_size,
+                        "modified_time": str(log_file_path.stat().st_mtime)
+                    })
+                except Exception as e:
+                    # 파일 읽기 실패 시에도 파일 정보는 포함
+                    log_files.append({
+                        "filename": log_file_path.name,
+                        "content": f"Error reading file: {str(e)}",
+                        "size": log_file_path.stat().st_size,
+                        "modified_time": str(log_file_path.stat().st_mtime)
+                    })
+
+        # run.log 파일을 맨 앞으로 정렬
+        log_files.sort(key=lambda x: (x["filename"] != "run.log", x["filename"]))
+
+        return {
+            "logs": log_files,
+            "task_info": {
+                "task_id": task.task_id,
+                "workflow_id": task.workflow_id,
+                "algorithm_id": task.algorithm_id,
+                "status": task.status,
+                "start_time": str(task.start_time),
+                "end_time": str(task.end_time) if task.end_time else None
+            }
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error retrieving logs: {str(e)}")
+
+
+def export_task_logs_json(*, db: Session, current_user: models.User, task_id: str) -> StreamingResponse:
+    """특정 task의 모든 로그 파일들을 JSON 형식으로 export합니다."""
+    from app.file.storage import construct_logs_path, is_safe_path, get_logs_base_path
+
+    try:
+        # task_id로 task 정보 조회
+        task = crud_task.get_task_by_task_id(db, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        # 권한 확인 (해당 유저의 task인지 확인)
+        if task.user_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        # 로그 폴더 경로 구성
+        # task_id를 전달하여 아카이브된 로그가 있으면 해당 경로 사용
+        logs_folder_path = construct_logs_path(
+            username=current_user.username,
+            workflow_id=task.workflow_id,
+            algorithm_id=task.algorithm_id,
+            task_type=task.task_type,
+            task_id=task.task_id
+        )
+
+        # 보안 검증
+        if not is_safe_path(logs_folder_path, get_logs_base_path()):
+            raise HTTPException(status_code=400, detail="Invalid path")
+
+        if not os.path.exists(logs_folder_path):
+            raise HTTPException(status_code=404, detail="Logs folder not found")
+
+        # 모든 로그 파일을 JSON 형태로 수집
+        logs_data = {}
+        logs_path = Path(logs_folder_path)
+
+        for log_file_path in logs_path.glob("*"):
+            if log_file_path.is_file():
+                # 보안 검증: 각 파일이 안전한지 확인
+                if not is_safe_path(str(log_file_path), get_logs_base_path()):
+                    continue  # Skip unsafe files
+
+                try:
+                    with open(log_file_path, 'r', encoding='utf-8') as f:
+                        content = f.read()
+                    logs_data[log_file_path.name] = content
+                except Exception as e:
+                    # 파일 읽기 실패 시 에러 정보 포함
+                    logs_data[log_file_path.name] = f"Error reading file: {str(e)}"
+
+        if not logs_data:
+            raise HTTPException(status_code=404, detail="No log files found")
+
+        # JSON으로 변환
+        json_content = json.dumps(logs_data, indent=2, ensure_ascii=False)
+
+        # 파일명 생성 (타임스탬프 포함)
+        from datetime import datetime
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"task_{task_id[:8]}_logs_{timestamp}.json"
+
+        # StreamingResponse로 다운로드 제공
+        return StreamingResponse(
+            io.StringIO(json_content),
+            media_type="application/json",
+            headers={"Content-Disposition": f"attachment; filename={filename}"}
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error exporting logs as JSON: {str(e)}")
+
+
+def export_task_log_txt(*, db: Session, current_user: models.User, task_id: str,
+                        filename: str) -> StreamingResponse:
+    """특정 task의 개별 로그 파일을 TXT 형식으로 export합니다."""
+    from app.file.storage import (
+        construct_logs_path,
+        is_safe_path,
+        get_logs_base_path,
+        validate_export_filename
+    )
+
+    try:
+        # 파일명 보안 검증 (path traversal 방지)
+        if not validate_export_filename(filename, task_id):
+            raise HTTPException(status_code=400, detail="Invalid filename")
+
+        # task_id로 task 정보 조회
+        task = crud_task.get_task_by_task_id(db, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        # 권한 확인 (해당 유저의 task인지 확인)
+        if task.user_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        # 로그 폴더 경로 구성
+        # task_id를 전달하여 아카이브된 로그가 있으면 해당 경로 사용
+        logs_folder_path = construct_logs_path(
+            username=current_user.username,
+            workflow_id=task.workflow_id,
+            algorithm_id=task.algorithm_id,
+            task_type=task.task_type,
+            task_id=task.task_id
+        )
+
+        # 보안 검증: 폴더 경로
+        if not is_safe_path(logs_folder_path, get_logs_base_path()):
+            raise HTTPException(status_code=400, detail="Invalid path")
+
+        # 요청된 로그 파일 경로
+        log_file_path = Path(logs_folder_path) / filename
+
+        # 보안 검증: 최종 파일 경로
+        if not is_safe_path(str(log_file_path), get_logs_base_path()):
+            raise HTTPException(status_code=400, detail="Invalid file path")
+
+        if not log_file_path.exists():
+            raise HTTPException(status_code=404, detail=f"Log file '{filename}' not found")
+
+        if not log_file_path.is_file():
+            raise HTTPException(status_code=400, detail=f"'{filename}' is not a valid file")
+
+        # 파일 읽기
+        try:
+            with open(log_file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Error reading file: {str(e)}")
+
+        # 다운로드용 파일명 생성 (타임스탬프 포함)
+        from datetime import datetime
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        base_name = Path(filename).stem
+        extension = Path(filename).suffix or ".txt"
+        download_filename = f"task_{task_id[:8]}_{base_name}_{timestamp}{extension}"
+
+        # StreamingResponse로 다운로드 제공
+        return StreamingResponse(
+            io.StringIO(content),
+            media_type="text/plain",
+            headers={"Content-Disposition": f"attachment; filename={download_filename}"}
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error exporting log file as TXT: {str(e)}")
+
+
+def get_dag_structure(*, db: Session, current_user: models.User, task_id: str) -> Dict[str, Any]:
+    """특정 Task의 Snakefile을 파싱하여 DAG 구조를 반환합니다."""
+    try:
+        # 입력 검증
+        if not task_id or not task_id.strip():
+            raise HTTPException(status_code=400, detail="Invalid task_id")
+
+        # Task 정보 조회
+        task = crud_task.get_task_by_task_id(db, task_id)
+        if not task:
+            logger.warning(f"Task not found: {task_id}")
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        # 권한 확인
+        if task.user_id != current_user.id:
+            logger.warning(f"Access denied for user {current_user.id} to task {task_id}")
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        # Snakefile 경로 구성
+        try:
+            if task.task_type == 'visualization':
+                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}/Snakefile"
+            else:
+                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}/Snakefile"
+        except AttributeError as e:
+            logger.error(f"Missing task attributes for DAG structure: {e}")
+            raise HTTPException(status_code=400, detail="Invalid task data")
+
+        logger.info(f"Parsing DAG structure for task {task_id}, snakefile: {snakefile_path}")
+
+        # Snakefile 파싱 (네이티브 파서 우선 사용, 실패 시 레거시 파서로 fallback)
+        dag_data = None
+        parsing_method = "unknown"
+
+        try:
+            # 1단계: Snakemake 네이티브 파서 시도 (실시간 파싱)
+            logger.info(f"Attempting native Snakemake parsing for task {task_id}")
+            dag_data = parse_snakefile_native(snakefile_path, method='auto')
+            parsing_method = f"native_{dag_data.get('method', 'unknown')}"
+
+            # DAG 데이터 유효성 검증
+            if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
+                raise ValueError("Invalid DAG data structure from native parser")
+
+            logger.info(f"Successfully parsed {len(dag_data.get('nodes', []))} rules using native parser ({parsing_method}) for task {task_id}")
+
+        except (SnakemakeNativeError, ValueError, Exception) as native_error:
+            logger.warning(f"Native parser failed for task {task_id}: {native_error}")
+
+            try:
+                # 2단계: 레거시 파서로 fallback
+                logger.info(f"Falling back to legacy parser for task {task_id}")
+                parser = SnakemakeDAGParser()
+                dag_data = parser.parse_snakefile_with_logs(snakefile_path)
+                parsing_method = "legacy"
+
+                # DAG 데이터 유효성 검증
+                if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
+                    logger.error(f"Invalid DAG data structure from legacy parser for task {task_id}")
+                    raise HTTPException(status_code=500, detail="Invalid DAG structure")
+
+                logger.info(f"Successfully parsed {len(dag_data.get('nodes', []))} rules using legacy parser for task {task_id}")
+
+            except Exception as legacy_error:
+                # 두 파서 모두 실패한 경우
+                logger.error(f"Both native and legacy parsers failed for task {task_id}. Native: {native_error}, Legacy: {legacy_error}")
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Failed to parse workflow with both native and legacy parsers. Last error: {str(legacy_error)}"
+                )
+
+        # 파싱 방법 정보 추가
+        if dag_data and isinstance(dag_data, dict):
+            dag_data['parsing_method'] = parsing_method
+
+        return {
+            "task_info": {
+                "task_id": task.task_id,
+                "workflow_id": task.workflow_id,
+                "algorithm_id": task.algorithm_id,
+                "task_type": task.task_type,
+                "plugin_name": task.plugin_name,
+                "status": task.status
+            },
+            "dag_structure": dag_data,
+            "snakefile_path": snakefile_path
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error getting DAG structure for task {task_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error while processing DAG structure")
+
+
+def get_rule_status(*, db: Session, current_user: models.User, task_id: str,
+                    actual_status: Optional[str] = None) -> Dict[str, Any]:
+    """특정 Task의 각 Rule별 실행 상태를 로그 파일 기반으로 추적하여 반환합니다."""
+    try:
+        # 입력 검증
+        if not task_id or not task_id.strip():
+            raise HTTPException(status_code=400, detail="Invalid task_id")
+
+        # Task 정보 조회
+        task = crud_task.get_task_by_task_id(db, task_id)
+        if not task:
+            logger.warning(f"Task not found for rule status: {task_id}")
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        # 권한 확인
+        if task.user_id != current_user.id:
+            logger.warning(f"Access denied for user {current_user.id} to task rule status {task_id}")
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        # Snakefile 경로 구성
+        try:
+            if task.task_type == 'visualization':
+                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}/Snakefile"
+            else:
+                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}/Snakefile"
+        except AttributeError as e:
+            logger.error(f"Missing task attributes for rule status: {e}")
+            raise HTTPException(status_code=400, detail="Invalid task data")
+
+        logger.info(f"Getting rule status for task {task_id}, snakefile: {snakefile_path}")
+
+        # Snakefile 파싱 (네이티브 파서 우선 사용)
+        dag_data = None
+        parsing_method = "unknown"
+
+        try:
+            # 1단계: Snakemake 네이티브 파서 시도 (실시간 파싱)
+            dag_data = parse_snakefile_native(snakefile_path, method='auto')
+            parsing_method = f"native_{dag_data.get('method', 'unknown')}"
+
+            # DAG 데이터 유효성 검증
+            if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
+                raise ValueError("Invalid DAG data structure from native parser")
+
+        except (SnakemakeNativeError, ValueError, Exception) as native_error:
+            logger.warning(f"Native parser failed for rule status {task_id}: {native_error}")
+
+            try:
+                # 2단계: 레거시 파서로 fallback
+                parser = SnakemakeDAGParser()
+                dag_data = parser.parse_snakefile_with_logs(snakefile_path)
+                parsing_method = "legacy"
+
+                # DAG 데이터 유효성 검증
+                if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
+                    logger.error(f"Invalid DAG data structure for rule status {task_id}")
+                    raise HTTPException(status_code=500, detail="Invalid workflow structure")
+
+            except Exception as legacy_error:
+                logger.error(f"Both parsers failed for rule status {task_id}. Native: {native_error}, Legacy: {legacy_error}")
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Cannot parse workflow: {str(legacy_error)}"
+                )
+
+        # 상태 추적기 초기화 및 향상된 진행률 계산
+        try:
+            # Use actual_status if provided, otherwise use task.status
+            effective_task_status = actual_status if actual_status else task.status
+            logger.info(f"Using task status for rule tracking: {effective_task_status} (actual_status: {actual_status}, db_status: {task.status})")
+
+            tracker = SnakemakeRuleStatusTracker(
+                workflow_path=snakefile_path,
+                task_status=effective_task_status
+            )
+            tracker.rules = dag_data['nodes']
+
+            # 향상된 진행률 정보 가져오기
+            enhanced_progress = tracker.get_enhanced_progress_info()
+
+            # 기본 진행률 정보 추출
+            basic_progress = enhanced_progress.get('basic_progress', {})
+            rule_statuses = enhanced_progress.get('rule_statuses', {})
+
+            # 기존 변수들 설정 (하위 호환성)
+            total_rules = basic_progress.get('total_rules', len(dag_data.get('execution_sequence', [])))
+            completed_rules = basic_progress.get('completed_rules', 0)
+            failed_rules = basic_progress.get('failed_rules', 0)
+            running_rules = basic_progress.get('running_rules', 0)
+            pending_rules = basic_progress.get('pending_rules', 0)
+            progress_percentage = basic_progress.get('percentage', 0.0)
+
+            logger.info(f"Enhanced rule status calculated for task {task_id}: {completed_rules}/{total_rules} completed")
+            logger.info(f"Rule statuses for task {task_id}: {rule_statuses}")
+            logger.info(f"Rule statuses type: {type(rule_statuses)}, keys: {list(rule_statuses.keys()) if isinstance(rule_statuses, dict) else 'Not a dict'}")
+
+        except Exception as e:
+            logger.error(f"Error tracking rule statuses for task {task_id}: {e}")
+            # 기본 상태로 모든 룰을 pending으로 설정
+            rule_statuses = {rule['id']: 'pending' for rule in dag_data.get('nodes', [])}
+
+            # 폴백 진행률 계산
+            try:
+                total_rules = len(dag_data.get('execution_sequence', []))
+                completed_rules = failed_rules = running_rules = 0
+                pending_rules = total_rules
+                progress_percentage = 0
+                enhanced_progress = None
+            except Exception:
+                total_rules = len(rule_statuses)
+                completed_rules = failed_rules = running_rules = 0
+                pending_rules = total_rules
+                progress_percentage = 0
+                enhanced_progress = None
+
+        # 응답 구성
+        response = {
+            "task_info": {
+                "task_id": task.task_id,
+                "workflow_id": task.workflow_id,
+                "algorithm_id": task.algorithm_id,
+                "task_type": task.task_type,
+                "plugin_name": task.plugin_name,
+                "status": task.status
+            },
+            "rule_statuses": rule_statuses,
+            "execution_sequence": dag_data.get('execution_sequence', []),
+            "progress": {
+                "total_rules": total_rules,
+                "completed_rules": completed_rules,
+                "failed_rules": failed_rules,
+                "running_rules": running_rules,
+                "pending_rules": pending_rules,
+                "percentage": round(progress_percentage, 1)
+            },
+            "snakefile_path": snakefile_path
+        }
+
+        logger.info(f"Final API response rule_statuses for task {task_id}: {response['rule_statuses']}")
+        logger.info(f"Final API response type check - rule_statuses is dict: {isinstance(response['rule_statuses'], dict)}")
+
+        # 향상된 진행률 정보 추가 (사용 가능한 경우)
+        if 'enhanced_progress' in locals() and enhanced_progress:
+            response["enhanced_progress"] = {
+                "timing_info": enhanced_progress.get('timing_info', {}),
+                "estimated_completion": enhanced_progress.get('estimated_completion', {}),
+                "bottleneck_analysis": enhanced_progress.get('bottleneck_analysis', {}),
+                "completion_percentage": enhanced_progress.get('basic_progress', {}).get('completion_percentage', 0.0),
+                "is_stalled": enhanced_progress.get('basic_progress', {}).get('is_stalled', False)
+            }
+
+        return response
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error getting rule status: {str(e)}")
+
+
+def get_enhanced_progress(*, db: Session, current_user: models.User, task_id: str) -> Dict[str, Any]:
+    """특정 Task의 향상된 진행률 정보를 반환합니다."""
+    try:
+        # 입력 검증
+        if not task_id or not task_id.strip():
+            raise HTTPException(status_code=400, detail="Invalid task_id")
+
+        # Task 정보 조회
+        task = crud_task.get_task_by_task_id(db, task_id)
+        if not task:
+            logger.warning(f"Task not found for enhanced progress: {task_id}")
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        # 권한 확인
+        if task.user_id != current_user.id:
+            logger.warning(f"Access denied for user {current_user.id} to enhanced progress {task_id}")
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        # Snakefile 경로 구성
+        try:
+            if task.task_type == 'visualization':
+                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}/Snakefile"
+            else:
+                snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}/Snakefile"
+        except AttributeError as e:
+            logger.error(f"Missing task attributes for enhanced progress: {e}")
+            raise HTTPException(status_code=400, detail="Invalid task data")
+
+        logger.info(f"Getting enhanced progress for task {task_id}, snakefile: {snakefile_path}")
+
+        # Snakefile 파싱 및 향상된 진행률 계산 (네이티브 파서 우선 사용)
+        dag_data = None
+
+        try:
+            # 1단계: Snakemake 네이티브 파서 시도 (실시간 파싱)
+            dag_data = parse_snakefile_native(snakefile_path, method='auto')
+
+            # DAG 데이터 유효성 검증
+            if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
+                raise ValueError("Invalid DAG data structure from native parser")
+
+        except (SnakemakeNativeError, ValueError, Exception) as native_error:
+            logger.warning(f"Native parser failed for enhanced progress {task_id}: {native_error}")
+
+            try:
+                # 2단계: 레거시 파서로 fallback
+                parser = SnakemakeDAGParser()
+                dag_data = parser.parse_snakefile_with_logs(snakefile_path)
+
+                # DAG 데이터 유효성 검증
+                if not isinstance(dag_data, dict) or 'nodes' not in dag_data:
+                    logger.error(f"Invalid DAG data structure for enhanced progress {task_id}")
+                    raise HTTPException(status_code=500, detail="Invalid workflow structure")
+
+            except Exception as legacy_error:
+                logger.error(f"Both parsers failed for enhanced progress {task_id}. Native: {native_error}, Legacy: {legacy_error}")
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Cannot parse workflow: {str(legacy_error)}"
+                )
+
+        # 상태 추적기 초기화
+        tracker = SnakemakeRuleStatusTracker(
+            workflow_path=snakefile_path,
+            task_status=task.status
+        )
+        tracker.rules = dag_data['nodes']
+
+        # 향상된 진행률 정보 계산
+        enhanced_progress = tracker.get_enhanced_progress_info()
+
+        logger.info(f"Enhanced progress calculated for task {task_id}")
+
+        return {
+            "task_info": {
+                "task_id": task.task_id,
+                "workflow_id": task.workflow_id,
+                "algorithm_id": task.algorithm_id,
+                "task_type": task.task_type,
+                "plugin_name": task.plugin_name,
+                "status": task.status
+            },
+            "enhanced_progress": enhanced_progress,
+            "snakefile_path": snakefile_path,
+            "timestamp": time.time()
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error getting enhanced progress for task {task_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error while processing enhanced progress")
+
+
+def get_rule_logs(*, db: Session, current_user: models.User, task_id: str,
+                  rule_name: str) -> Dict[str, Any]:
+    """특정 Rule의 로그 파일들(stdout, stderr)을 조회합니다."""
+    try:
+        # Task 정보 조회
+        task = crud_task.get_task_by_task_id(db, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        # 권한 확인
+        if task.user_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        # Snakefile 파싱하여 해당 Rule의 로그 경로 찾기
+        if task.task_type == 'visualization':
+            snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}/Snakefile"
+        else:
+            snakefile_path = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}/Snakefile"
+
+        if not os.path.exists(snakefile_path):
+            raise HTTPException(status_code=404, detail="Snakefile not found")
+
+        # 네이티브 파서 우선 사용
+        try:
+            dag_data = parse_snakefile_native(snakefile_path, method='auto')
+        except (SnakemakeNativeError, Exception) as native_error:
+            logger.warning(f"Native parser failed for rule logs {task_id}: {native_error}")
+            # 레거시 파서로 fallback
+            parser = SnakemakeDAGParser()
+            dag_data = parser.parse_snakefile_with_logs(snakefile_path)
+
+        # 해당 Rule 찾기
+        target_rule = None
+        for node in dag_data['nodes']:
+            if node['id'] == rule_name:
+                target_rule = node
+                break
+
+        if not target_rule:
+            raise HTTPException(status_code=404, detail=f"Rule '{rule_name}' not found")
+
+        # 아카이브된 로그 경로 확인을 위한 기본 경로 구성
+        if task.task_type == 'visualization':
+            base_task_folder = f"user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}"
+        else:
+            base_task_folder = f"user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}"
+
+        archived_logs_folder = os.path.join(base_task_folder, "executions", task.task_id, "logs")
+        use_archived_logs = os.path.exists(archived_logs_folder)
+
+        # 로그 파일들 읽기
+        rule_logs = {}
+        for log_type, log_path in target_rule['log_paths'].items():
+            # 아카이브된 로그가 있으면 해당 경로로 변환
+            actual_log_path = log_path
+            if use_archived_logs:
+                log_filename = os.path.basename(log_path)
+                archived_log_path = os.path.join(archived_logs_folder, log_filename)
+                if os.path.exists(archived_log_path):
+                    actual_log_path = archived_log_path
+
+            if os.path.exists(actual_log_path):
+                try:
+                    with open(actual_log_path, 'r', encoding='utf-8') as f:
+                        content = f.read()
+
+                    # 파일 정보 포함
+                    file_stat = os.stat(actual_log_path)
+                    rule_logs[log_type] = {
+                        "content": content,
+                        "file_path": actual_log_path,
+                        "size": file_stat.st_size,
+                        "modified_time": file_stat.st_mtime,
+                        "exists": True
+                    }
+                except Exception as e:
+                    rule_logs[log_type] = {
+                        "content": f"Error reading file: {str(e)}",
+                        "file_path": actual_log_path,
+                        "size": 0,
+                        "modified_time": 0,
+                        "exists": True,
+                        "error": str(e)
+                    }
+            else:
+                rule_logs[log_type] = {
+                    "content": "",
+                    "file_path": actual_log_path,
+                    "size": 0,
+                    "modified_time": 0,
+                    "exists": False
+                }
+
+        return {
+            "task_info": {
+                "task_id": task.task_id,
+                "workflow_id": task.workflow_id,
+                "algorithm_id": task.algorithm_id,
+                "task_type": task.task_type
+            },
+            "rule_info": {
+                "rule_name": rule_name,
+                "label": target_rule['label'],
+                "description": target_rule['description'],
+                "inputs": target_rule['inputs'],
+                "outputs": target_rule['outputs'],
+                "params": target_rule['params']
+            },
+            "logs": rule_logs
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error getting rule logs: {str(e)}")
+
+
+def get_dag_cache_stats(*, current_user: models.User) -> dict:
+    """DAG 파싱 캐시 통계 정보 조회 (관리자 전용)."""
+    try:
+        # 레거시 파서의 캐시 통계만 수집 (네이티브 파서는 캐시 제거됨)
+        from app.workflow.compiler.dag_parser import get_cache_stats as get_legacy_stats
+
+        legacy_stats = get_legacy_stats()
+
+        return {
+            "native_parser_cache": {"message": "Cache removed for simplification"},
+            "legacy_parser_cache": legacy_stats,
+            "timestamp": time.time(),
+            "message": "Cache statistics retrieved successfully"
+        }
+
+    except Exception as e:
+        logger.error(f"Error getting cache stats: {e}")
+        return {
+            "error": f"Failed to get cache statistics: {str(e)}",
+            "timestamp": time.time()
+        }
+
+
+def clear_dag_caches(*, current_user: models.User) -> dict:
+    """모든 DAG 파싱 캐시 초기화 (관리자 전용)."""
+    try:
+        # 레거시 파서의 캐시만 초기화 (네이티브 파서는 캐시 제거됨)
+        from app.workflow.compiler.dag_parser import clear_all_caches
+
+        # 레거시 파서 캐시 초기화
+        clear_all_caches()
+
+        logger.info(f"Legacy DAG cache cleared by user {current_user.id} (native cache removed)")
+
+        return {
+            "message": "Legacy DAG parsing cache cleared successfully (native cache removed for simplification)",
+            "timestamp": time.time(),
+            "cleared_by": current_user.username
+        }
+
+    except Exception as e:
+        logger.error(f"Error clearing caches: {e}")
+        return {
+            "error": f"Failed to clear caches: {str(e)}",
+            "timestamp": time.time()
+        }
+
+
+def get_execution_manifest(*, db: Session, current_user: models.User, task_id: str) -> StreamingResponse:
+    """SUCCESS 상태이고 Analysis 타입 플러그인인 Task의 execution manifest를 JSON으로 다운로드합니다."""
+    try:
+        # task_id로 task 정보 조회
+        task = crud_task.get_task_by_task_id(db, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        # 권한 확인 (해당 유저의 task인지 확인)
+        if task.user_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        # Task 상태 검증 - SUCCESS 상태만 허용
+        if task.status != 'SUCCESS':
+            raise HTTPException(
+                status_code=400,
+                detail=f"Execution manifest is only available for tasks with SUCCESS status. Current status: {task.status}"
+            )
+
+        # Plugin 정보 확인 및 타입 검증 - Analysis 타입만 허용
+        if not task.plugin:
+            raise HTTPException(status_code=400, detail="Plugin information not found for this task")
+
+        if task.plugin.plugin_type != PluginType.ANALYSIS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Execution manifest is only available for Analysis type plugins. Current plugin type: {task.plugin.plugin_type.value if task.plugin.plugin_type else 'unknown'}"
+            )
+
+        # Workflow 정보 조회
+        workflow = crud_workflow.get_workflow_by_id(db, task.workflow_id)
+
+        # 로그 폴더 경로 구성 - task_type에 따라 다른 경로 사용
+        if task.task_type == 'visualization':
+            task_folder_path = f"./user/{current_user.username}/workflow_{task.workflow_id}/visualization_{task.algorithm_id}"
+        else:
+            task_folder_path = f"./user/{current_user.username}/workflow_{task.workflow_id}/algorithm_{task.algorithm_id}"
+
+        # 아카이브된 로그가 있으면 해당 경로 사용 (task_id별 분리된 로그)
+        archived_logs_folder_path = os.path.join(task_folder_path, "executions", task.task_id, "logs")
+        if os.path.exists(archived_logs_folder_path):
+            logs_folder_path = archived_logs_folder_path
+        else:
+            logs_folder_path = os.path.join(task_folder_path, "logs")
+
+        # Execution manifest 데이터 구성
+        manifest_data = {
+            "manifest_info": {
+                "format_version": "1.0",
+                "generated_at": datetime.now().isoformat(),
+                "generated_by": current_user.username,
+                "description": "CellCraft execution manifest for analysis reproducibility"
+            },
+            "task_metadata": {
+                "task_id": task.task_id,
+                "workflow_id": task.workflow_id,
+                "algorithm_id": task.algorithm_id,
+                "plugin_name": task.plugin_name,
+                "task_type": task.task_type,
+                "status": task.status,
+                "start_time": str(task.start_time) if task.start_time else None,
+                "end_time": str(task.end_time) if task.end_time else None,
+                "plugin_image_uri": task.plugin_image_uri
+            },
+            "plugin_metadata": {
+                "id": task.plugin.id,
+                "name": task.plugin.name,
+                "description": task.plugin.description,
+                "author": task.plugin.author,
+                "version": task.plugin.version,
+                "plugin_type": task.plugin.plugin_type.value if task.plugin.plugin_type else None,
+                "source": task.plugin.source,
+                "use_gpu": task.plugin.use_gpu,
+                "created_at": str(task.plugin.created_at),
+                "updated_at": str(task.plugin.updated_at),
+                "dependencies": task.plugin.dependencies,
+                "drawflow": task.plugin.drawflow,
+                "rules": task.plugin.rules
+            },
+            "workflow_metadata": {
+                "id": workflow.id if workflow else None,
+                "title": workflow.title if workflow else None,
+                "workflow_info": workflow.workflow_info if workflow else None,
+                "created_at": str(workflow.created_at) if workflow else None,
+                "updated_at": str(workflow.updated_at) if workflow else None
+            },
+            "execution_files": {
+                "logs": {},
+                "snakefile": None,
+                "plugin_metadata": None,
+                "meta_yml": None,
+                "results": {}
+            }
+        }
+
+        # 로그 파일들 수집
+        if os.path.exists(logs_folder_path):
+            logs_path = Path(logs_folder_path)
+
+            for log_file_path in logs_path.glob("*"):
+                if log_file_path.is_file():
+                    try:
+                        with open(log_file_path, 'r', encoding='utf-8') as f:
+                            content = f.read()
+                        manifest_data["execution_files"]["logs"][log_file_path.name] = {
+                            "content": content,
+                            "size": log_file_path.stat().st_size,
+                            "modified_time": str(log_file_path.stat().st_mtime)
+                        }
+                    except Exception as e:
+                        # 파일 읽기 실패 시에도 에러 정보 포함
+                        manifest_data["execution_files"]["logs"][log_file_path.name] = {
+                            "content": f"Error reading file: {str(e)}",
+                            "size": log_file_path.stat().st_size if log_file_path.exists() else 0,
+                            "modified_time": str(log_file_path.stat().st_mtime) if log_file_path.exists() else None,
+                            "error": str(e)
+                        }
+
+        # Snakefile 내용 포함
+        snakefile_path = os.path.join(task_folder_path, "Snakefile")
+        if os.path.exists(snakefile_path):
+            try:
+                with open(snakefile_path, 'r', encoding='utf-8') as f:
+                    manifest_data["execution_files"]["snakefile"] = {
+                        "content": f.read(),
+                        "path": snakefile_path
+                    }
+            except Exception as e:
+                manifest_data["execution_files"]["snakefile"] = {
+                    "content": f"Error reading Snakefile: {str(e)}",
+                    "path": snakefile_path,
+                    "error": str(e)
+                }
+
+        # Plugin metadata.json 파일 내용 포함
+        plugin_metadata_path = os.path.join(task.plugin.plugin_path, "metadata.json")
+        if os.path.exists(plugin_metadata_path):
+            try:
+                with open(plugin_metadata_path, 'r', encoding='utf-8') as f:
+                    import json as json_lib
+                    manifest_data["execution_files"]["plugin_metadata"] = {
+                        "content": json_lib.load(f),
+                        "path": plugin_metadata_path
+                    }
+            except Exception as e:
+                manifest_data["execution_files"]["plugin_metadata"] = {
+                    "content": f"Error reading plugin metadata.json: {str(e)}",
+                    "path": plugin_metadata_path,
+                    "error": str(e)
+                }
+
+        # meta.yml 파일 내용 포함 (있는 경우)
+        # 아카이브된 로그를 사용하는 경우 아카이브된 meta.yml도 확인
+        archived_meta_yml_path = os.path.join(task_folder_path, "executions", task.task_id, "meta.yml")
+        if os.path.exists(archived_meta_yml_path):
+            meta_yml_path = archived_meta_yml_path
+        else:
+            meta_yml_path = os.path.join(task_folder_path, "meta.yml")
+
+        if os.path.exists(meta_yml_path):
+            try:
+                with open(meta_yml_path, 'r', encoding='utf-8') as f:
+                    manifest_data["execution_files"]["meta_yml"] = {
+                        "content": f.read(),
+                        "path": meta_yml_path
+                    }
+            except Exception as e:
+                manifest_data["execution_files"]["meta_yml"] = {
+                    "content": f"Error reading meta.yml: {str(e)}",
+                    "path": meta_yml_path,
+                    "error": str(e)
+                }
+
+        # Results 디렉토리의 파일들 메타데이터 수집
+        results_folder_path = os.path.join(task_folder_path, "results")
+        if os.path.exists(results_folder_path) and os.path.isdir(results_folder_path):
+            results_path = Path(results_folder_path)
+
+            # 파일 타입 분류 함수
+            def get_file_type(extension):
+                file_type_mapping = {
+                    '.sif': 'network',
+                    '.txt': 'text',
+                    '.csv': 'tabular',
+                    '.tsv': 'tabular',
+                    '.json': 'visualization',
+                    '.npy': 'numpy_array',
+                    '.h5ad': 'anndata',
+                    '.png': 'image',
+                    '.jpg': 'image',
+                    '.jpeg': 'image',
+                    '.pdf': 'document'
+                }
+                return file_type_mapping.get(extension.lower(), 'unknown')
+
+            for result_file_path in results_path.glob("*"):
+                if result_file_path.is_file():
+                    try:
+                        file_stat = result_file_path.stat()
+                        file_extension = result_file_path.suffix
+
+                        manifest_data["execution_files"]["results"][result_file_path.name] = {
+                            "size": file_stat.st_size,
+                            "modified_time": str(file_stat.st_mtime),
+                            "extension": file_extension,
+                            "file_type": get_file_type(file_extension),
+                            "path": str(result_file_path)
+                        }
+                    except Exception as e:
+                        # 파일 정보 읽기 실패 시에도 기본 정보는 포함
+                        manifest_data["execution_files"]["results"][result_file_path.name] = {
+                            "size": 0,
+                            "modified_time": None,
+                            "extension": result_file_path.suffix,
+                            "file_type": "error",
+                            "error": str(e)
+                        }
+
+            # 결과 파일이 없는 경우 정보 표시
+            if not manifest_data["execution_files"]["results"]:
+                logger.warning(f"No result files found in {results_folder_path}")
+        else:
+            logger.info(f"Results directory not found or not accessible: {results_folder_path}")
+
+        # JSON으로 변환
+        json_content = json.dumps(manifest_data, indent=2, ensure_ascii=False)
+
+        # 파일명 생성 (타임스탬프 포함)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"execution_manifest_{task.plugin_name}_{task_id[:8]}_{timestamp}.json"
+
+        # StreamingResponse로 다운로드 제공
+        return StreamingResponse(
+            io.StringIO(json_content),
+            media_type="application/json",
+            headers={"Content-Disposition": f"attachment; filename={filename}"}
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error generating execution manifest: {str(e)}")

--- a/backend/app/task/sse.py
+++ b/backend/app/task/sse.py
@@ -1,0 +1,63 @@
+"""
+Task status SSE (Server-Sent Events) streaming.
+
+Extracted from ``task/router.py`` in PR-7 (Phase 3c). The ``event_generator``
+that previously lived inline inside ``get_task_status`` now lives here as the
+reusable async streaming utility ``stream_task_status``. The router endpoint is
+reduced to ``EventSourceResponse(sse.stream_task_status(task_id))``.
+
+Behavior is preserved exactly: a 1-hour (3600s) timeout guard, a 5-second poll
+interval, termination on the terminal Celery states (SUCCESS / FAILURE /
+REVOKED), cancellation handling, and the ``finally`` cleanup log.
+
+NOTE on test patching: ``get_task_info`` is bound into this module's namespace
+at import time, so tests exercising the stream must patch
+``app.task.sse.get_task_info`` (not ``app.worker.utils.get_task_info``);
+otherwise the loop polls the real Celery backend.
+"""
+import asyncio
+import time
+
+from app.worker.utils import get_task_info
+
+
+async def stream_task_status(task_id: str):
+    """Yield task status frames for an SSE connection until a terminal state.
+
+    Emits the current Celery ``task_status`` every 5 seconds, terminates on
+    SUCCESS / FAILURE / REVOKED, and emits ``TIMEOUT`` after 3600s to prevent
+    memory leaks from abandoned connections. Cancellation and unexpected errors
+    are swallowed (logged via ``print``) and the ``finally`` block logs cleanup —
+    identical to the original inline generator.
+    """
+    timeout = 3600  # 1시간 타임아웃 (메모리 누수 방지)
+    start_time = time.time()
+    try:
+        while True:
+            # 타임아웃 체크
+            if time.time() - start_time > timeout:
+                print(f"SSE timeout reached for task {task_id}")
+                yield f"TIMEOUT"
+                break
+
+            if task_id:
+                task = get_task_info(task_id)
+                task_status = task.get('task_status', 'UNKNOWN')
+
+                if task_status in ['SUCCESS', 'FAILURE', 'REVOKED']:
+                    yield f"{task_status}"
+                    break
+
+                print(f"Task {task_id} status: {task_status}")
+                yield f"{task_status}"
+                await asyncio.sleep(5)
+            else:
+                break
+    except asyncio.CancelledError:
+        # 클라이언트 연결 끊김 처리
+        print(f"SSE connection cancelled for task {task_id}")
+    except Exception as e:
+        print(f"SSE error for task {task_id}: {e}")
+    finally:
+        # 정리 로직 - 리소스 해제
+        print(f"SSE generator cleanup for task {task_id}")

--- a/backend/tests/integration/test_characterization_task_status.py
+++ b/backend/tests/integration/test_characterization_task_status.py
@@ -41,7 +41,7 @@ TASK_PREFIX = f"{settings.ROUTES_STR}/task"
 class TestCharacterizationTaskStatus:
     """Freeze non-SSE task status endpoints; minimal SSE smoke."""
 
-    @patch("app.task.router.get_task_info")
+    @patch("app.task.service.get_task_info")
     def test_status_simple_response_shape(
         self,
         mock_get_task_info,
@@ -55,7 +55,7 @@ class TestCharacterizationTaskStatus:
         assert response.status_code == 200
         assert response.json() == {"task_id": "some-task-123", "status": "SUCCESS"}
 
-    @patch("app.task.router.get_task_info")
+    @patch("app.task.service.get_task_info")
     def test_status_missing_status_defaults_to_unknown(
         self,
         mock_get_task_info,
@@ -157,11 +157,12 @@ class TestCharacterizationTaskStatus:
 
         assert response.status_code == 404
 
-    # NOTE: task.py binds get_task_info at import time
-    # (`from ...worker.utils import get_task_info`), so the patch must target
-    # the endpoint module namespace — patching app.worker.utils has no effect and
-    # the SSE loop would poll the real backend forever.
-    @patch("app.task.router.get_task_info")
+    # NOTE: after PR-7 the SSE generator lives in ``app.task.sse`` and binds
+    # get_task_info at import time (`from ...worker.utils import get_task_info`),
+    # so the patch must target the SSE module namespace — patching
+    # app.worker.utils has no effect and the SSE loop would poll the real backend
+    # forever.
+    @patch("app.task.sse.get_task_info")
     def test_info_sse_stream_content_type(
         self,
         mock_get_task_info,

--- a/backend/tests/integration/test_task_api.py
+++ b/backend/tests/integration/test_task_api.py
@@ -705,7 +705,7 @@ class TestDAGStructure:
     """
 
     # Test 1: GET /dag-structure - success with valid task
-    @patch('app.task.router.parse_snakefile_native')
+    @patch('app.task.service.parse_snakefile_native')
     def test_dag_structure_success_native_parser(self, mock_parse_native, client, db_session, auth_headers, sample_task):
         """Test DAG structure endpoint successfully parses Snakefile using native parser."""
         # Arrange: Mock native parser to return valid DAG data
@@ -747,7 +747,7 @@ class TestDAGStructure:
 
     # Test 2: GET /dag-structure - fallback to legacy parser
     @patch('app.workflow.compiler.dag_parser.SnakemakeDAGParser')
-    @patch('app.task.router.parse_snakefile_native')
+    @patch('app.task.service.parse_snakefile_native')
     def test_dag_structure_fallback_to_legacy(self, mock_parse_native, mock_parser_class, client, db_session, auth_headers, sample_task):
         """Test DAG structure endpoint falls back to legacy parser when native parser fails."""
         # Arrange: Native parser fails, legacy succeeds
@@ -786,7 +786,7 @@ class TestDAGStructure:
         assert response.status_code == 401
 
     # Test 5: GET /dag-structure - forbidden access (different user)
-    @patch('app.task.router.parse_snakefile_native')
+    @patch('app.task.service.parse_snakefile_native')
     def test_dag_structure_forbidden(self, mock_parse_native, client, db_session, sample_task):
         """Test DAG structure endpoint returns 403 for different user's task."""
         # Mock parser to avoid file not found errors
@@ -815,7 +815,7 @@ class TestDAGStructure:
 
     # Test 6: GET /dag-structure - both parsers fail
     @patch('app.workflow.compiler.dag_parser.SnakemakeDAGParser')
-    @patch('app.task.router.parse_snakefile_native')
+    @patch('app.task.service.parse_snakefile_native')
     def test_dag_structure_both_parsers_fail(self, mock_parse_native, mock_parser_class, client, db_session, auth_headers, sample_task):
         """Test DAG structure endpoint returns 500 when both parsers fail."""
         # Arrange: Both parsers fail
@@ -833,8 +833,8 @@ class TestDAGStructure:
         assert "Failed to parse workflow" in response.json()["detail"]
 
     # Test 7: GET /rule-status - success with rule tracking
-    @patch('app.task.router.SnakemakeRuleStatusTracker')
-    @patch('app.task.router.parse_snakefile_native')
+    @patch('app.task.service.SnakemakeRuleStatusTracker')
+    @patch('app.task.service.parse_snakefile_native')
     def test_rule_status_success(self, mock_parse_native, mock_tracker_class, client, db_session, auth_headers, sample_task):
         """Test rule status endpoint returns rule execution statuses."""
         # Arrange: Mock DAG parsing
@@ -894,8 +894,8 @@ class TestDAGStructure:
         assert progress["percentage"] == 50.0
 
     # Test 8: GET /rule-status - with actual_status parameter
-    @patch('app.task.router.SnakemakeRuleStatusTracker')
-    @patch('app.task.router.parse_snakefile_native')
+    @patch('app.task.service.SnakemakeRuleStatusTracker')
+    @patch('app.task.service.parse_snakefile_native')
     def test_rule_status_with_actual_status_param(self, mock_parse_native, mock_tracker_class, client, db_session, auth_headers, sample_task):
         """Test rule status endpoint accepts and uses actual_status query parameter."""
         # Arrange
@@ -948,7 +948,7 @@ class TestDAGStructure:
         assert response.status_code == 401
 
     # Test 11: GET /rule-status - forbidden access (different user)
-    @patch('app.task.router.parse_snakefile_native')
+    @patch('app.task.service.parse_snakefile_native')
     def test_rule_status_forbidden(self, mock_parse_native, client, db_session, sample_task):
         """Test rule status endpoint returns 403 for different user's task."""
         # Mock parser to avoid file not found errors
@@ -974,8 +974,8 @@ class TestDAGStructure:
         assert "access denied" in response.json()["detail"].lower()
 
     # Test 12: GET /rule-status - fallback when tracker fails
-    @patch('app.task.router.SnakemakeRuleStatusTracker')
-    @patch('app.task.router.parse_snakefile_native')
+    @patch('app.task.service.SnakemakeRuleStatusTracker')
+    @patch('app.task.service.parse_snakefile_native')
     def test_rule_status_tracker_fallback(self, mock_parse_native, mock_tracker_class, client, db_session, auth_headers, sample_task):
         """Test rule status endpoint falls back to pending statuses when tracker fails."""
         # Arrange: DAG parsing succeeds, tracker fails
@@ -1030,7 +1030,7 @@ class TestSSEStatusStream:
     """
 
     # Test 1: SSE stream returns status updates
-    @patch('app.worker.utils.get_task_info')
+    @patch('app.task.sse.get_task_info')
     def test_sse_stream_status_updates(self, mock_get_task_info, client):
         """Test SSE endpoint streams task status updates."""
         # Arrange: Mock task info to return SUCCESS immediately
@@ -1048,7 +1048,7 @@ class TestSSEStatusStream:
         assert "SUCCESS" in response_text or response_text != ""
 
     # Test 2: SSE stream handles FAILURE status
-    @patch('app.worker.utils.get_task_info')
+    @patch('app.task.sse.get_task_info')
     def test_sse_stream_failure_status(self, mock_get_task_info, client):
         """Test SSE endpoint handles FAILURE status and terminates stream."""
         # Arrange
@@ -1063,7 +1063,7 @@ class TestSSEStatusStream:
         assert "FAILURE" in response.text
 
     # Test 3: SSE stream handles REVOKED status
-    @patch('app.worker.utils.get_task_info')
+    @patch('app.task.sse.get_task_info')
     def test_sse_stream_revoked_status(self, mock_get_task_info, client):
         """Test SSE endpoint handles REVOKED status and terminates stream."""
         # Arrange
@@ -1087,7 +1087,7 @@ class TestSSEStatusStream:
         assert response.status_code in [404, 405]  # 404 Not Found or 405 Method Not Allowed
 
     # Test 5: SSE stream with RUNNING status
-    @patch('app.worker.utils.get_task_info')
+    @patch('app.task.sse.get_task_info')
     def test_sse_stream_running_status(self, mock_get_task_info, client):
         """Test SSE endpoint returns RUNNING status."""
         # Arrange: Mock RUNNING status (in real scenario, would continue until terminal state)
@@ -1106,7 +1106,7 @@ class TestSSEStatusStream:
     def test_sse_content_type_header(self, client):
         """Test SSE endpoint returns correct content-type header."""
         # Act
-        with patch('app.worker.utils.get_task_info') as mock_get_task:
+        with patch('app.task.sse.get_task_info') as mock_get_task:
             mock_get_task.return_value = {"task_status": "SUCCESS"}
             response = client.get("/routes/task/info/test-task-headers")
 

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -1,0 +1,421 @@
+"""
+Unit tests for the task service + SSE layer (app/task/service.py, app/task/sse.py)
+and the ``TaskSubmission`` dispatch schema, extracted in PR-7.
+
+Scope: pin the extracted business logic directly with the Celery / Docker /
+filesystem boundaries mocked. The characterization/integration tests already
+pin the HTTP contract; these tests give the new service functions, the SSE
+streaming generator, and the ``TaskSubmission`` wire-format schema direct
+coverage.
+
+The most load-bearing test here is ``test_task_submission_dict_matches_*``:
+it proves ``TaskSubmission(...).dict(exclude_none=True)`` reproduces the exact
+legacy ``process_data_task`` dispatch kwargs (compile + visualization forms),
+so typing the payload does not change the on-the-wire contract.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastapi import HTTPException
+
+from app.task import service
+from app.task import sse
+from app.task.schemas import TaskSubmission
+
+
+def _user(username="tasksvc", user_id=11):
+    u = MagicMock()
+    u.id = user_id
+    u.username = username
+    return u
+
+
+# ---------------------------------------------------------------------------
+# TaskSubmission: wire-format round-trip (the PR-7 core improvement)
+# ---------------------------------------------------------------------------
+
+class TestTaskSubmissionWireFormat:
+    """``TaskSubmission.dict(exclude_none=True)`` must equal the legacy kwargs."""
+
+    def test_task_submission_dict_matches_compile_kwargs(self):
+        """Compile dispatch: schema reproduces the 7-key wire kwargs exactly.
+
+        Mirrors ``app/workflow/service.py::_dispatch_compile_task`` kwargs.
+        """
+        legacy_compile_kwargs = {
+            'user_id': 11,
+            'workflow_id': 5,
+            'algorithm_id': 9,
+            'plugin_name': 'P',
+            'task_type': 'compile',
+            'resource_type': 'cpu',
+            'resource_slots': 1,
+        }
+
+        submission = TaskSubmission(
+            user_id=11,
+            workflow_id=5,
+            algorithm_id=9,
+            plugin_name='P',
+            task_type='compile',
+            resource_type='cpu',
+            resource_slots=1,
+        )
+
+        assert submission.dict(exclude_none=True) == legacy_compile_kwargs
+
+    def test_task_submission_dict_matches_visualization_kwargs(self):
+        """Visualization dispatch: schema reproduces the 9-key wire kwargs exactly.
+
+        Mirrors ``app/workflow/service.py::visualize_data`` apply_async kwargs
+        (adds ``cache_key`` + ``cache_info``; resource_type='cpu', slots=1).
+        """
+        cache_info = {
+            'user_path': './user/tasksvc/',
+            'result_file_path': './user/tasksvc/workflow_5/visualization_3/results/out.json',
+            'plugin_name': 'P',
+            'script_name': 'viz',
+            'linked_location': 'workflow_5/visualization_3/results/out.json',
+        }
+        legacy_viz_kwargs = {
+            'user_id': 11,
+            'workflow_id': 5,
+            'algorithm_id': 3,
+            'plugin_name': 'P',
+            'task_type': 'visualization',
+            'resource_type': 'cpu',
+            'resource_slots': 1,
+            'cache_key': 'abc123',
+            'cache_info': cache_info,
+        }
+
+        submission = TaskSubmission(
+            user_id=11,
+            workflow_id=5,
+            algorithm_id=3,
+            plugin_name='P',
+            task_type='visualization',
+            resource_type='cpu',
+            resource_slots=1,
+            cache_key='abc123',
+            cache_info=cache_info,
+        )
+
+        assert submission.dict(exclude_none=True) == legacy_viz_kwargs
+
+    def test_defaults_match_worker_signature(self):
+        """resource_type / resource_slots defaults match the worker signature."""
+        submission = TaskSubmission(
+            user_id=1, workflow_id=2, algorithm_id=3,
+            plugin_name='P', task_type='compile',
+        )
+        assert submission.resource_type == 'cpu'
+        assert submission.resource_slots == 4
+        # exclude_none keeps the (defaulted, non-None) resource fields but drops
+        # the visualization-only extras.
+        assert submission.dict(exclude_none=True) == {
+            'user_id': 1,
+            'workflow_id': 2,
+            'algorithm_id': 3,
+            'plugin_name': 'P',
+            'task_type': 'compile',
+            'resource_type': 'cpu',
+            'resource_slots': 4,
+        }
+
+    def test_algorithm_id_value_shape_preserved(self):
+        """algorithm_id is passed through untouched (no int coercion of node ids)."""
+        submission = TaskSubmission(
+            user_id=1, workflow_id=2, algorithm_id="node-7",
+            plugin_name='P', task_type='visualization',
+        )
+        assert submission.dict(exclude_none=True)['algorithm_id'] == "node-7"
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming: terminal states, timeout, cleanup
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestStreamTaskStatus:
+    """``sse.stream_task_status`` terminal/timeout/cleanup behavior."""
+
+    async def _collect(self, task_id):
+        return [frame async for frame in sse.stream_task_status(task_id)]
+
+    @pytest.mark.parametrize("terminal", ["SUCCESS", "FAILURE", "REVOKED"])
+    async def test_terminal_status_yields_once_and_stops(self, terminal):
+        with patch("app.task.sse.get_task_info", return_value={"task_status": terminal}):
+            frames = await self._collect("t1")
+        assert frames == [terminal]
+
+    async def test_missing_status_defaults_to_unknown_then_sleeps(self):
+        # UNKNOWN is non-terminal -> yields once, then hits asyncio.sleep(5).
+        # Patch sleep to raise so the loop terminates deterministically.
+        with patch("app.task.sse.get_task_info", return_value={}), \
+                patch("app.task.sse.asyncio.sleep", side_effect=StopAsyncIteration):
+            frames = await self._collect("t2")
+        # StopAsyncIteration is swallowed by the generator's except Exception.
+        assert frames == ["UNKNOWN"]
+
+    async def test_timeout_yields_timeout_frame(self):
+        # Force the elapsed-time check to exceed the 3600s timeout immediately.
+        times = iter([1000.0, 1000.0 + 4000])
+        with patch("app.task.sse.get_task_info", return_value={"task_status": "RUNNING"}), \
+                patch("app.task.sse.time.time", side_effect=lambda: next(times)):
+            frames = await self._collect("t3")
+        assert frames == ["TIMEOUT"]
+
+    async def test_exception_is_swallowed(self):
+        with patch("app.task.sse.get_task_info", side_effect=RuntimeError("boom")):
+            frames = await self._collect("t4")
+        assert frames == []
+
+
+# ---------------------------------------------------------------------------
+# get_task_status_simple
+# ---------------------------------------------------------------------------
+
+class TestGetTaskStatusSimple:
+    def test_returns_status_shape(self):
+        with patch("app.task.service.get_task_info", return_value={"task_status": "SUCCESS"}):
+            result = service.get_task_status_simple(task_id="abc")
+        assert result == {"task_id": "abc", "status": "SUCCESS"}
+
+    def test_missing_status_defaults_unknown(self):
+        with patch("app.task.service.get_task_info", return_value={}):
+            result = service.get_task_status_simple(task_id="abc")
+        assert result == {"task_id": "abc", "status": "UNKNOWN"}
+
+    def test_blank_task_id_raises_400(self):
+        with pytest.raises(HTTPException) as exc:
+            service.get_task_status_simple(task_id="   ")
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Invalid task_id"
+
+
+# ---------------------------------------------------------------------------
+# get_resources
+# ---------------------------------------------------------------------------
+
+class TestGetResources:
+    def test_returns_status_dict(self):
+        with patch("app.shared.resources.get_resource_status", return_value={"cpu": 4}):
+            assert service.get_resources() == {"cpu": 4}
+
+    def test_none_status_raises_503(self):
+        with patch("app.shared.resources.get_resource_status", return_value=None):
+            with pytest.raises(HTTPException) as exc:
+                service.get_resources()
+        assert exc.value.status_code == 503
+        assert exc.value.detail == "Resource monitoring unavailable"
+
+
+# ---------------------------------------------------------------------------
+# get_task_monitoring
+# ---------------------------------------------------------------------------
+
+class TestGetTaskMonitoring:
+    def test_empty_returns_empty_list(self):
+        db = MagicMock()
+        with patch("app.task.service.crud_task.get_user_task_with_plugin", return_value=[]):
+            assert service.get_task_monitoring(db=db, current_user=_user()) == []
+
+    def test_filters_plugin_build_and_shapes_items(self):
+        from datetime import datetime
+
+        db = MagicMock()
+        user = _user()
+
+        def _task(task_type, tid):
+            t = MagicMock()
+            t.id = 1
+            t.task_id = tid
+            t.workflow_id = 5
+            t.user_id = user.id
+            t.status = "RUNNING"
+            t.start_time = datetime(2026, 1, 1, 0, 0, 0)
+            t.end_time = None
+            t.task_type = task_type
+            t.plugin_name = "P"
+            t.plugin = None
+            t.workflows = None
+            return t
+
+        tasks = [_task("compile", "c1"), _task("visualization", "v1"), _task("plugin_build", "b1")]
+        with patch("app.task.service.crud_task.get_user_task_with_plugin", return_value=tasks):
+            items = service.get_task_monitoring(db=db, current_user=user)
+
+        assert len(items) == 2
+        types = {i.task_type for i in items}
+        assert "plugin_build" not in types
+        assert types == {"compile", "visualization"}
+        # compile task_title == plugin_name; visualization gets the -visualization suffix
+        titles = {i.task_type: i.task_title for i in items}
+        assert titles["compile"] == "P"
+        assert titles["visualization"] == "P-visualization"
+
+
+# ---------------------------------------------------------------------------
+# delete_task
+# ---------------------------------------------------------------------------
+
+class TestDeleteTask:
+    def test_returns_fixed_message(self):
+        db = MagicMock()
+        with patch("app.task.service.crud_task.delete_user_task", return_value=MagicMock()):
+            result = service.delete_task(db=db, current_user=_user(), task_id="abc")
+        assert result == {"message": "Task Deleted", "task_id": "abc"}
+
+    def test_propagates_not_found(self):
+        db = MagicMock()
+        with patch(
+            "app.task.service.crud_task.delete_user_task",
+            side_effect=HTTPException(status_code=404, detail="Task abc not found"),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                service.delete_task(db=db, current_user=_user(), task_id="abc")
+        assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# get_task_logs: auth + not-found
+# ---------------------------------------------------------------------------
+
+class TestGetTaskLogs:
+    def test_task_not_found_raises_404(self):
+        db = MagicMock()
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=None):
+            with pytest.raises(HTTPException) as exc:
+                service.get_task_logs(db=db, current_user=_user(), task_id="abc")
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Task not found"
+
+    def test_other_users_task_raises_403(self):
+        db = MagicMock()
+        task = MagicMock()
+        task.user_id = 999  # different from _user().id
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=task):
+            with pytest.raises(HTTPException) as exc:
+                service.get_task_logs(db=db, current_user=_user(), task_id="abc")
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Access denied"
+
+
+# ---------------------------------------------------------------------------
+# get_dag_structure: parser delegation + fallback + auth
+# ---------------------------------------------------------------------------
+
+class TestGetDagStructure:
+    def _task(self, user):
+        t = MagicMock()
+        t.user_id = user.id
+        t.task_id = "abc"
+        t.workflow_id = 5
+        t.algorithm_id = 1
+        t.task_type = "compile"
+        t.plugin_name = "P"
+        t.status = "RUNNING"
+        return t
+
+    def test_native_parser_success(self):
+        db = MagicMock()
+        user = _user()
+        dag = {"nodes": [{"id": "r1"}], "edges": [], "execution_sequence": ["r1"], "method": "native"}
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=self._task(user)), \
+                patch("app.task.service.parse_snakefile_native", return_value=dag):
+            result = service.get_dag_structure(db=db, current_user=user, task_id="abc")
+        assert result["dag_structure"]["parsing_method"] == "native_native"
+        assert result["task_info"]["task_id"] == "abc"
+
+    def test_falls_back_to_legacy_parser(self):
+        db = MagicMock()
+        user = _user()
+        legacy_parser = MagicMock()
+        legacy_parser.parse_snakefile_with_logs.return_value = {
+            "nodes": [{"id": "r1"}], "edges": [], "execution_sequence": ["r1"]
+        }
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=self._task(user)), \
+                patch("app.task.service.parse_snakefile_native", side_effect=Exception("native down")), \
+                patch("app.task.service.SnakemakeDAGParser", return_value=legacy_parser):
+            result = service.get_dag_structure(db=db, current_user=user, task_id="abc")
+        assert result["dag_structure"]["parsing_method"] == "legacy"
+
+    def test_task_not_found_raises_404(self):
+        db = MagicMock()
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=None):
+            with pytest.raises(HTTPException) as exc:
+                service.get_dag_structure(db=db, current_user=_user(), task_id="abc")
+        assert exc.value.status_code == 404
+
+    def test_forbidden_raises_403(self):
+        db = MagicMock()
+        task = MagicMock()
+        task.user_id = 999
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=task):
+            with pytest.raises(HTTPException) as exc:
+                service.get_dag_structure(db=db, current_user=_user(), task_id="abc")
+        assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# get_rule_status: tracker success + fallback
+# ---------------------------------------------------------------------------
+
+class TestGetRuleStatus:
+    def _task(self, user):
+        t = MagicMock()
+        t.user_id = user.id
+        t.task_id = "abc"
+        t.workflow_id = 5
+        t.algorithm_id = 1
+        t.task_type = "compile"
+        t.plugin_name = "P"
+        t.status = "RUNNING"
+        return t
+
+    def test_tracker_success(self):
+        db = MagicMock()
+        user = _user()
+        dag = {"nodes": [{"id": "r1"}, {"id": "r2"}], "execution_sequence": ["r1", "r2"]}
+        tracker = MagicMock()
+        tracker.get_enhanced_progress_info.return_value = {
+            "basic_progress": {
+                "total_rules": 2, "completed_rules": 1, "failed_rules": 0,
+                "running_rules": 1, "pending_rules": 0, "percentage": 50.0,
+            },
+            "rule_statuses": {"r1": "completed", "r2": "running"},
+        }
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=self._task(user)), \
+                patch("app.task.service.parse_snakefile_native", return_value=dag), \
+                patch("app.task.service.SnakemakeRuleStatusTracker", return_value=tracker):
+            result = service.get_rule_status(db=db, current_user=user, task_id="abc")
+        assert result["rule_statuses"] == {"r1": "completed", "r2": "running"}
+        assert result["progress"]["percentage"] == 50.0
+
+    def test_actual_status_param_used(self):
+        db = MagicMock()
+        user = _user()
+        dag = {"nodes": [{"id": "r1"}], "execution_sequence": ["r1"]}
+        tracker = MagicMock()
+        tracker.get_enhanced_progress_info.return_value = {
+            "basic_progress": {"total_rules": 1, "completed_rules": 1, "percentage": 100.0},
+            "rule_statuses": {"r1": "completed"},
+        }
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=self._task(user)), \
+                patch("app.task.service.parse_snakefile_native", return_value=dag), \
+                patch("app.task.service.SnakemakeRuleStatusTracker", return_value=tracker) as mk:
+            service.get_rule_status(db=db, current_user=user, task_id="abc", actual_status="COMPLETED")
+        assert mk.call_args[1]["task_status"] == "COMPLETED"
+
+    def test_tracker_failure_falls_back_to_pending(self):
+        db = MagicMock()
+        user = _user()
+        dag = {"nodes": [{"id": "r1"}, {"id": "r2"}], "execution_sequence": ["r1", "r2"]}
+        with patch("app.task.service.crud_task.get_task_by_task_id", return_value=self._task(user)), \
+                patch("app.task.service.parse_snakefile_native", return_value=dag), \
+                patch("app.task.service.SnakemakeRuleStatusTracker", side_effect=Exception("tracker down")):
+            result = service.get_rule_status(db=db, current_user=user, task_id="abc")
+        assert result["rule_statuses"] == {"r1": "pending", "r2": "pending"}
+        assert result["progress"]["pending_rules"] == 2
+        assert result["progress"]["completed_rules"] == 0

--- a/docs/refactoring/v1.0.7/phase-3-service-layer.md
+++ b/docs/refactoring/v1.0.7/phase-3-service-layer.md
@@ -97,13 +97,15 @@ def submit_task(*, db: Session, user: User, payload: ...) -> Task:
     submission = TaskSubmission(...)
     celery_task = run_pipeline.apply_async(kwargs=submission.dict(), ...)
 ```
-- [ ] `worker/tasks.py` 쪽에서도 수신 시 같은 스키마로 파싱 → 런타임 검증
-- [ ] **와이어 포맷(kwargs 키 이름) 불변** — 구버전 워커/신버전 웹 혼재 배포 호환
+- [~] `worker/tasks.py` 쪽에서도 수신 시 같은 스키마로 파싱 → 런타임 검증
+      (SKIPPED: `process_data_task` 시그니처는 `**kwargs`가 아닌 명시 인자라 워커 변경 없음. `TaskSubmission`은 task/schemas.py에 정의 — 디스패치측 타입화 전용)
+- [x] **와이어 포맷(kwargs 키 이름) 불변** — 구버전 워커/신버전 웹 혼재 배포 호환
+      (`TaskSubmission.dict(exclude_none=True)` == 기존 compile/visualization kwargs, 왕복 테스트로 검증)
 
 ### 체크리스트
-- [ ] SSE 이벤트 포맷·종료 조건 characterization 테스트 통과
-- [ ] 타임아웃/정리(finally) 로직이 sse.py로 이동 후에도 동일 동작
-- [ ] service + sse 단위 테스트
+- [x] SSE 이벤트 포맷·종료 조건 characterization 테스트 통과 (patch 경로만 `app.task.sse`/`app.task.service`로 갱신)
+- [x] 타임아웃/정리(finally) 로직이 sse.py로 이동 후에도 동일 동작 (`stream_task_status` 단위 테스트: 종료조건/타임아웃/예외/cleanup)
+- [x] service + sse 단위 테스트 (tests/unit/test_task_service.py, 28건)
 
 ---
 


### PR DESCRIPTION
## refactor(v1.0.7): task 서비스 계층 추출 + SSE 분리 (PR-7)

**Phase**: 3c | **PR 번호**: PR-7 | **계획 문서**: docs/refactoring/v1.0.7/phase-3-service-layer.md
**선행 PR**: PR-6 (#116) — ⚠️ **스택 PR**: #111→#112→#113→#114→#115→#116→PR-7 순차 머지.

### 범위 (동작 보존 추출)
- `task/service.py` 신설 — 상태 조회/모니터링/삭제/취소/로그/DAG 구조 전 로직 추출. **router 1,449줄 → 245줄**
- `task/sse.py` 신설 — SSE 스트리밍 루프 분리 (타임아웃·종료조건·정리 동작 동일)
- **Celery 디스패치 kwargs 타입화**: `TaskSubmission` pydantic 스키마 — `.dict()` == 기존 kwargs를 왕복 테스트로 검증 (와이어 포맷 불변, 혼재 배포 호환). 워커 수신부는 명시 인자 시그니처라 변경 없음
- 신규 단위 테스트 28건

### 트러블슈팅 기록 (리뷰어 참고)
SSE 추출 후 기존 테스트의 stale patch(`app.worker.utils.get_task_info`)가 mock 미적용 상태로 실제 폴링 루프를 돌려 `test_task_api.py` 단독 실행이 62분까지 늘어났음 → patch를 `app.task.sse` 네임스페이스로 갱신해 2분 46초로 복구 (기대값 불변). [sse.py](backend/app/task/sse.py) docstring에 올바른 patch 대상 문서화.

### 머지 게이트 결과
| 게이트 | 결과 |
|---|---|
| 1. pytest 전체 | ✅ **524 passed** / 68 failed — baseline과 실패 집합 완전 동일 (diff empty), 런타임 4:31 정상 |
| 2. OpenAPI 스냅샷 | ✅ diff 0 |
| 3. alembic | ✅ 스키마 변경 없음 |
| 4. 워커 스모크 | ✅ 태스크 이름 2종 불변 + app.main 미유입 |
| import-linter | ✅ 2 kept, 0 broken |

### 과도기 항목 (PR-8에서 정리)
- service 내 HTTPException → 도메인 예외 전환
- `service.revoke_task`의 `app.main` 지연 import (기존 테스트 patch 호환용)

### 롤백
`git revert` (DB 변경 없음)