### PR TITLE
refactor(v1.0.7) PR-8: 나머지 도메인 서비스 + 전역 예외 핸들러 — Phase 3 완료

### DIFF
--- a/backend/app/admin/router.py
+++ b/backend/app/admin/router.py
@@ -1,21 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
-from typing import List,Optional,Any
+from fastapi import APIRouter, Depends, Query
+from typing import Any
 from sqlalchemy.orm import Session
-import docker
-from sqlalchemy import asc, desc, or_
-import logging
 
 from app.auth import deps as dep
-from app.admin.schemas import Conditions
-from app.admin import crud as crud_admin
 from app import models
-from app.plugin.sync import PluginSyncManager
-from app.plugin.versioning import PluginVersionValidator
-from app.shared.docker import container_manager
-
-logger = logging.getLogger(__name__)
+from app.admin import service
 
 router = APIRouter()
+
 
 @router.get("/users", response_model=Any)
 def get_filtered_users(
@@ -28,23 +20,11 @@ def get_filtered_users(
     order: str,
     searchTerm: str,
 ):
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    conditions = Conditions(
-        amount=amount,
-        page_num=page_num,
-        sort=sort,
-        order=order,
-        searchTerm=searchTerm
+    return service.get_filtered_users(
+        db=db, current_user=current_user, amount=amount, page_num=page_num,
+        sort=sort, order=order, searchTerm=searchTerm,
     )
 
-    users, total_count = crud_admin.get_filtered_users(db, conditions)
-
-    if not users:
-        raise HTTPException(status_code=404, detail="Users not found")
-    return users
 
 @router.get("/users_count", response_model=Any)
 def get_users_count(
@@ -52,12 +32,8 @@ def get_users_count(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
+    return service.get_users_count(db=db, current_user=current_user)
 
-    users_num = crud_admin.get_users_count(db)
-    return users_num
 
 @router.get("/files", response_model=Any)
 def get_filtered_files(
@@ -70,41 +46,11 @@ def get_filtered_files(
     order: str,
     searchTerm: str,
     ):
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    conditions = Conditions(
-        amount=amount,
-        page_num=page_num,
-        sort=sort,
-        order=order,
-        searchTerm=searchTerm
+    return service.get_filtered_files(
+        db=db, current_user=current_user, amount=amount, page_num=page_num,
+        sort=sort, order=order, searchTerm=searchTerm,
     )
 
-    files, total_count = crud_admin.get_filtered_files(db, conditions)
-
-    if not files:
-        raise HTTPException(status_code=404, detail="Files not found")
-    
-    # 결과 포맷팅
-    formatted_files = []
-    for file, username in files:
-        formatted_file = {
-            'id': file.id,
-            'file_name': file.file_name,
-            'file_path': file.file_path,
-            'file_size': file.file_size,
-            'folder': file.folder,
-            'username': username,
-            'user_id': file.user_id
-        }
-        formatted_files.append(formatted_file)
-    
-    return {
-        'data': formatted_files,
-        'total_count': total_count
-    }
 
 @router.get("/files_count", response_model=Any)
 def get_files_count(
@@ -112,12 +58,8 @@ def get_files_count(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
+    return service.get_files_count(db=db, current_user=current_user)
 
-    files_num = crud_admin.get_files_count(db)
-    return files_num
 
 @router.get("/workflows", response_model=Any)
 def get_filtered_workflows(
@@ -130,39 +72,11 @@ def get_filtered_workflows(
     order: str,
     searchTerm: str,
 ):
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    conditions = Conditions(
-        amount=amount,
-        page_num=page_num,
-        sort=sort,
-        order=order,
-        searchTerm=searchTerm
+    return service.get_filtered_workflows(
+        db=db, current_user=current_user, amount=amount, page_num=page_num,
+        sort=sort, order=order, searchTerm=searchTerm,
     )
 
-    workflows, total_count = crud_admin.get_filtered_workflows(db, conditions)
-
-    if not workflows:
-        raise HTTPException(status_code=404, detail="Workflows not found")
-    
-    # 결과 포맷팅
-    formatted_workflows = []
-    for workflow, username in workflows:
-        formatted_workflow = {
-            'id': workflow.id,
-            'title': workflow.title,
-            'username': username,
-            'updated_at': workflow.updated_at,
-            'user_id': workflow.user_id
-        }
-        formatted_workflows.append(formatted_workflow)
-    
-    return {
-        'data': formatted_workflows,
-        'total_count': total_count
-    }
 
 @router.get("/workflows_count", response_model=Any)
 def get_workflows_count(
@@ -170,13 +84,8 @@ def get_workflows_count(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
+    return service.get_workflows_count(db=db, current_user=current_user)
 
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    workflows_num = crud_admin.get_workflows_count(db)
-    return workflows_num
 
 @router.get("/tasks", response_model=Any)
 def get_filtered_tasks(
@@ -189,42 +98,11 @@ def get_filtered_tasks(
     order: str,
     searchTerm: str,
     ):
-
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    conditions = Conditions(
-        amount=amount,
-        page_num=page_num,
-        sort=sort,
-        order=order,
-        searchTerm=searchTerm
+    return service.get_filtered_tasks(
+        db=db, current_user=current_user, amount=amount, page_num=page_num,
+        sort=sort, order=order, searchTerm=searchTerm,
     )
 
-    tasks, total_count = crud_admin.get_filtered_tasks(db, conditions)
-
-    if not tasks:
-        raise HTTPException(status_code=404, detail="Tasks not found")
-    
-    # 결과 포맷팅
-    formatted_tasks = []
-    for task, username, workflow_title in tasks:
-        formatted_task = {
-            'id': task.id,
-            'user_id': task.user_id,
-            'workflow_id': task.workflow_id,
-            'username': username,
-            'workflow_title': workflow_title,
-            'status': task.status,
-            'start_time': task.start_time
-        }
-        formatted_tasks.append(formatted_task)
-    
-    return {
-        'data': formatted_tasks,
-        'total_count': total_count
-    }
 
 @router.get("/tasks_count", response_model=Any)
 def get_tasks_count(
@@ -232,12 +110,8 @@ def get_tasks_count(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
+    return service.get_tasks_count(db=db, current_user=current_user)
 
-    tasks_num = crud_admin.get_tasks_count(db)
-    return tasks_num
 
 @router.get("/plugins", response_model=Any)
 def get_filtered_plugins(
@@ -250,23 +124,11 @@ def get_filtered_plugins(
     order: str,
     searchTerm: str,
     ):
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    conditions = Conditions(
-        amount=amount,
-        page_num=page_num,
-        sort=sort,
-        order=order,
-        searchTerm=searchTerm
+    return service.get_filtered_plugins(
+        db=db, current_user=current_user, amount=amount, page_num=page_num,
+        sort=sort, order=order, searchTerm=searchTerm,
     )
 
-    plugins, total_count = crud_admin.get_filtered_plugins(db, conditions)
-
-    if not plugins:
-        raise HTTPException(status_code=404, detail="Plugins not found")
-    return plugins
 
 @router.get("/plugins_count", response_model=Any)
 def get_plugins_count(
@@ -274,167 +136,13 @@ def get_plugins_count(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    # 관리자 권한 확인
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
+    return service.get_plugins_count(db=db, current_user=current_user)
 
-    plugins_num = crud_admin.get_plugins_count(db)
-    return plugins_num
 
 @router.get("/system/stats", response_model=Any)
 def get_system_stats():
-    # Docker 클라이언트 연결
-    client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+    return service.get_system_stats()
 
-    try:  # 메모리 누수 방지를 위한 try/finally 패턴
-        containers = client.containers.list()
-        print("현재 실행 중인 컨테이너 목록:")
-        
-        # 모든 컨테이너의 통계 정보를 저장할 리스트
-        container_stats = []
-        
-        for container in containers:
-            container_name = container.name
-            print(container_name)
-            
-            # 컨테이너 필터링 로직 - cellcraft 서비스와 plugin 컨테이너만 포함
-            should_monitor = False
-            
-            # 1. cellcraft 서비스 컨테이너 (docker-compose로 생성된 컨테이너)
-            # docker-compose는 서비스명-숫자 형태로 컨테이너를 명명함
-            cellcraft_services = ["cellcraft-frontend", "cellcraft-backend", "cellcraft-celery", "cellcraft-db"]
-            if any(container_name.startswith(service) for service in cellcraft_services):
-                should_monitor = True
-            
-            # 2. plugin 실행 컨테이너 (plugin-으로 시작하는 컨테이너)
-            # 예: plugin-tenet-task-12345678-1234567890
-            elif container_name.startswith("plugin-"):
-                should_monitor = True
-            
-            # 모니터링 대상이 아니면 건너뛰기
-            if not should_monitor:
-                continue
-            
-            try:
-                # 컨테이너 상세 정보 가져오기
-                stats = container.stats(stream=False)
-                container_info = container.attrs
-
-                # CPU 상세 정보 계산
-                cpu_stats = stats['cpu_stats']
-                precpu_stats = stats['precpu_stats']
-                cpu_usage = cpu_stats['cpu_usage']['total_usage'] - precpu_stats['cpu_usage']['total_usage']
-                system_cpu_usage = cpu_stats['system_cpu_usage'] - precpu_stats['system_cpu_usage']
-                num_cpus = len(cpu_stats['cpu_usage'].get('percpu_usage', []))
-                cpu_percent = (cpu_usage / system_cpu_usage) * 100 * num_cpus if system_cpu_usage > 0 else 0
-
-                # 메모리 상세 정보 계산
-                memory_stats = stats['memory_stats']
-                memory_usage = memory_stats.get('usage', 0)
-                memory_limit = memory_stats.get('limit', 0)
-                memory_percent = (memory_usage / memory_limit) * 100 if memory_limit > 0 else 0
-                memory_stats_detailed = {
-                    'total_bytes': memory_limit,
-                    'used_bytes': memory_usage,
-                    'available_bytes': memory_limit - memory_usage,
-                    'percent': memory_percent,
-                    'stats': memory_stats.get('stats', {})
-                }
-
-                # GPU 정보 가져오기
-                gpu_stats = None
-                try:
-                    exec_result = container.exec_run(
-                        'nvidia-smi --query-gpu=index,name,temperature.gpu,utilization.gpu,memory.total,memory.used,memory.free,power.draw,power.limit --format=csv,noheader,nounits'
-                    )
-                    if exec_result.exit_code == 0:
-                        gpu_stats = []
-                        gpu_output = exec_result.output.decode('utf-8')
-                        for line in gpu_output.splitlines():
-                            index, name, temp, util, mem_total, mem_used, mem_free, power_draw, power_limit = line.split(',')
-                            gpu_stats.append({
-                                'id': int(index.strip()),
-                                'name': name.strip(),
-                                'temperature_c': float(temp.strip()),
-                                'utilization_percent': float(util.strip()),
-                                'memory': {
-                                    'total_bytes': int(mem_total.strip()) * 1024 * 1024,
-                                    'used_bytes': int(mem_used.strip()) * 1024 * 1024,
-                                    'free_bytes': int(mem_free.strip()) * 1024 * 1024,
-                                    'utilization_percent': (int(mem_used.strip()) / int(mem_total.strip())) * 100
-                                },
-                                'power': {
-                                    'draw_watts': float(power_draw.strip()),
-                                    'limit_watts': float(power_limit.strip())
-                                }
-                            })
-                except Exception as e:
-                    print(f"GPU 정보 조회 실패: {e}")
-
-                # 네트워크 정보
-                network_stats = stats.get('networks', {})
-                
-                # 컨테이너별 통계 정보 저장
-                container_stats.append({
-                    'container_info': {
-                        'id': container.id,
-                        'name': container.name,
-                        'status': container.status,
-                        'created': container_info['Created'],
-                        'image': container_info['Config']['Image'],
-                        'command': container_info['Config']['Cmd'],
-                        'labels': container_info['Config'].get('Labels', {})
-                    },
-                    'cpu': {
-                        'usage_percent': cpu_percent,
-                        'num_cpus': num_cpus,
-                        'total_usage': cpu_usage,
-                        'system_usage': system_cpu_usage,
-                        'per_cpu_usage': cpu_stats['cpu_usage'].get('percpu_usage', [])
-                    },
-                    'memory': memory_stats_detailed,
-                    'gpu': gpu_stats,
-                    'network': {
-                        interface: {
-                            'rx_bytes': data['rx_bytes'],
-                            'tx_bytes': data['tx_bytes'],
-                            'rx_packets': data['rx_packets'],
-                            'tx_packets': data['tx_packets'],
-                            'rx_errors': data['rx_errors'],
-                            'tx_errors': data['tx_errors']
-                        } for interface, data in network_stats.items()
-                    }
-                })
-            except Exception as e:
-                print(f"컨테이너 {container.name} 통계 정보 조회 실패: {e}")
-                continue
-
-        # 전체 시스템 통계 계산
-        total_cpu_usage = sum(stat['cpu']['usage_percent'] for stat in container_stats)
-        total_memory_usage = sum(stat['memory']['used_bytes'] for stat in container_stats)
-        total_memory_limit = sum(stat['memory']['total_bytes'] for stat in container_stats)
-        
-        system_stats = {
-            'total_containers': len(container_stats),
-            'total_cpu_usage_percent': total_cpu_usage,
-            'total_memory_usage_bytes': total_memory_usage,
-            'total_memory_limit_bytes': total_memory_limit,
-            'total_memory_usage_percent': (total_memory_usage / total_memory_limit * 100) if total_memory_limit > 0 else 0,
-            'containers': container_stats
-        }
-        
-        return system_stats
-
-    except docker.errors.NotFound:
-        return {'message': "Docker 데몬에 연결할 수 없습니다."}
-    except Exception as e:
-        return {'message': f"시스템 정보 조회 중 오류 발생: {str(e)}"}
-    finally:
-        # Docker 클라이언트 연결 해제 - TCP 소켓 누수 방지
-        try:
-            client.close()
-        except Exception:
-            pass
 
 @router.put("/users/{user_id}", response_model=Any)
 def update_user(
@@ -443,13 +151,10 @@ def update_user(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    user = crud_admin.update_user(db, user_id, user_data)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-    return user
+    return service.update_user(
+        db=db, current_user=current_user, user_id=user_id, user_data=user_data
+    )
+
 
 @router.delete("/users/{user_id}")
 def delete_user(
@@ -457,13 +162,8 @@ def delete_user(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    success = crud_admin.delete_user(db, user_id)
-    if not success:
-        raise HTTPException(status_code=404, detail="User not found")
-    return {"message": "User deleted successfully"}
+    return service.delete_user(db=db, current_user=current_user, user_id=user_id)
+
 
 @router.delete("/files/{file_id}")
 def delete_file(
@@ -471,13 +171,8 @@ def delete_file(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    success = crud_admin.delete_file(db, file_id)
-    if not success:
-        raise HTTPException(status_code=404, detail="File not found")
-    return {"message": "File deleted successfully"}
+    return service.delete_file(db=db, current_user=current_user, file_id=file_id)
+
 
 @router.delete("/workflows/{workflow_id}")
 def delete_workflow(
@@ -485,13 +180,8 @@ def delete_workflow(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    success = crud_admin.delete_workflow(db, workflow_id)
-    if not success:
-        raise HTTPException(status_code=404, detail="Workflow not found")
-    return {"message": "Workflow deleted successfully"}
+    return service.delete_workflow(db=db, current_user=current_user, workflow_id=workflow_id)
+
 
 @router.post("/tasks/{task_id}/cancel")
 def cancel_task(
@@ -499,13 +189,8 @@ def cancel_task(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    success = crud_admin.cancel_task(db, task_id)
-    if not success:
-        raise HTTPException(status_code=404, detail="Task not found")
-    return {"message": "Task cancelled successfully"}
+    return service.cancel_task(db=db, current_user=current_user, task_id=task_id)
+
 
 @router.post("/plugins/{plugin_id}/install-dependencies")
 def install_plugin_dependencies(
@@ -513,13 +198,9 @@ def install_plugin_dependencies(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    success = crud_admin.install_plugin_dependencies(db, plugin_id)
-    if not success:
-        raise HTTPException(status_code=404, detail="Plugin not found")
-    return {"message": "Plugin dependencies installed successfully"}
+    return service.install_plugin_dependencies(
+        db=db, current_user=current_user, plugin_id=plugin_id
+    )
 
 
 # =============================================================================
@@ -531,37 +212,16 @@ def get_plugin_sync_status(
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
     """Get current plugin synchronization status"""
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    try:
-        sync_manager = PluginSyncManager()
-        status = sync_manager.get_sync_status()
-        return status
-    except Exception as e:
-        logger.error(f"Failed to get sync status: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get sync status: {str(e)}")
+    return service.get_plugin_sync_status(current_user=current_user)
+
 
 @router.post("/plugins/sync")
 def sync_plugins_from_repository(
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
     """Manually trigger plugin synchronization from repository to database"""
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    try:
-        sync_manager = PluginSyncManager()
-        result = sync_manager.sync_plugins_to_database()
-        
-        if result["success"]:
-            return result
-        else:
-            raise HTTPException(status_code=500, detail=result.get("error", "Synchronization failed"))
-            
-    except Exception as e:
-        logger.error(f"Plugin sync failed: {e}")
-        raise HTTPException(status_code=500, detail=f"Synchronization failed: {str(e)}")
+    return service.sync_plugins_from_repository(current_user=current_user)
+
 
 @router.get("/plugins/consistency")
 def get_plugin_consistency_report(
@@ -569,47 +229,16 @@ def get_plugin_consistency_report(
     format: str = Query("json", description="Report format: json or text")
 ):
     """Get plugin version consistency report"""
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    try:
-        validator = PluginVersionValidator()
-        
-        if format.lower() == "text":
-            # Return plain text report
-            report = validator.generate_consistency_report()
-            return {"report": report}
-        else:
-            # Return JSON format
-            result = validator.validate_consistency()
-            return result
-            
-    except Exception as e:
-        logger.error(f"Failed to generate consistency report: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to generate report: {str(e)}")
+    return service.get_plugin_consistency_report(current_user=current_user, format=format)
+
 
 @router.get("/plugins/branches")
 def get_available_plugin_branches(
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
     """Get list of available plugin repository branches"""
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    try:
-        sync_manager = PluginSyncManager()
-        branches = sync_manager.get_available_branches()
-        current_branch = sync_manager.get_current_branch()
-        
-        return {
-            "current_branch": current_branch,
-            "available_branches": branches,
-            "total_branches": len(branches)
-        }
-        
-    except Exception as e:
-        logger.error(f"Failed to get available branches: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get branches: {str(e)}")
+    return service.get_available_plugin_branches(current_user=current_user)
+
 
 @router.post("/plugins/branch/{branch}")
 def switch_plugin_branch(
@@ -617,59 +246,15 @@ def switch_plugin_branch(
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
     """Switch plugin repository branch and synchronize database"""
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-    
-    try:
-        sync_manager = PluginSyncManager()
-        
-        # Switch branch
-        success = sync_manager.switch_branch(branch)
-        if not success:
-            raise HTTPException(status_code=400, detail=f"Failed to switch to branch: {branch}")
-        
-        # Synchronize database
-        sync_result = sync_manager.sync_plugins_to_database()
-        
-        if sync_result["success"]:
-            return {
-                "message": f"Successfully switched to branch {branch} and synchronized database",
-                "branch": branch,
-                "bundle_version": sync_result.get("bundle_version"),
-                "sync_result": sync_result
-            }
-        else:
-            raise HTTPException(
-                status_code=500, 
-                detail=f"Branch switched but sync failed: {sync_result.get('error')}"
-            )
-            
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to switch branch and sync: {e}")
-        raise HTTPException(status_code=500, detail=f"Operation failed: {str(e)}")
+    return service.switch_plugin_branch(current_user=current_user, branch=branch)
+
 
 @router.get("/plugins/consistency/quick")
 def quick_consistency_check(
     current_user: models.User = Depends(dep.get_current_active_user),
 ):
     """Quick consistency check (returns boolean only)"""
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    try:
-        validator = PluginVersionValidator()
-        consistent = validator.quick_check()
-
-        return {
-            "consistent": consistent,
-            "message": "All components are in sync" if consistent else "Inconsistencies detected"
-        }
-
-    except Exception as e:
-        logger.error(f"Quick consistency check failed: {e}")
-        raise HTTPException(status_code=500, detail=f"Check failed: {str(e)}")
+    return service.quick_consistency_check(current_user=current_user)
 
 
 # =============================================================================
@@ -690,15 +275,7 @@ def get_container_manager_status(
         - container_task_mapping: 컨테이너-작업 매핑
         - cleanup_in_progress: 정리 중인 컨테이너 ID 목록
     """
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    try:
-        status = container_manager.get_status()
-        return status
-    except Exception as e:
-        logger.error(f"Failed to get container manager status: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get status: {str(e)}")
+    return service.get_container_manager_status(current_user=current_user)
 
 
 @router.post("/container-manager/cleanup")
@@ -716,22 +293,7 @@ def cleanup_container_manager(
         - cleanup_set: 정리된 cleanup_in_progress 항목 수
         - errors: 발생한 오류 목록 (있는 경우)
     """
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    try:
-        result = container_manager.cleanup_stale_mappings()
-
-        if "error" in result:
-            raise HTTPException(status_code=500, detail=result["error"])
-
-        logger.info(f"Container manager cleanup completed: {result}")
-        return result
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Container manager cleanup failed: {e}")
-        raise HTTPException(status_code=500, detail=f"Cleanup failed: {str(e)}")
+    return service.cleanup_container_manager(current_user=current_user)
 
 
 @router.post("/container-manager/force-clear")
@@ -749,13 +311,4 @@ def force_clear_container_manager(
         - cleared_tasks: 삭제된 작업-컨테이너 매핑 수
         - cleared_cleanup_markers: 삭제된 cleanup 마커 수
     """
-    if not current_user.is_superuser:
-        raise HTTPException(status_code=403, detail="Access denied: Admins only")
-
-    try:
-        result = container_manager.force_clear_all_mappings()
-        logger.warning(f"Container manager force cleared: {result}")
-        return result
-    except Exception as e:
-        logger.error(f"Container manager force clear failed: {e}")
-        raise HTTPException(status_code=500, detail=f"Force clear failed: {str(e)}")
+    return service.force_clear_container_manager(current_user=current_user)

--- a/backend/app/admin/service.py
+++ b/backend/app/admin/service.py
@@ -1,0 +1,612 @@
+"""
+Admin domain service layer.
+
+Extracted from ``admin/router.py`` in PR-8 (Phase 3d). This module holds the
+business logic that previously lived inline in the endpoints: superuser-gated
+listing/counting of users/files/workflows/tasks/plugins, user/file/workflow/task
+mutations, the Docker-based system-stats aggregation, plugin synchronization
+management, and container-manager administration. The router now only parses
+requests, resolves dependencies, calls a service function, and returns its
+result.
+
+Exception policy (PR-8): the repeated ``is_superuser`` gate now raises
+``PermissionDeniedError`` (-> 403) via ``_require_admin``, and the "not found"
+guards raise ``NotFoundError`` (-> 404). The global handler in ``app.main`` maps
+these onto the exact ``{"detail": ...}`` wire format, so responses are unchanged.
+
+NOTE (domain boundaries): ``admin/crud.py`` reads other domains' tables directly
+(users/files/workflows/tasks/plugins) for the admin dashboards. That cross-domain
+data access is pre-existing and left as-is per the PR-8 scope note (boundary
+hardening is out of scope here). The plugin-sync / container-manager 500 handlers
+that swallow-and-stringify their inner errors are kept as ``HTTPException``
+verbatim to guarantee byte-identical error bodies.
+"""
+import logging
+
+import docker
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app import models
+from app.admin.schemas import Conditions
+from app.admin import crud as crud_admin
+from app.core.exceptions import (
+    NotFoundError, PermissionDeniedError, ExternalServiceError
+)
+from app.plugin.sync import PluginSyncManager
+from app.plugin.versioning import PluginVersionValidator
+from app.shared.docker import container_manager
+
+logger = logging.getLogger(__name__)
+
+
+def _require_admin(current_user: models.User) -> None:
+    """Raise 403 unless the caller is a superuser (admin-only gate)."""
+    if not current_user.is_superuser:
+        raise PermissionDeniedError("Access denied: Admins only")
+
+
+def get_filtered_users(*, db: Session, current_user: models.User, amount: int,
+                       page_num: int, sort: str, order: str, searchTerm: str):
+    """Return a filtered/paginated user list (admin only; 404 if none match)."""
+    _require_admin(current_user)
+
+    conditions = Conditions(
+        amount=amount, page_num=page_num, sort=sort, order=order, searchTerm=searchTerm
+    )
+    users, total_count = crud_admin.get_filtered_users(db, conditions)
+
+    if not users:
+        raise NotFoundError("Users not found")
+    return users
+
+
+def get_users_count(*, db: Session, current_user: models.User):
+    """Return the total user count (admin only)."""
+    _require_admin(current_user)
+    return crud_admin.get_users_count(db)
+
+
+def get_filtered_files(*, db: Session, current_user: models.User, amount: int,
+                       page_num: int, sort: str, order: str, searchTerm: str):
+    """Return a filtered/paginated file list with owner usernames (admin only)."""
+    _require_admin(current_user)
+
+    conditions = Conditions(
+        amount=amount, page_num=page_num, sort=sort, order=order, searchTerm=searchTerm
+    )
+    files, total_count = crud_admin.get_filtered_files(db, conditions)
+
+    if not files:
+        raise NotFoundError("Files not found")
+
+    formatted_files = []
+    for file, username in files:
+        formatted_file = {
+            'id': file.id,
+            'file_name': file.file_name,
+            'file_path': file.file_path,
+            'file_size': file.file_size,
+            'folder': file.folder,
+            'username': username,
+            'user_id': file.user_id
+        }
+        formatted_files.append(formatted_file)
+
+    return {
+        'data': formatted_files,
+        'total_count': total_count
+    }
+
+
+def get_files_count(*, db: Session, current_user: models.User):
+    """Return the total file count (admin only)."""
+    _require_admin(current_user)
+    return crud_admin.get_files_count(db)
+
+
+def get_filtered_workflows(*, db: Session, current_user: models.User, amount: int,
+                           page_num: int, sort: str, order: str, searchTerm: str):
+    """Return a filtered/paginated workflow list with owner usernames (admin only)."""
+    _require_admin(current_user)
+
+    conditions = Conditions(
+        amount=amount, page_num=page_num, sort=sort, order=order, searchTerm=searchTerm
+    )
+    workflows, total_count = crud_admin.get_filtered_workflows(db, conditions)
+
+    if not workflows:
+        raise NotFoundError("Workflows not found")
+
+    formatted_workflows = []
+    for workflow, username in workflows:
+        formatted_workflow = {
+            'id': workflow.id,
+            'title': workflow.title,
+            'username': username,
+            'updated_at': workflow.updated_at,
+            'user_id': workflow.user_id
+        }
+        formatted_workflows.append(formatted_workflow)
+
+    return {
+        'data': formatted_workflows,
+        'total_count': total_count
+    }
+
+
+def get_workflows_count(*, db: Session, current_user: models.User):
+    """Return the total workflow count (admin only)."""
+    _require_admin(current_user)
+    return crud_admin.get_workflows_count(db)
+
+
+def get_filtered_tasks(*, db: Session, current_user: models.User, amount: int,
+                       page_num: int, sort: str, order: str, searchTerm: str):
+    """Return a filtered/paginated task list with owner + workflow titles (admin only)."""
+    _require_admin(current_user)
+
+    conditions = Conditions(
+        amount=amount, page_num=page_num, sort=sort, order=order, searchTerm=searchTerm
+    )
+    tasks, total_count = crud_admin.get_filtered_tasks(db, conditions)
+
+    if not tasks:
+        raise NotFoundError("Tasks not found")
+
+    formatted_tasks = []
+    for task, username, workflow_title in tasks:
+        formatted_task = {
+            'id': task.id,
+            'user_id': task.user_id,
+            'workflow_id': task.workflow_id,
+            'username': username,
+            'workflow_title': workflow_title,
+            'status': task.status,
+            'start_time': task.start_time
+        }
+        formatted_tasks.append(formatted_task)
+
+    return {
+        'data': formatted_tasks,
+        'total_count': total_count
+    }
+
+
+def get_tasks_count(*, db: Session, current_user: models.User):
+    """Return the total task count (admin only)."""
+    _require_admin(current_user)
+    return crud_admin.get_tasks_count(db)
+
+
+def get_filtered_plugins(*, db: Session, current_user: models.User, amount: int,
+                         page_num: int, sort: str, order: str, searchTerm: str):
+    """Return a filtered/paginated plugin list (admin only; 404 if none match)."""
+    _require_admin(current_user)
+
+    conditions = Conditions(
+        amount=amount, page_num=page_num, sort=sort, order=order, searchTerm=searchTerm
+    )
+    plugins, total_count = crud_admin.get_filtered_plugins(db, conditions)
+
+    if not plugins:
+        raise NotFoundError("Plugins not found")
+    return plugins
+
+
+def get_plugins_count(*, db: Session, current_user: models.User):
+    """Return the total plugin count (admin only)."""
+    _require_admin(current_user)
+    return crud_admin.get_plugins_count(db)
+
+
+def get_system_stats():
+    """Aggregate per-container CPU/memory/GPU/network stats via the Docker socket.
+
+    NOTE (pinned): this endpoint has no auth dependency and returns a ``message``
+    dict (not an error response) on Docker failures — preserved exactly.
+    """
+    # Docker 클라이언트 연결
+    client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+
+    try:  # 메모리 누수 방지를 위한 try/finally 패턴
+        containers = client.containers.list()
+        print("현재 실행 중인 컨테이너 목록:")
+
+        # 모든 컨테이너의 통계 정보를 저장할 리스트
+        container_stats = []
+
+        for container in containers:
+            container_name = container.name
+            print(container_name)
+
+            # 컨테이너 필터링 로직 - cellcraft 서비스와 plugin 컨테이너만 포함
+            should_monitor = False
+
+            # 1. cellcraft 서비스 컨테이너 (docker-compose로 생성된 컨테이너)
+            # docker-compose는 서비스명-숫자 형태로 컨테이너를 명명함
+            cellcraft_services = ["cellcraft-frontend", "cellcraft-backend", "cellcraft-celery", "cellcraft-db"]
+            if any(container_name.startswith(service) for service in cellcraft_services):
+                should_monitor = True
+
+            # 2. plugin 실행 컨테이너 (plugin-으로 시작하는 컨테이너)
+            # 예: plugin-tenet-task-12345678-1234567890
+            elif container_name.startswith("plugin-"):
+                should_monitor = True
+
+            # 모니터링 대상이 아니면 건너뛰기
+            if not should_monitor:
+                continue
+
+            try:
+                # 컨테이너 상세 정보 가져오기
+                stats = container.stats(stream=False)
+                container_info = container.attrs
+
+                # CPU 상세 정보 계산
+                cpu_stats = stats['cpu_stats']
+                precpu_stats = stats['precpu_stats']
+                cpu_usage = cpu_stats['cpu_usage']['total_usage'] - precpu_stats['cpu_usage']['total_usage']
+                system_cpu_usage = cpu_stats['system_cpu_usage'] - precpu_stats['system_cpu_usage']
+                num_cpus = len(cpu_stats['cpu_usage'].get('percpu_usage', []))
+                cpu_percent = (cpu_usage / system_cpu_usage) * 100 * num_cpus if system_cpu_usage > 0 else 0
+
+                # 메모리 상세 정보 계산
+                memory_stats = stats['memory_stats']
+                memory_usage = memory_stats.get('usage', 0)
+                memory_limit = memory_stats.get('limit', 0)
+                memory_percent = (memory_usage / memory_limit) * 100 if memory_limit > 0 else 0
+                memory_stats_detailed = {
+                    'total_bytes': memory_limit,
+                    'used_bytes': memory_usage,
+                    'available_bytes': memory_limit - memory_usage,
+                    'percent': memory_percent,
+                    'stats': memory_stats.get('stats', {})
+                }
+
+                # GPU 정보 가져오기
+                gpu_stats = None
+                try:
+                    exec_result = container.exec_run(
+                        'nvidia-smi --query-gpu=index,name,temperature.gpu,utilization.gpu,memory.total,memory.used,memory.free,power.draw,power.limit --format=csv,noheader,nounits'
+                    )
+                    if exec_result.exit_code == 0:
+                        gpu_stats = []
+                        gpu_output = exec_result.output.decode('utf-8')
+                        for line in gpu_output.splitlines():
+                            index, name, temp, util, mem_total, mem_used, mem_free, power_draw, power_limit = line.split(',')
+                            gpu_stats.append({
+                                'id': int(index.strip()),
+                                'name': name.strip(),
+                                'temperature_c': float(temp.strip()),
+                                'utilization_percent': float(util.strip()),
+                                'memory': {
+                                    'total_bytes': int(mem_total.strip()) * 1024 * 1024,
+                                    'used_bytes': int(mem_used.strip()) * 1024 * 1024,
+                                    'free_bytes': int(mem_free.strip()) * 1024 * 1024,
+                                    'utilization_percent': (int(mem_used.strip()) / int(mem_total.strip())) * 100
+                                },
+                                'power': {
+                                    'draw_watts': float(power_draw.strip()),
+                                    'limit_watts': float(power_limit.strip())
+                                }
+                            })
+                except Exception as e:
+                    print(f"GPU 정보 조회 실패: {e}")
+
+                # 네트워크 정보
+                network_stats = stats.get('networks', {})
+
+                # 컨테이너별 통계 정보 저장
+                container_stats.append({
+                    'container_info': {
+                        'id': container.id,
+                        'name': container.name,
+                        'status': container.status,
+                        'created': container_info['Created'],
+                        'image': container_info['Config']['Image'],
+                        'command': container_info['Config']['Cmd'],
+                        'labels': container_info['Config'].get('Labels', {})
+                    },
+                    'cpu': {
+                        'usage_percent': cpu_percent,
+                        'num_cpus': num_cpus,
+                        'total_usage': cpu_usage,
+                        'system_usage': system_cpu_usage,
+                        'per_cpu_usage': cpu_stats['cpu_usage'].get('percpu_usage', [])
+                    },
+                    'memory': memory_stats_detailed,
+                    'gpu': gpu_stats,
+                    'network': {
+                        interface: {
+                            'rx_bytes': data['rx_bytes'],
+                            'tx_bytes': data['tx_bytes'],
+                            'rx_packets': data['rx_packets'],
+                            'tx_packets': data['tx_packets'],
+                            'rx_errors': data['rx_errors'],
+                            'tx_errors': data['tx_errors']
+                        } for interface, data in network_stats.items()
+                    }
+                })
+            except Exception as e:
+                print(f"컨테이너 {container.name} 통계 정보 조회 실패: {e}")
+                continue
+
+        # 전체 시스템 통계 계산
+        total_cpu_usage = sum(stat['cpu']['usage_percent'] for stat in container_stats)
+        total_memory_usage = sum(stat['memory']['used_bytes'] for stat in container_stats)
+        total_memory_limit = sum(stat['memory']['total_bytes'] for stat in container_stats)
+
+        system_stats = {
+            'total_containers': len(container_stats),
+            'total_cpu_usage_percent': total_cpu_usage,
+            'total_memory_usage_bytes': total_memory_usage,
+            'total_memory_limit_bytes': total_memory_limit,
+            'total_memory_usage_percent': (total_memory_usage / total_memory_limit * 100) if total_memory_limit > 0 else 0,
+            'containers': container_stats
+        }
+
+        return system_stats
+
+    except docker.errors.NotFound:
+        return {'message': "Docker 데몬에 연결할 수 없습니다."}
+    except Exception as e:
+        return {'message': f"시스템 정보 조회 중 오류 발생: {str(e)}"}
+    finally:
+        # Docker 클라이언트 연결 해제 - TCP 소켓 누수 방지
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+def update_user(*, db: Session, current_user: models.User, user_id: int, user_data: dict):
+    """Update a user record (admin only; 404 if the user is missing)."""
+    _require_admin(current_user)
+
+    user = crud_admin.update_user(db, user_id, user_data)
+    if not user:
+        raise NotFoundError("User not found")
+    return user
+
+
+def delete_user(*, db: Session, current_user: models.User, user_id: int) -> dict:
+    """Delete a user (admin only; 404 if the user is missing)."""
+    _require_admin(current_user)
+
+    success = crud_admin.delete_user(db, user_id)
+    if not success:
+        raise NotFoundError("User not found")
+    return {"message": "User deleted successfully"}
+
+
+def delete_file(*, db: Session, current_user: models.User, file_id: int) -> dict:
+    """Delete a file record (admin only; 404 if the file is missing)."""
+    _require_admin(current_user)
+
+    success = crud_admin.delete_file(db, file_id)
+    if not success:
+        raise NotFoundError("File not found")
+    return {"message": "File deleted successfully"}
+
+
+def delete_workflow(*, db: Session, current_user: models.User, workflow_id: int) -> dict:
+    """Delete a workflow record (admin only; 404 if the workflow is missing)."""
+    _require_admin(current_user)
+
+    success = crud_admin.delete_workflow(db, workflow_id)
+    if not success:
+        raise NotFoundError("Workflow not found")
+    return {"message": "Workflow deleted successfully"}
+
+
+def cancel_task(*, db: Session, current_user: models.User, task_id: int) -> dict:
+    """Cancel a task (admin only; 404 if the task is missing)."""
+    _require_admin(current_user)
+
+    success = crud_admin.cancel_task(db, task_id)
+    if not success:
+        raise NotFoundError("Task not found")
+    return {"message": "Task cancelled successfully"}
+
+
+def install_plugin_dependencies(*, db: Session, current_user: models.User, plugin_id: int) -> dict:
+    """Install a plugin's dependencies (admin only; 404 if the plugin is missing)."""
+    _require_admin(current_user)
+
+    success = crud_admin.install_plugin_dependencies(db, plugin_id)
+    if not success:
+        raise NotFoundError("Plugin not found")
+    return {"message": "Plugin dependencies installed successfully"}
+
+
+# =============================================================================
+# Plugin Synchronization Management
+# =============================================================================
+
+def get_plugin_sync_status(*, current_user: models.User):
+    """Return current plugin synchronization status (admin only)."""
+    _require_admin(current_user)
+
+    try:
+        sync_manager = PluginSyncManager()
+        status = sync_manager.get_sync_status()
+        return status
+    except Exception as e:
+        logger.error(f"Failed to get sync status: {e}")
+        raise ExternalServiceError(f"Failed to get sync status: {str(e)}", status_code=500)
+
+
+def sync_plugins_from_repository(*, current_user: models.User):
+    """Manually trigger plugin synchronization from repository to database (admin only).
+
+    NOTE (pinned): the inner ``result["success"] is False`` raise is kept as an
+    ``HTTPException`` because the bare ``except Exception`` below stringifies the
+    caught exception into the final detail (``"Synchronization failed: 500: ..."``);
+    converting it would change that byte-identical error body.
+    """
+    _require_admin(current_user)
+
+    try:
+        sync_manager = PluginSyncManager()
+        result = sync_manager.sync_plugins_to_database()
+
+        if result["success"]:
+            return result
+        else:
+            raise HTTPException(status_code=500, detail=result.get("error", "Synchronization failed"))
+
+    except Exception as e:
+        logger.error(f"Plugin sync failed: {e}")
+        raise HTTPException(status_code=500, detail=f"Synchronization failed: {str(e)}")
+
+
+def get_plugin_consistency_report(*, current_user: models.User, format: str):
+    """Return a plugin version consistency report (admin only; json or text)."""
+    _require_admin(current_user)
+
+    try:
+        validator = PluginVersionValidator()
+
+        if format.lower() == "text":
+            # Return plain text report
+            report = validator.generate_consistency_report()
+            return {"report": report}
+        else:
+            # Return JSON format
+            result = validator.validate_consistency()
+            return result
+
+    except Exception as e:
+        logger.error(f"Failed to generate consistency report: {e}")
+        raise ExternalServiceError(f"Failed to generate report: {str(e)}", status_code=500)
+
+
+def get_available_plugin_branches(*, current_user: models.User):
+    """List available plugin repository branches + the current one (admin only)."""
+    _require_admin(current_user)
+
+    try:
+        sync_manager = PluginSyncManager()
+        branches = sync_manager.get_available_branches()
+        current_branch = sync_manager.get_current_branch()
+
+        return {
+            "current_branch": current_branch,
+            "available_branches": branches,
+            "total_branches": len(branches)
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to get available branches: {e}")
+        raise ExternalServiceError(f"Failed to get branches: {str(e)}", status_code=500)
+
+
+def switch_plugin_branch(*, current_user: models.User, branch: str):
+    """Switch the plugin repo branch and re-synchronize the database (admin only).
+
+    NOTE (pinned): inner 400/500 raises are kept as ``HTTPException`` and the
+    ``except HTTPException: raise`` guard preserves them; the terminal handler is
+    kept verbatim so the swallow-and-stringify error body is byte-identical.
+    """
+    _require_admin(current_user)
+
+    try:
+        sync_manager = PluginSyncManager()
+
+        # Switch branch
+        success = sync_manager.switch_branch(branch)
+        if not success:
+            raise HTTPException(status_code=400, detail=f"Failed to switch to branch: {branch}")
+
+        # Synchronize database
+        sync_result = sync_manager.sync_plugins_to_database()
+
+        if sync_result["success"]:
+            return {
+                "message": f"Successfully switched to branch {branch} and synchronized database",
+                "branch": branch,
+                "bundle_version": sync_result.get("bundle_version"),
+                "sync_result": sync_result
+            }
+        else:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Branch switched but sync failed: {sync_result.get('error')}"
+            )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to switch branch and sync: {e}")
+        raise HTTPException(status_code=500, detail=f"Operation failed: {str(e)}")
+
+
+def quick_consistency_check(*, current_user: models.User):
+    """Return a boolean plugin consistency flag with a message (admin only)."""
+    _require_admin(current_user)
+
+    try:
+        validator = PluginVersionValidator()
+        consistent = validator.quick_check()
+
+        return {
+            "consistent": consistent,
+            "message": "All components are in sync" if consistent else "Inconsistencies detected"
+        }
+
+    except Exception as e:
+        logger.error(f"Quick consistency check failed: {e}")
+        raise ExternalServiceError(f"Check failed: {str(e)}", status_code=500)
+
+
+# =============================================================================
+# Container Manager (메모리 누수 방지)
+# =============================================================================
+
+def get_container_manager_status(*, current_user: models.User):
+    """Return container-manager tracking status (admin only)."""
+    _require_admin(current_user)
+
+    try:
+        status = container_manager.get_status()
+        return status
+    except Exception as e:
+        logger.error(f"Failed to get container manager status: {e}")
+        raise ExternalServiceError(f"Failed to get status: {str(e)}", status_code=500)
+
+
+def cleanup_container_manager(*, current_user: models.User):
+    """Clean up stale container-manager mappings (admin only).
+
+    NOTE (pinned): the ``"error" in result`` raise is kept as ``HTTPException``
+    and guarded by ``except HTTPException: raise`` so its body is byte-identical.
+    """
+    _require_admin(current_user)
+
+    try:
+        result = container_manager.cleanup_stale_mappings()
+
+        if "error" in result:
+            raise HTTPException(status_code=500, detail=result["error"])
+
+        logger.info(f"Container manager cleanup completed: {result}")
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Container manager cleanup failed: {e}")
+        raise HTTPException(status_code=500, detail=f"Cleanup failed: {str(e)}")
+
+
+def force_clear_container_manager(*, current_user: models.User):
+    """Force-clear all container-manager mappings (admin only, emergency use)."""
+    _require_admin(current_user)
+
+    try:
+        result = container_manager.force_clear_all_mappings()
+        logger.warning(f"Container manager force cleared: {result}")
+        return result
+    except Exception as e:
+        logger.error(f"Container manager force clear failed: {e}")
+        raise ExternalServiceError(f"Force clear failed: {str(e)}", status_code=500)

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -1,83 +1,48 @@
-from typing import Any, List
-from datetime import timedelta
+from typing import Any
 
-from fastapi import APIRouter, Body, Depends, HTTPException
-from fastapi.encoders import jsonable_encoder
+from fastapi import APIRouter, Depends
 from fastapi.security import OAuth2PasswordRequestForm
 
-from pydantic.networks import EmailStr
 from sqlalchemy.orm import Session
-
-import os
 
 from app.auth import schemas as model
 from app import models
-from app.user import crud as crud_user
 from app.user import schemas as user
-from app.core.security import create_access_token
-from app.core.config import settings
+from app.auth import service as auth_service
+from app.user import service as user_service
 from app.auth import deps as dep
 
 router = APIRouter()
 
-#create New User
+
+# create New User
 @router.post("/register", response_model=user.UserProfile)
 def create_user(
     *,
     db: Session = Depends(dep.get_db),
     user_in: user.UserCreate,
 ) -> Any:
-    user = crud_user.get_user_by_email(db, email=user_in.email)
-    if user:
-        raise HTTPException(
-            status_code=400,
-            detail="Email already registered",
-        )
-    user = crud_user.create_user(db, user=user_in)
-    USER_DIRECTORY_NAME = './user/' + user_in.username + '/data'
-    os.makedirs(USER_DIRECTORY_NAME, exist_ok=True)
-    #회원가입 시 보내는 확인 이메일
-    # if user_in.email:
-    #     send_new_account_email(
-    #         email_to=user_in.email, username=user_in.email, password=user_in.password
-    #     )
-    return user
+    return user_service.register(db=db, user_in=user_in)
 
-#Login + JWT 발급
+
+# Login + JWT 발급
 @router.post("/login/access-token", response_model=model.Token)
 def login_access_token(
     db: Session = Depends(dep.get_db), form_data: OAuth2PasswordRequestForm = Depends()
 ) -> Any:
-    user = crud_user.authenticate(
-        db, email=form_data.username, password=form_data.password
-    )
-    if not user:
-        raise HTTPException(status_code=400, detail="Incorrect email or password")
-    elif not crud_user.is_active(user):
-        raise HTTPException(status_code=400, detail="please login to activate")
-    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    return {
-        "access_token": create_access_token(
-            user.id, expires_delta=access_token_expires
-        ),
-        "token_type": "bearer",
-        "user_info": {
-            "is_superuser": crud_user.is_superuser(user),
-            "email": user.email,
-            "is_active": user.is_active
-        }
-    }
+    return auth_service.login(db=db, form_data=form_data)
 
-#read Current User
+
+# read Current User
 @router.get("/me", response_model=user.UserProfile)
 def read_user_me(
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
 ) -> Any:
+    return user_service.read_me(current_user=current_user)
 
-    return { "id": current_user.id, "email" : current_user.email, "username" : current_user.username, "is_superuser" : current_user.is_superuser}
 
-#update user plugins
+# update user plugins
 @router.post("/plugins", response_model=user.UserProfile)
 def update_user_plugins(
     *,
@@ -85,5 +50,4 @@ def update_user_plugins(
     user_in: user.UserUpdate,
     current_user: models.User = Depends(dep.get_current_active_user),
 ) -> Any:
-    user = crud_user.update_user(db, user_id=current_user.id, user=user_in)
-    return user
+    return user_service.update_plugins(db=db, current_user=current_user, user_in=user_in)

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -1,0 +1,43 @@
+"""
+Auth domain service layer.
+
+Extracted from ``auth/router.py`` in PR-8 (Phase 3d). Holds the login / token
+issuance business logic; the router keeps only the OAuth2 form dependency and
+the ``response_model`` wiring.
+
+Exception policy (PR-8): credential failures raise ``ValidationFailedError``
+(-> 400), which the global handler in ``app.main`` maps onto the exact
+``{"detail": ...}`` wire format (status code + detail string unchanged).
+"""
+from datetime import timedelta
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import ValidationFailedError
+from app.core.security import create_access_token
+from app.core.config import settings
+from app.user import crud as crud_user
+
+
+def login(*, db: Session, form_data) -> Any:
+    """Authenticate an OAuth2 form login and issue a JWT + user_info payload."""
+    user = crud_user.authenticate(
+        db, email=form_data.username, password=form_data.password
+    )
+    if not user:
+        raise ValidationFailedError("Incorrect email or password")
+    elif not crud_user.is_active(user):
+        raise ValidationFailedError("please login to activate")
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return {
+        "access_token": create_access_token(
+            user.id, expires_delta=access_token_expires
+        ),
+        "token_type": "bearer",
+        "user_info": {
+            "is_superuser": crud_user.is_superuser(user),
+            "email": user.email,
+            "is_active": user.is_active
+        }
+    }

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -240,6 +240,58 @@ class TaskSubmissionError(CellCraftHTTPException):
         )
 
 
+# ---------------------------------------------------------------------------
+# Domain exception hierarchy (PR-8, Phase 3d)
+#
+# These are plain ``Exception`` subclasses — NOT ``HTTPException`` — so the
+# service layer can raise domain-meaningful errors with no HTTP coupling. The
+# global handler registered in ``app.main.create_app`` maps them back onto the
+# exact same wire response FastAPI produces for ``HTTPException``:
+#
+#     JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+#
+# so converting an ``HTTPException(status_code=S, detail=D)`` raise to the
+# matching domain exception is response-preserving (byte-identical body + code).
+# Each class carries a default ``status_code``; pass ``status_code=`` to cover
+# the less common codes (413/502/503) while keeping the same semantic class.
+# ---------------------------------------------------------------------------
+
+class CellcraftError(Exception):
+    """Base class for domain (non-HTTP) errors raised by the service layer."""
+
+    status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    def __init__(self, detail: Any = None, *, status_code: Optional[int] = None):
+        if status_code is not None:
+            self.status_code = status_code
+        self.detail = detail
+        super().__init__(str(detail) if detail is not None else self.__class__.__name__)
+
+
+class NotFoundError(CellcraftError):
+    """Requested resource does not exist (maps to HTTP 404)."""
+
+    status_code = status.HTTP_404_NOT_FOUND
+
+
+class PermissionDeniedError(CellcraftError):
+    """Caller is not allowed to perform the action (maps to HTTP 403)."""
+
+    status_code = status.HTTP_403_FORBIDDEN
+
+
+class ValidationFailedError(CellcraftError):
+    """Input failed a business-rule validation (maps to HTTP 400)."""
+
+    status_code = status.HTTP_400_BAD_REQUEST
+
+
+class ExternalServiceError(CellcraftError):
+    """A downstream service failed — Docker / GitHub / Redis (maps to HTTP 502)."""
+
+    status_code = status.HTTP_502_BAD_GATEWAY
+
+
 def log_error(error: Exception, context: Dict[str, Any] = None):
     """Log error with context information."""
     context_str = f" Context: {context}" if context else ""

--- a/backend/app/datatable/router.py
+++ b/backend/app/datatable/router.py
@@ -1,29 +1,13 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi import Depends
 
 from app.auth import deps as dep
-from app import models
-from app.workflow.utils import load_tab_file, transform_df_to_vgt_format
-from app.datatable.utils import RemoteDataTable, DataTableEvent
+from app.datatable.utils import DataTableEvent
+from app.datatable import service
 
 router = APIRouter()
 
+
 @router.post("/load_data")
 def load_data(vgt_info: DataTableEvent, current_user: str = Depends(dep.get_current_active_user)):
-    try:
-        from app.file.path_resolver import resolve_data_file_path
-        from app.datatable.cache import get_cached_dataframe, set_cached_dataframe
-
-        file_path = resolve_data_file_path(vgt_info.file_name, current_user.username, vgt_info.source)
-
-        df = get_cached_dataframe(file_path)
-        if df is None:
-            df = load_tab_file(file_path)
-            set_cached_dataframe(file_path, df)
-
-        remote_table = RemoteDataTable(df, vgt_info)
-        data = remote_table.get_filtered_sorted_paginated_data()
-        vgt_data = transform_df_to_vgt_format(data["df"])
-        return {"status": "success", "columns": vgt_data['columns'], "rows": vgt_data["rows"], "totalRecords": data["totalRecords"]}
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    return service.load_data(vgt_info=vgt_info, current_user=current_user)

--- a/backend/app/datatable/service.py
+++ b/backend/app/datatable/service.py
@@ -1,0 +1,41 @@
+"""
+Datatable domain service layer.
+
+Extracted from ``datatable/router.py`` in PR-8 (Phase 3d). Holds the h5ad/tabular
+data-load orchestration: path resolution, dataframe caching, and the
+filter/sort/paginate + vue-good-table formatting. The ``RemoteDataTable`` engine
+and the workflow/cache utilities are invoked, never modified (utils internals are
+out of scope per PR-8).
+
+Exception policy (PR-8): the terminal catch-all now raises
+``ValidationFailedError`` (-> 400); the global handler maps it onto the exact
+``{"detail": str(e)}`` wire format, so the response (400 + detail string) is
+unchanged.
+"""
+from typing import Any
+
+from app import models
+from app.core.exceptions import ValidationFailedError
+from app.workflow.utils import load_tab_file, transform_df_to_vgt_format
+from app.datatable.utils import RemoteDataTable, DataTableEvent
+
+
+def load_data(*, vgt_info: DataTableEvent, current_user: models.User) -> Any:
+    """Load, cache, filter/sort/paginate and vgt-format a user's data file."""
+    try:
+        from app.file.path_resolver import resolve_data_file_path
+        from app.datatable.cache import get_cached_dataframe, set_cached_dataframe
+
+        file_path = resolve_data_file_path(vgt_info.file_name, current_user.username, vgt_info.source)
+
+        df = get_cached_dataframe(file_path)
+        if df is None:
+            df = load_tab_file(file_path)
+            set_cached_dataframe(file_path, df)
+
+        remote_table = RemoteDataTable(df, vgt_info)
+        data = remote_table.get_filtered_sorted_paginated_data()
+        vgt_data = transform_df_to_vgt_format(data["df"])
+        return {"status": "success", "columns": vgt_data['columns'], "rows": vgt_data["rows"], "totalRecords": data["totalRecords"]}
+    except Exception as e:
+        raise ValidationFailedError(str(e))

--- a/backend/app/file/router.py
+++ b/backend/app/file/router.py
@@ -1,27 +1,17 @@
-from typing import Any
-from fastapi import APIRouter, Body, Depends, HTTPException, Request, UploadFile, File
-from fastapi.responses import HTMLResponse, FileResponse
-from typing import List, Union
+from typing import Any, List
+from fastapi import APIRouter, Depends, UploadFile, File
+from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
-from datetime import datetime
-import os
-import pandas as pd
-import scanpy as sc
-import json
-import gc
-import asyncio
 
 from app.auth import deps as dep
-from app.file import crud as crud_file
 from app import models
-from app.file.schemas import FileCreate, FileDelete, FileUpdate, FileFind, FolderFind, FileGet, FileResultFind
-from app.datatable.h5ad import organize_column_dtypes, get_annotation_columns, get_pseudotime_columns
-from app.datatable.cache import get_cached_columns, set_cached_columns, get_cached_clusters, set_cached_clusters, invalidate_file
-from app.workflow.utils import load_tab_file
+from app.file.schemas import FileDelete, FileUpdate, FileFind, FolderFind, FileResultFind
+from app.file import service
 
 router = APIRouter()
 
-#h5ad file-upload
+
+# h5ad file-upload
 @router.post("/upload")
 async def fileUpload(
     *,
@@ -29,125 +19,18 @@ async def fileUpload(
     files: List[UploadFile] = File(),
     current_user: models.User = Depends(dep.get_current_active_user),
 ) -> Any:
-    from app.core.config import MAX_FILES_PER_UPLOAD
-    from app.file.security import validate_file_upload
+    return await service.save_upload(db=db, files=files, current_user=current_user)
 
-    # Validation 1: Check batch upload limit
-    if len(files) > MAX_FILES_PER_UPLOAD:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Too many files. Maximum {MAX_FILES_PER_UPLOAD} files per upload."
-        )
 
-    # Setup upload directory
-    UPLOAD_DIRECTORY = f'./user/{current_user.username}/data'
-    os.makedirs(UPLOAD_DIRECTORY, exist_ok=True)
-
-    uploaded_files = []
-
-    for item_file in files:
-        # Validation 2: Comprehensive file validation
-        safe_filename = validate_file_upload(item_file)
-
-        # Parse folder and filename (format: "folder_filename.ext")
-        folder_file = safe_filename.split('_', 1)
-        if len(folder_file) != 2:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Invalid filename format. Expected 'folder_filename.ext', got '{safe_filename}'"
-            )
-
-        folder, actual_filename = folder_file
-        final_filename = actual_filename
-
-        # Check for duplicate files
-        user_file = crud_file.get_user_file(db, current_user.id, final_filename)
-        if user_file:
-            raise HTTPException(
-                status_code=400,
-                detail=f"File '{final_filename}' already exists in your files"
-            )
-
-        # Stream file to disk in chunks to prevent memory exhaustion
-        from app.core.config import UPLOAD_CHUNK_SIZE, MAX_UPLOAD_SIZE
-
-        file_path = os.path.join(UPLOAD_DIRECTORY, final_filename)
-        file_size = 0
-
-        try:
-            with open(file_path, "wb") as f:
-                while chunk := await item_file.read(UPLOAD_CHUNK_SIZE):
-                    f.write(chunk)
-                    file_size += len(chunk)
-
-                    # Enforce size limit during streaming to fail fast
-                    if file_size > MAX_UPLOAD_SIZE:
-                        # Clean up partial file
-                        f.close()
-                        if os.path.exists(file_path):
-                            os.remove(file_path)
-                        raise HTTPException(
-                            status_code=413,
-                            detail=f"File too large. Maximum size is {MAX_UPLOAD_SIZE / (1024*1024):.0f}MB"
-                        )
-        except HTTPException:
-            raise
-        except Exception as e:
-            # Clean up partial file on error
-            if os.path.exists(file_path):
-                os.remove(file_path)
-            raise HTTPException(
-                status_code=500,
-                detail=f"File upload failed: {str(e)}"
-            )
-
-        # Compress H5AD files to reduce storage
-        if final_filename.lower().endswith('.h5ad'):
-            from app.datatable.h5ad_compression import compress_h5ad_file
-            from app.core.config import H5AD_COMPRESSION_ENABLED, H5AD_COMPRESSION_MIN_SIZE
-
-            if H5AD_COMPRESSION_ENABLED:
-                _compressed, file_size = await asyncio.to_thread(
-                    compress_h5ad_file,
-                    file_path,
-                    min_size_bytes=H5AD_COMPRESSION_MIN_SIZE,
-                )
-
-        # Create database record
-        created_file = crud_file.create_file(
-            db,
-            final_filename,
-            file_size,
-            UPLOAD_DIRECTORY,
-            folder,
-            current_user.id
-        )
-        uploaded_files.append(created_file)
-
-    # Return last uploaded file (maintain backward compatibility)
-    # or return list if multiple files
-    if len(uploaded_files) == 1:
-        return uploaded_files[0]
-    else:
-        return {"files": uploaded_files, "count": len(uploaded_files)}
-
-#User Files get
+# User Files get
 @router.get("/me")
 def read_user_folder(
     current_user: models.User = Depends(dep.get_current_active_user)
     ) -> Any:
-    USER_FOLDER = f'./user/{current_user.username}/data'
-    res = []
-    for (dir_path, dir_names, file_names) in os.walk(USER_FOLDER):
-        folder = dir_path.replace(USER_FOLDER , 'data')
-        res.extend({folder : file_names}.items())
-        # print(f"Directories: {dir_path}, Files: {file_names}")
-    # print(res)
+    return service.read_user_folder(current_user=current_user)
 
-    # print(user_files)
-    return res
 
-#User File find
+# User File find
 @router.post("/find")
 def find_user_file(
     *,
@@ -155,16 +38,10 @@ def find_user_file(
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileFind,
     ) -> Any:
-    user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-    if user_file:
-        return user_file
-    else:
-        raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-                )
+    return service.find_user_file(db=db, current_user=current_user, file_info=fileInfo)
 
-#User find File of folder
+
+# User find File of folder
 @router.post("/folder")
 def find_user_folder(
     *,
@@ -172,16 +49,10 @@ def find_user_folder(
     current_user: models.User = Depends(dep.get_current_active_user),
     folder: FolderFind,
     ) -> Any:
-    user_file = crud_file.get_user_folder(db, current_user.id, folder.folder_name)
-    if user_file:
-        return user_file
-    else:
-        raise HTTPException(
-                status_code=400,
-                detail="this folder not exists in your folders",
-                )
+    return service.find_user_folder(db=db, current_user=current_user, folder=folder)
 
-#User File delete
+
+# User File delete
 @router.post("/delete")
 def delete_user_file(
     *,
@@ -189,40 +60,10 @@ def delete_user_file(
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileDelete,
     ) -> Any:
-    from app.file.security import validate_file_path
+    return service.delete_file(db=db, current_user=current_user, file_info=fileInfo)
 
-    user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-    if user_file:
-        # 실제 파일 경로 구성
-        user_folder = f'./user/{current_user.username}/data'
-        file_path = os.path.join(user_folder, fileInfo.file_name)
 
-        # 보안: Path traversal 방지 (centralized validation)
-        validate_file_path(user_folder, file_path)
-
-        # 파일 존재 여부 확인 및 삭제
-        if os.path.exists(file_path) and os.path.isfile(file_path):
-            try:
-                from app.datatable.cache import invalidate_datatable
-                invalidate_file(file_path)
-                invalidate_datatable(file_path)
-                os.remove(file_path)
-            except Exception as e:
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"Failed to delete file: {str(e)}"
-                )
-
-        # DB에서 파일 정보 삭제
-        delete_file = crud_file.delete_user_file(db, current_user.id, fileInfo.file_name)
-        return delete_file
-    else:
-        raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-                )
-
-#User File Update
+# User File Update
 @router.post("/update")
 def update_user_file(
     *,
@@ -230,17 +71,9 @@ def update_user_file(
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileUpdate,
     ) -> Any:
-    user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-    if user_file:
-        update_file = crud_file.update_user_file(db, current_user.id, fileInfo)
-        # print(update_file)
-        return update_file
-    else:
-        raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-                )
-    
+    return service.update_file(db=db, current_user=current_user, file_info=fileInfo)
+
+
 @router.post("/convert")
 def user_file_convert(
     *,
@@ -248,52 +81,8 @@ def user_file_convert(
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileFind,
     ) -> Any:
-    user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-    if user_file:
-        # 해당 유저의 폴더에 있는 파일을 가져와서 csv로 변환
-        # 변환된 파일을 해당 유저의 폴더에 저장
-        # 변환된 파일의 정보를 db에 저장
-        # 유저 폴더 내 파일 경로 "user/{username}/data/{filename}.h5ad"
-        # 변환된 파일 경로 "user/{username}/result/{filename}.csv"
-        folder_path = './user' + '/' + current_user.username
-        input_filename = fileInfo.file_name
-        output_filename = fileInfo.file_name.replace('.h5ad', '') + '_obs_umap.csv'
-        input_filepath = f"{folder_path}/data/{input_filename}"
-        output_filepath = f"{folder_path}/result/{output_filename}"
+    return service.convert_file(db=db, current_user=current_user, file_info=fileInfo)
 
-        # Check if directory exists, if not, create it
-        if not os.path.exists(folder_path + '/result'):
-            os.makedirs(folder_path + '/result')
-
-        # Check if file exists, if not, continue
-        if not os.path.isfile(output_filepath):
-            # 메모리 누수 방지를 위해 adata를 명시적으로 해제
-            adata = None
-            try:
-                # Read the h5ad file
-                adata = sc.read_h5ad(input_filepath)
-
-                # Process and combine data to form the desired dataframe structure
-                df = pd.concat([
-                    adata.obs.copy(),
-                    pd.DataFrame(adata.obsm['X_umap'], columns=['X', 'Y'], index=adata.obs.index)
-                ], axis=1)
-
-                # Save the dataframe to a specific folder
-                df.to_csv(output_filepath, index=False)
-                return {'file_name': output_filename}
-            finally:
-                if adata is not None:
-                    del adata
-                gc.collect()
-        else:
-            return {'file_name': output_filename}
-            
-    else:
-        raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-                )
 
 @router.get("/check/{file_name}")
 def check_user_file_convert(
@@ -301,114 +90,36 @@ def check_user_file_convert(
     current_user: models.User = Depends(dep.get_current_active_user),
     file_name: str,
     ) -> Any:
-    folder_path = './user' + '/' + current_user.username
-    output_filename = file_name.replace('.h5ad', '') + '_obs_umap.csv'
-    output_filepath = f"{folder_path}/result/{output_filename}"
-    if os.path.isfile(output_filepath):
-        return { 'file_name': output_filename }
-    else:
-        raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-                )
+    return service.check_convert(current_user=current_user, file_name=file_name)
 
 
 @router.post("/columns")
-def h5ad_columns (
+def h5ad_columns(
     *,
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileFind,
     ) -> Any:
-    from app.file.path_resolver import resolve_data_file_path
+    return service.get_h5ad_columns(db=db, current_user=current_user, file_info=fileInfo)
 
-    # 공용 파일은 DB 소유권 검사 스킵
-    if fileInfo.source != "shared":
-        user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-        if not user_file:
-            raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-            )
-
-    input_filepath = resolve_data_file_path(fileInfo.file_name, current_user.username, fileInfo.source)
-
-    if not os.path.isfile(input_filepath):
-        raise HTTPException(status_code=404, detail="File not found")
-
-    cached = get_cached_columns(input_filepath)
-    if cached is not None:
-        return cached
-
-    adata = None
-    try:
-        adata = sc.read_h5ad(input_filepath)
-        obs = organize_column_dtypes(adata.obs)
-        anno_columns = get_annotation_columns(obs, organized=True)
-        pseudo_columns = get_pseudotime_columns(obs, organized=True)
-        result = {'anno_columns': anno_columns, 'pseudo_columns': pseudo_columns}
-        set_cached_columns(input_filepath, result)
-        return result
-    finally:
-        if adata is not None:
-            del adata
-        gc.collect()
 
 @router.post("/clusters")
-def h5ad_cluster (
+def h5ad_cluster(
     *,
     db: Session = Depends(dep.get_db),
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileFind,
     ) -> Any:
-    from app.file.path_resolver import resolve_data_file_path
+    return service.get_h5ad_clusters(db=db, current_user=current_user, file_info=fileInfo)
 
-    # 공용 파일은 DB 소유권 검사 스킵
-    if fileInfo.source != "shared":
-        user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-        if not user_file:
-            raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-            )
 
-    input_filepath = resolve_data_file_path(fileInfo.file_name, current_user.username, fileInfo.source)
-
-    if not os.path.isfile(input_filepath):
-        raise HTTPException(status_code=404, detail="File not found")
-
-    cached = get_cached_clusters(input_filepath, fileInfo.anno_column)
-    if cached is not None:
-        return {'clusters': cached}
-
-    adata = None
-    try:
-        adata = sc.read_h5ad(input_filepath)
-        adata.obs = organize_column_dtypes(adata.obs)
-        clusters = list(map(str, adata.obs[fileInfo.anno_column].value_counts().index))
-        set_cached_clusters(input_filepath, fileInfo.anno_column, clusters)
-        return {'clusters': clusters}
-    finally:
-        if adata is not None:
-            del adata
-        gc.collect()
-    
 @router.get("/setup/check")
-def algorithm_setup_check (
+def algorithm_setup_check(
     *,
     current_user: models.User = Depends(dep.get_current_active_user),
     ) -> Any:
-    folder_path = './user' + '/' + current_user.username
-    input_filepath = f"{folder_path}/data/"
+    return service.list_option_files(current_user=current_user)
 
-    # input_filepath 안에 .option.json 파일이 있는지 확인 후, 있으면 모두 return
-    files = os.listdir(input_filepath)
-    option_files = []
-    for file in files:
-        if file.endswith('.json'):
-            option_files.append(file)
-    # print(option_files)
-    return {'option_files': option_files}
 
 @router.get("/setup/{file_name}")
 def read_user_file(
@@ -416,52 +127,15 @@ def read_user_file(
     current_user: models.User = Depends(dep.get_current_active_user),
     file_name: str,
     ) -> Any:
-    from app.file.security import validate_file_path
+    return service.read_setup_file(current_user=current_user, file_name=file_name)
 
-    folder_path = f'./user/{current_user.username}/data'
-    input_filepath = os.path.join(folder_path, file_name)
 
-    # Security: Prevent path traversal
-    validate_file_path(folder_path, input_filepath)
-
-    if not os.path.exists(input_filepath):
-        raise HTTPException(status_code=404, detail="File not found")
-
-    # file_name에 해당하는 파일이 .json 확장자면 json으로 로드해서 return
-    # 아니면 파일을 읽어서 return
-    if file_name.endswith('.json'):
-        with open(input_filepath) as json_file:
-            data = json.load(json_file)
-            return data
-    else:
-        with open(input_filepath, 'rb') as file:
-            contents = file.read()
-            return contents
-        
 @router.get("/shared")
 def get_shared_files(
     current_user: models.User = Depends(dep.get_current_active_user),
 ) -> Any:
     """tutorials/ 디렉토리의 데이터 파일 목록 반환 (html 제외)"""
-    SHARED_DIR = './tutorials'
-    DATA_EXTENSIONS = {'.h5ad', '.csv', '.txt', '.json'}
-    shared_files = []
-
-    if not os.path.isdir(SHARED_DIR):
-        return shared_files
-
-    for f in os.listdir(SHARED_DIR):
-        ext = os.path.splitext(f)[1].lower()
-        if ext in DATA_EXTENSIONS:
-            file_path = os.path.join(SHARED_DIR, f)
-            shared_files.append({
-                "file_name": f,
-                "file_size": str(os.path.getsize(file_path)),
-                "file_path": SHARED_DIR,
-                "folder": "tutorials",
-                "source": "shared",
-            })
-    return shared_files
+    return service.get_shared_files()
 
 
 @router.post("/shared/find")
@@ -471,41 +145,15 @@ def find_shared_file(
     fileInfo: FileFind,
 ) -> Any:
     """공용 파일 단건 조회 (InputFile.vue에서 사용)"""
-    from app.file.security import validate_file_path
-
-    SHARED_DIR = './tutorials'
-    file_path = os.path.join(SHARED_DIR, fileInfo.file_name)
-    validate_file_path(SHARED_DIR, file_path)
-
-    if not os.path.exists(file_path):
-        raise HTTPException(status_code=404, detail="Shared file not found")
-
-    return {
-        "file_name": fileInfo.file_name,
-        "file_size": str(os.path.getsize(file_path)),
-        "file_path": SHARED_DIR,
-        "folder": "tutorials",
-        "source": "shared",
-    }
+    return service.find_shared_file(file_info=fileInfo)
 
 
 @router.get("/html/{filename}", response_class=HTMLResponse)
 async def read_html_file(
     filename: str,
 ) -> Any:
-    from app.file.security import validate_file_path
+    return service.read_html_file(filename=filename)
 
-    folder_path = './tutorials'
-    file_path = os.path.join(folder_path, f'{filename}.html')
-
-    validate_file_path(folder_path, file_path)
-
-    if not os.path.exists(file_path):
-        raise HTTPException(status_code=404, detail="File not found")
-
-    with open(file_path, "r") as f:
-        html = f.read()
-    return HTMLResponse(content=html)
 
 @router.post("/result")
 async def read_result_file(
@@ -514,26 +162,8 @@ async def read_result_file(
     current_user: models.User = Depends(dep.get_current_active_user),
     fileInfo: FileResultFind,
     ) -> Any:
-    user_file = crud_file.get_user_file(db, current_user.id, fileInfo.file_name)
-    if user_file:
-        folder_path = './user' + '/' + current_user.username + "/result/"
-        filename = fileInfo.file_name
-        option_filename = fileInfo.option_file_name
-        ## folder_path 안에 파일들의 이름에 option_filename, filename이 포함되어 있는지 확인
-        ## 둘 다 포함되어 있으면 파일들을 읽어서 return
-        ## 파일들을 리스트 형식으로 return
-        files = os.listdir(folder_path)
-        result_files = []
-        for file in files:
-            if option_filename in file and filename in file:
-                result_files.append(file)
-        # print(result_files)
-        return {'result_files': result_files}
-    else:
-        raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-        )
+    return service.read_result_file(db=db, current_user=current_user, file_info=fileInfo)
+
 
 @router.get("/result/{filename}")
 async def download_result_file(
@@ -541,18 +171,8 @@ async def download_result_file(
     current_user: models.User = Depends(dep.get_current_active_user),
     filename: str,
     ) -> Any:
-    from app.file.security import validate_file_path
+    return service.download_result_file(current_user=current_user, filename=filename)
 
-    folder_path = f'./user/{current_user.username}/result'
-    file_path = os.path.join(folder_path, filename)
-
-    # Security: Prevent path traversal
-    validate_file_path(folder_path, file_path)
-
-    if not os.path.exists(file_path):
-        raise HTTPException(status_code=404, detail="File not found")
-
-    return FileResponse(file_path, filename=filename)
 
 @router.get("/data/{filename}")
 async def download_data_file(
@@ -561,23 +181,10 @@ async def download_data_file(
     filename: str,
     source: str = None,
     ) -> Any:
-    from app.file.path_resolver import resolve_data_file_path
+    return await service.download_data_file(
+        current_user=current_user, filename=filename, source=source
+    )
 
-    file_path = resolve_data_file_path(filename, current_user.username, source)
-
-    # 파일이 존재하는지 확인
-    if not os.path.isfile(file_path):
-        raise HTTPException(
-                status_code=400,
-                detail="this file not exists in your files",
-        )
-
-    if filename.endswith('.h5ad'):
-        # asyncio.to_thread()를 사용하여 blocking I/O를 별도 스레드에서 실행
-        # 이벤트 루프 블로킹 방지
-        df = await asyncio.to_thread(load_tab_file, file_path)
-        return df.to_dict(orient="records")
-    return FileResponse(file_path, filename=filename)
 
 @router.get("/tutorials/{filename}")
 async def download_tutorial_file(
@@ -585,15 +192,4 @@ async def download_tutorial_file(
     current_user: models.User = Depends(dep.get_current_active_user),
     filename: str,
     ) -> Any:
-    from app.file.security import validate_file_path
-
-    folder_path = './tutorials'
-    file_path = os.path.join(folder_path, filename)
-
-    # Security: Prevent path traversal
-    validate_file_path(folder_path, file_path)
-
-    if not os.path.exists(file_path):
-        raise HTTPException(status_code=404, detail="File not found")
-
-    return FileResponse(file_path, filename=filename)
+    return service.download_tutorial_file(current_user=current_user, filename=filename)

--- a/backend/app/file/service.py
+++ b/backend/app/file/service.py
@@ -1,0 +1,487 @@
+"""
+File domain service layer.
+
+Extracted from ``file/router.py`` in PR-8 (Phase 3d). This module holds the
+business logic that previously lived inline in the endpoints: streaming uploads
+(with size/extension validation via ``file/security.py``), user file CRUD, h5ad
+column/cluster extraction, setup/result/shared/tutorial file access, and the
+download handlers. The router now only parses requests, resolves dependencies,
+calls a service function, and returns its result.
+
+Exception policy (PR-8): business-rule failures raise the domain exceptions from
+``app.core.exceptions`` (``NotFoundError`` -> 404, ``ValidationFailedError`` ->
+400, ``CellcraftError`` -> 500). The global handler in ``app.main`` maps these
+onto the exact ``{"detail": ...}`` wire format FastAPI produces for
+``HTTPException``, so responses (status code + detail string) are unchanged.
+Path-traversal rejections still come from ``file/security.py`` as ``HTTPException``
+and are handled by FastAPI's default handler (also unchanged).
+"""
+import os
+import gc
+import json
+import asyncio
+from typing import Any, List, Optional
+
+import pandas as pd
+import scanpy as sc
+from fastapi import HTTPException, UploadFile
+from fastapi.responses import HTMLResponse, FileResponse
+from sqlalchemy.orm import Session
+
+from app import models
+from app.core.exceptions import NotFoundError, ValidationFailedError, CellcraftError
+from app.file import crud as crud_file
+from app.file.schemas import FileFind, FileDelete, FileUpdate, FolderFind, FileResultFind
+from app.datatable.h5ad import (
+    organize_column_dtypes, get_annotation_columns, get_pseudotime_columns
+)
+from app.datatable.cache import (
+    get_cached_columns, set_cached_columns,
+    get_cached_clusters, set_cached_clusters, invalidate_file
+)
+from app.workflow.utils import load_tab_file
+
+SHARED_DIR = './tutorials'
+DATA_EXTENSIONS = {'.h5ad', '.csv', '.txt', '.json'}
+
+
+async def save_upload(*, db: Session, files: List[UploadFile],
+                      current_user: models.User) -> Any:
+    """Stream-validate-persist one or more uploaded data files for a user."""
+    from app.core.config import MAX_FILES_PER_UPLOAD
+    from app.file.security import validate_file_upload
+
+    # Validation 1: Check batch upload limit
+    if len(files) > MAX_FILES_PER_UPLOAD:
+        raise ValidationFailedError(
+            f"Too many files. Maximum {MAX_FILES_PER_UPLOAD} files per upload."
+        )
+
+    # Setup upload directory
+    UPLOAD_DIRECTORY = f'./user/{current_user.username}/data'
+    os.makedirs(UPLOAD_DIRECTORY, exist_ok=True)
+
+    uploaded_files = []
+
+    for item_file in files:
+        # Validation 2: Comprehensive file validation
+        safe_filename = validate_file_upload(item_file)
+
+        # Parse folder and filename (format: "folder_filename.ext")
+        folder_file = safe_filename.split('_', 1)
+        if len(folder_file) != 2:
+            raise ValidationFailedError(
+                f"Invalid filename format. Expected 'folder_filename.ext', got '{safe_filename}'"
+            )
+
+        folder, actual_filename = folder_file
+        final_filename = actual_filename
+
+        # Check for duplicate files
+        user_file = crud_file.get_user_file(db, current_user.id, final_filename)
+        if user_file:
+            raise ValidationFailedError(
+                f"File '{final_filename}' already exists in your files"
+            )
+
+        # Stream file to disk in chunks to prevent memory exhaustion
+        from app.core.config import UPLOAD_CHUNK_SIZE, MAX_UPLOAD_SIZE
+
+        file_path = os.path.join(UPLOAD_DIRECTORY, final_filename)
+        file_size = 0
+
+        try:
+            with open(file_path, "wb") as f:
+                while chunk := await item_file.read(UPLOAD_CHUNK_SIZE):
+                    f.write(chunk)
+                    file_size += len(chunk)
+
+                    # Enforce size limit during streaming to fail fast
+                    if file_size > MAX_UPLOAD_SIZE:
+                        # Clean up partial file
+                        f.close()
+                        if os.path.exists(file_path):
+                            os.remove(file_path)
+                        raise ValidationFailedError(
+                            f"File too large. Maximum size is {MAX_UPLOAD_SIZE / (1024*1024):.0f}MB",
+                            status_code=413,
+                        )
+        except (HTTPException, CellcraftError):
+            raise
+        except Exception as e:
+            # Clean up partial file on error
+            if os.path.exists(file_path):
+                os.remove(file_path)
+            raise CellcraftError(f"File upload failed: {str(e)}")
+
+        # Compress H5AD files to reduce storage
+        if final_filename.lower().endswith('.h5ad'):
+            from app.datatable.h5ad_compression import compress_h5ad_file
+            from app.core.config import H5AD_COMPRESSION_ENABLED, H5AD_COMPRESSION_MIN_SIZE
+
+            if H5AD_COMPRESSION_ENABLED:
+                _compressed, file_size = await asyncio.to_thread(
+                    compress_h5ad_file,
+                    file_path,
+                    min_size_bytes=H5AD_COMPRESSION_MIN_SIZE,
+                )
+
+        # Create database record
+        created_file = crud_file.create_file(
+            db,
+            final_filename,
+            file_size,
+            UPLOAD_DIRECTORY,
+            folder,
+            current_user.id
+        )
+        uploaded_files.append(created_file)
+
+    # Return last uploaded file (maintain backward compatibility)
+    # or return list if multiple files
+    if len(uploaded_files) == 1:
+        return uploaded_files[0]
+    else:
+        return {"files": uploaded_files, "count": len(uploaded_files)}
+
+
+def read_user_folder(*, current_user: models.User) -> Any:
+    """Walk the user's data folder and return {folder: [filenames]} entries."""
+    USER_FOLDER = f'./user/{current_user.username}/data'
+    res = []
+    for (dir_path, dir_names, file_names) in os.walk(USER_FOLDER):
+        folder = dir_path.replace(USER_FOLDER, 'data')
+        res.extend({folder: file_names}.items())
+    return res
+
+
+def find_user_file(*, db: Session, current_user: models.User, file_info: FileFind) -> Any:
+    """Return a user's file record by name (400 if the user has no such file)."""
+    user_file = crud_file.get_user_file(db, current_user.id, file_info.file_name)
+    if user_file:
+        return user_file
+    raise ValidationFailedError("this file not exists in your files")
+
+
+def find_user_folder(*, db: Session, current_user: models.User, folder: FolderFind) -> Any:
+    """Return a user's files within a folder (400 if the folder is unknown)."""
+    user_file = crud_file.get_user_folder(db, current_user.id, folder.folder_name)
+    if user_file:
+        return user_file
+    raise ValidationFailedError("this folder not exists in your folders")
+
+
+def delete_file(*, db: Session, current_user: models.User, file_info: FileDelete) -> Any:
+    """Delete a user's file from disk (path-traversal guarded) and its DB row."""
+    from app.file.security import validate_file_path
+
+    user_file = crud_file.get_user_file(db, current_user.id, file_info.file_name)
+    if user_file:
+        # 실제 파일 경로 구성
+        user_folder = f'./user/{current_user.username}/data'
+        file_path = os.path.join(user_folder, file_info.file_name)
+
+        # 보안: Path traversal 방지 (centralized validation)
+        validate_file_path(user_folder, file_path)
+
+        # 파일 존재 여부 확인 및 삭제
+        if os.path.exists(file_path) and os.path.isfile(file_path):
+            try:
+                from app.datatable.cache import invalidate_datatable
+                invalidate_file(file_path)
+                invalidate_datatable(file_path)
+                os.remove(file_path)
+            except Exception as e:
+                raise CellcraftError(f"Failed to delete file: {str(e)}")
+
+        # DB에서 파일 정보 삭제
+        return crud_file.delete_user_file(db, current_user.id, file_info.file_name)
+    raise ValidationFailedError("this file not exists in your files")
+
+
+def update_file(*, db: Session, current_user: models.User, file_info: FileUpdate) -> Any:
+    """Update a user's file metadata (400 if the user has no such file)."""
+    user_file = crud_file.get_user_file(db, current_user.id, file_info.file_name)
+    if user_file:
+        return crud_file.update_user_file(db, current_user.id, file_info)
+    raise ValidationFailedError("this file not exists in your files")
+
+
+def convert_file(*, db: Session, current_user: models.User, file_info: FileFind) -> Any:
+    """Convert a user's h5ad file to a `_obs_umap.csv` result (idempotent)."""
+    user_file = crud_file.get_user_file(db, current_user.id, file_info.file_name)
+    if not user_file:
+        raise ValidationFailedError("this file not exists in your files")
+
+    folder_path = './user' + '/' + current_user.username
+    input_filename = file_info.file_name
+    output_filename = file_info.file_name.replace('.h5ad', '') + '_obs_umap.csv'
+    input_filepath = f"{folder_path}/data/{input_filename}"
+    output_filepath = f"{folder_path}/result/{output_filename}"
+
+    # Check if directory exists, if not, create it
+    if not os.path.exists(folder_path + '/result'):
+        os.makedirs(folder_path + '/result')
+
+    # Check if file exists, if not, continue
+    if not os.path.isfile(output_filepath):
+        # 메모리 누수 방지를 위해 adata를 명시적으로 해제
+        adata = None
+        try:
+            # Read the h5ad file
+            adata = sc.read_h5ad(input_filepath)
+
+            # Process and combine data to form the desired dataframe structure
+            df = pd.concat([
+                adata.obs.copy(),
+                pd.DataFrame(adata.obsm['X_umap'], columns=['X', 'Y'], index=adata.obs.index)
+            ], axis=1)
+
+            # Save the dataframe to a specific folder
+            df.to_csv(output_filepath, index=False)
+            return {'file_name': output_filename}
+        finally:
+            if adata is not None:
+                del adata
+            gc.collect()
+    else:
+        return {'file_name': output_filename}
+
+
+def check_convert(*, current_user: models.User, file_name: str) -> Any:
+    """Return the converted csv filename if it already exists (400 otherwise)."""
+    folder_path = './user' + '/' + current_user.username
+    output_filename = file_name.replace('.h5ad', '') + '_obs_umap.csv'
+    output_filepath = f"{folder_path}/result/{output_filename}"
+    if os.path.isfile(output_filepath):
+        return {'file_name': output_filename}
+    raise ValidationFailedError("this file not exists in your files")
+
+
+def get_h5ad_columns(*, db: Session, current_user: models.User, file_info: FileFind) -> Any:
+    """Return organized annotation/pseudotime columns for an h5ad file (cached)."""
+    from app.file.path_resolver import resolve_data_file_path
+
+    # 공용 파일은 DB 소유권 검사 스킵
+    if file_info.source != "shared":
+        user_file = crud_file.get_user_file(db, current_user.id, file_info.file_name)
+        if not user_file:
+            raise ValidationFailedError("this file not exists in your files")
+
+    input_filepath = resolve_data_file_path(file_info.file_name, current_user.username, file_info.source)
+
+    if not os.path.isfile(input_filepath):
+        raise NotFoundError("File not found")
+
+    cached = get_cached_columns(input_filepath)
+    if cached is not None:
+        return cached
+
+    adata = None
+    try:
+        adata = sc.read_h5ad(input_filepath)
+        obs = organize_column_dtypes(adata.obs)
+        anno_columns = get_annotation_columns(obs, organized=True)
+        pseudo_columns = get_pseudotime_columns(obs, organized=True)
+        result = {'anno_columns': anno_columns, 'pseudo_columns': pseudo_columns}
+        set_cached_columns(input_filepath, result)
+        return result
+    finally:
+        if adata is not None:
+            del adata
+        gc.collect()
+
+
+def get_h5ad_clusters(*, db: Session, current_user: models.User, file_info: FileFind) -> Any:
+    """Return the distinct cluster labels for an h5ad annotation column (cached)."""
+    from app.file.path_resolver import resolve_data_file_path
+
+    # 공용 파일은 DB 소유권 검사 스킵
+    if file_info.source != "shared":
+        user_file = crud_file.get_user_file(db, current_user.id, file_info.file_name)
+        if not user_file:
+            raise ValidationFailedError("this file not exists in your files")
+
+    input_filepath = resolve_data_file_path(file_info.file_name, current_user.username, file_info.source)
+
+    if not os.path.isfile(input_filepath):
+        raise NotFoundError("File not found")
+
+    cached = get_cached_clusters(input_filepath, file_info.anno_column)
+    if cached is not None:
+        return {'clusters': cached}
+
+    adata = None
+    try:
+        adata = sc.read_h5ad(input_filepath)
+        adata.obs = organize_column_dtypes(adata.obs)
+        clusters = list(map(str, adata.obs[file_info.anno_column].value_counts().index))
+        set_cached_clusters(input_filepath, file_info.anno_column, clusters)
+        return {'clusters': clusters}
+    finally:
+        if adata is not None:
+            del adata
+        gc.collect()
+
+
+def list_option_files(*, current_user: models.User) -> Any:
+    """List `.json` option files present in the user's data folder."""
+    folder_path = './user' + '/' + current_user.username
+    input_filepath = f"{folder_path}/data/"
+
+    files = os.listdir(input_filepath)
+    option_files = []
+    for file in files:
+        if file.endswith('.json'):
+            option_files.append(file)
+    return {'option_files': option_files}
+
+
+def read_setup_file(*, current_user: models.User, file_name: str) -> Any:
+    """Read a setup file from the user's data folder (json parsed, else raw bytes)."""
+    from app.file.security import validate_file_path
+
+    folder_path = f'./user/{current_user.username}/data'
+    input_filepath = os.path.join(folder_path, file_name)
+
+    # Security: Prevent path traversal
+    validate_file_path(folder_path, input_filepath)
+
+    if not os.path.exists(input_filepath):
+        raise NotFoundError("File not found")
+
+    # file_name에 해당하는 파일이 .json 확장자면 json으로 로드해서 return
+    # 아니면 파일을 읽어서 return
+    if file_name.endswith('.json'):
+        with open(input_filepath) as json_file:
+            data = json.load(json_file)
+            return data
+    else:
+        with open(input_filepath, 'rb') as file:
+            contents = file.read()
+            return contents
+
+
+def get_shared_files() -> list:
+    """List data files (html excluded) available under the shared tutorials dir."""
+    shared_files = []
+
+    if not os.path.isdir(SHARED_DIR):
+        return shared_files
+
+    for f in os.listdir(SHARED_DIR):
+        ext = os.path.splitext(f)[1].lower()
+        if ext in DATA_EXTENSIONS:
+            file_path = os.path.join(SHARED_DIR, f)
+            shared_files.append({
+                "file_name": f,
+                "file_size": str(os.path.getsize(file_path)),
+                "file_path": SHARED_DIR,
+                "folder": "tutorials",
+                "source": "shared",
+            })
+    return shared_files
+
+
+def find_shared_file(*, file_info: FileFind) -> Any:
+    """Return a single shared file's metadata (path-traversal guarded)."""
+    from app.file.security import validate_file_path
+
+    file_path = os.path.join(SHARED_DIR, file_info.file_name)
+    validate_file_path(SHARED_DIR, file_path)
+
+    if not os.path.exists(file_path):
+        raise NotFoundError("Shared file not found")
+
+    return {
+        "file_name": file_info.file_name,
+        "file_size": str(os.path.getsize(file_path)),
+        "file_path": SHARED_DIR,
+        "folder": "tutorials",
+        "source": "shared",
+    }
+
+
+def read_html_file(*, filename: str) -> HTMLResponse:
+    """Return a tutorial HTML file's content (path-traversal guarded)."""
+    from app.file.security import validate_file_path
+
+    folder_path = './tutorials'
+    file_path = os.path.join(folder_path, f'{filename}.html')
+
+    validate_file_path(folder_path, file_path)
+
+    if not os.path.exists(file_path):
+        raise NotFoundError("File not found")
+
+    with open(file_path, "r") as f:
+        html = f.read()
+    return HTMLResponse(content=html)
+
+
+def read_result_file(*, db: Session, current_user: models.User,
+                     file_info: FileResultFind) -> Any:
+    """List result files whose names contain both the file and option filenames."""
+    user_file = crud_file.get_user_file(db, current_user.id, file_info.file_name)
+    if user_file:
+        folder_path = './user' + '/' + current_user.username + "/result/"
+        filename = file_info.file_name
+        option_filename = file_info.option_file_name
+        files = os.listdir(folder_path)
+        result_files = []
+        for file in files:
+            if option_filename in file and filename in file:
+                result_files.append(file)
+        return {'result_files': result_files}
+    raise ValidationFailedError("this file not exists in your files")
+
+
+def download_result_file(*, current_user: models.User, filename: str) -> FileResponse:
+    """Return a FileResponse for a file in the user's result folder (traversal guarded)."""
+    from app.file.security import validate_file_path
+
+    folder_path = f'./user/{current_user.username}/result'
+    file_path = os.path.join(folder_path, filename)
+
+    # Security: Prevent path traversal
+    validate_file_path(folder_path, file_path)
+
+    if not os.path.exists(file_path):
+        raise NotFoundError("File not found")
+
+    return FileResponse(file_path, filename=filename)
+
+
+async def download_data_file(*, current_user: models.User, filename: str,
+                             source: Optional[str] = None) -> Any:
+    """Download a user/shared data file; h5ad is loaded and returned as records."""
+    from app.file.path_resolver import resolve_data_file_path
+
+    file_path = resolve_data_file_path(filename, current_user.username, source)
+
+    # 파일이 존재하는지 확인
+    if not os.path.isfile(file_path):
+        raise ValidationFailedError("this file not exists in your files")
+
+    if filename.endswith('.h5ad'):
+        # asyncio.to_thread()를 사용하여 blocking I/O를 별도 스레드에서 실행
+        # 이벤트 루프 블로킹 방지
+        df = await asyncio.to_thread(load_tab_file, file_path)
+        return df.to_dict(orient="records")
+    return FileResponse(file_path, filename=filename)
+
+
+def download_tutorial_file(*, current_user: models.User, filename: str) -> FileResponse:
+    """Return a FileResponse for a tutorial file (path-traversal guarded)."""
+    from app.file.security import validate_file_path
+
+    folder_path = './tutorials'
+    file_path = os.path.join(folder_path, filename)
+
+    # Security: Prevent path traversal
+    validate_file_path(folder_path, file_path)
+
+    if not os.path.exists(file_path):
+        raise NotFoundError("File not found")
+
+    return FileResponse(file_path, filename=filename)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,28 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
 
 from app.api import api_router
 from app.core.config import settings
 from app.core import startup
+from app.core.exceptions import CellcraftError
 from app.worker.app import celery
 
 
 def get_celery_app():
     return celery
+
+
+async def cellcraft_error_handler(request: Request, exc: CellcraftError) -> JSONResponse:
+    """Map a domain ``CellcraftError`` onto FastAPI's HTTPException wire format.
+
+    Emits ``{"detail": <detail>}`` with the exception's status code — byte-for-byte
+    identical to FastAPI's default ``HTTPException`` response — so converting a
+    service ``raise HTTPException(...)`` to the matching domain exception does not
+    change any response. FastAPI's built-in 422 ``RequestValidationError`` handling
+    is untouched (this handler only fires for ``CellcraftError`` subclasses).
+    """
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
 
 def create_app() -> FastAPI:
@@ -40,6 +54,7 @@ def create_app() -> FastAPI:
     )
 
     app.celery_app = celery
+    app.add_exception_handler(CellcraftError, cellcraft_error_handler)
     app.include_router(api_router, prefix=settings.ROUTES_STR)
     app.add_event_handler("startup", startup.on_startup)
     startup.setup_signal_handlers()

--- a/backend/app/task/service.py
+++ b/backend/app/task/service.py
@@ -32,6 +32,7 @@ from sqlalchemy.orm import Session
 
 from app import models
 from app.core.enums import PluginType
+from app.core.exceptions import ValidationFailedError, ExternalServiceError
 from app.shared.docker import container_manager
 from app.task import crud as crud_task
 from app.task.schemas import TaskMonitoringItem, PluginInfo
@@ -53,14 +54,14 @@ def get_resources() -> dict:
 
     status = get_resource_status()
     if status is None:
-        raise HTTPException(status_code=503, detail="Resource monitoring unavailable")
+        raise ExternalServiceError("Resource monitoring unavailable", status_code=503)
     return status
 
 
 def get_task_status_simple(*, task_id: str) -> dict:
     """SSE 재연결 판단용 경량 상태 확인 (Celery AsyncResult 상태만 반환)."""
     if not task_id or not task_id.strip():
-        raise HTTPException(status_code=400, detail="Invalid task_id")
+        raise ValidationFailedError("Invalid task_id")
 
     task = get_task_info(task_id)
     return {

--- a/backend/app/user/service.py
+++ b/backend/app/user/service.py
@@ -1,0 +1,53 @@
+"""
+User domain service layer.
+
+Extracted from ``auth/router.py`` in PR-8 (Phase 3d). Holds the user registration
+/ profile-read / plugin-update business logic. The three endpoints physically
+remain on ``auth/router.py`` (moving them would change their mounted paths and
+break the OpenAPI contract snapshot), but their logic now lives here.
+
+Exception policy (PR-8): a duplicate-email signup raises ``ValidationFailedError``
+(-> 400); the global handler maps it onto the exact ``{"detail": ...}`` wire
+format (status code + detail string unchanged).
+"""
+import os
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app import models
+from app.core.exceptions import ValidationFailedError
+from app.user import crud as crud_user
+from app.user import schemas as user_schemas
+
+
+def register(*, db: Session, user_in: user_schemas.UserCreate) -> Any:
+    """Create a new user, provisioning their data folder (400 on duplicate email)."""
+    existing = crud_user.get_user_by_email(db, email=user_in.email)
+    if existing:
+        raise ValidationFailedError("Email already registered")
+    created = crud_user.create_user(db, user=user_in)
+    USER_DIRECTORY_NAME = './user/' + user_in.username + '/data'
+    os.makedirs(USER_DIRECTORY_NAME, exist_ok=True)
+    # 회원가입 시 보내는 확인 이메일
+    # if user_in.email:
+    #     send_new_account_email(
+    #         email_to=user_in.email, username=user_in.email, password=user_in.password
+    #     )
+    return created
+
+
+def read_me(*, current_user: models.User) -> Any:
+    """Return the current user's public profile fields."""
+    return {
+        "id": current_user.id,
+        "email": current_user.email,
+        "username": current_user.username,
+        "is_superuser": current_user.is_superuser,
+    }
+
+
+def update_plugins(*, db: Session, current_user: models.User,
+                   user_in: user_schemas.UserUpdate) -> Any:
+    """Update the current user's record (plugin associations / password)."""
+    return crud_user.update_user(db, user_id=current_user.id, user=user_in)

--- a/backend/app/workflow/service.py
+++ b/backend/app/workflow/service.py
@@ -37,7 +37,8 @@ from app.workflow.compiler.snakefile import change_snakefile_parameter
 from app.core.exceptions import (
     PluginNotFoundError, ScriptNotFoundError, FileNotFoundError as CellCraftFileNotFoundError,
     ValidationError, WorkflowError, SnakefileGenerationError, TaskSubmissionError,
-    log_error, create_error_response
+    log_error, create_error_response,
+    NotFoundError, PermissionDeniedError, ValidationFailedError,
 )
 from app.shared.cache import (
     generate_cache_key, check_cache_with_expiry, create_symbolic_link,
@@ -749,10 +750,7 @@ def get_visualization_result(*, workflow_result: WorkflowResult) -> JSONResponse
         return JSONResponse(content=plotly_data)
 
     except Exception as e:
-        raise HTTPException(
-                status_code=400,
-                detail=str(e),
-                )
+        raise ValidationFailedError(str(e))
 
 
 def save_workflow(*, db: Session, user: models.User, workflow: WorkflowCreate) -> Any:
@@ -780,10 +778,7 @@ def delete_workflow(*, db: Session, user: models.User, workflow_id: int) -> Any:
 
         # 워크플로우 경로가 사용자 폴더 내에 있는지 확인
         if not real_workflow_path.startswith(real_user_path):
-            raise HTTPException(
-                status_code=403,
-                detail="Access denied: Invalid workflow path"
-            )
+            raise PermissionDeniedError("Access denied: Invalid workflow path")
 
         # 폴더 존재 여부 확인 및 삭제
         if os.path.exists(workflow_path) and os.path.isdir(workflow_path):
@@ -799,10 +794,7 @@ def delete_workflow(*, db: Session, user: models.User, workflow_id: int) -> Any:
         delete_workflow = crud_workflow.delete_user_workflow(db, user.id, workflow_id)
         return delete_workflow
     else:
-        raise HTTPException(
-                status_code=400,
-                detail="this workflow not exists in your workflows",
-                )
+        raise ValidationFailedError("this workflow not exists in your workflows")
 
 
 def list_workflows(*, db: Session, user: models.User) -> Any:
@@ -822,10 +814,7 @@ def list_workflows(*, db: Session, user: models.User) -> Any:
         # print(res)
         return res
     else:
-        raise HTTPException(
-                status_code=400,
-                detail="this workflow not exists in your workflows",
-                )
+        raise ValidationFailedError("this workflow not exists in your workflows")
 
 
 def find_workflow(*, db: Session, user: models.User, workflow_id: int) -> Any:
@@ -838,10 +827,7 @@ def find_workflow(*, db: Session, user: models.User, workflow_id: int) -> Any:
             'workflow_info': user_workflow.workflow_info,
         }
     else:
-        raise HTTPException(
-                status_code=400,
-                detail="this workflow not exists in your workflows",
-                )
+        raise ValidationFailedError("this workflow not exists in your workflows")
 
 
 def get_results(*, user: models.User, workflow_result: WorkflowResult) -> list:
@@ -861,7 +847,7 @@ def get_results(*, user: models.User, workflow_result: WorkflowResult) -> list:
                 }
                 file_info_list.append(file_info)
     else:
-        raise HTTPException(status_code=404, detail="Results directory not found.")
+        raise NotFoundError("Results directory not found.")
 
     return file_info_list
 
@@ -936,17 +922,11 @@ def check_visualization_result(*, user: models.User, workflow_result: WorkflowRe
                 time.sleep(retry_delay)
             else:
                 logger.error(f"Failed to read visualization file after {max_retries} attempts: {FILE_PATH}")
-                raise HTTPException(
-                    status_code=400,
-                    detail=str(e),
-                )
+                raise ValidationFailedError(str(e))
         except Exception as e:
             # Unexpected error, don't retry
             logger.error(f"Unexpected error reading visualization file: {str(e)}")
-            raise HTTPException(
-                status_code=400,
-                detail=str(e),
-            )
+            raise ValidationFailedError(str(e))
 
 
 def save_node_data(*, db: Session, user: models.User,
@@ -978,10 +958,7 @@ def save_node_data(*, db: Session, user: models.User,
             'file_path': result_file_path
         }
     else:
-        raise HTTPException(
-                status_code=400,
-                detail="this workflow not exists in your workflows",
-                )
+        raise ValidationFailedError("this workflow not exists in your workflows")
 
 
 def read_node_data(*, db: Session, user: models.User,
@@ -994,10 +971,7 @@ def read_node_data(*, db: Session, user: models.User,
         workflow_path = f"{user_path}workflow_{node_file_info.id}"
         print(workflow_path)
         if not os.path.exists(workflow_path):
-            raise HTTPException(
-                status_code=400,
-                detail="this workflow not exists in your workflows",
-                )
+            raise ValidationFailedError("this workflow not exists in your workflows")
         # workflowNodeFileInfo.node_name이랑 workflowNodeFileInfo.node_id로 파일 읽어오기
         file_name = f"{node_file_info.node_name}_{node_file_info.node_id}.{node_file_info.file_extension}"
         with open(f"{workflow_path}/{file_name}", "r") as f:
@@ -1014,10 +988,7 @@ def read_node_data(*, db: Session, user: models.User,
             'file_extension': node_file_info.file_extension
         }
     else:
-        raise HTTPException(
-                status_code=400,
-                detail="this workflow not exists in your workflows",
-                )
+        raise ValidationFailedError("this workflow not exists in your workflows")
 
 
 def delete_node_data(*, db: Session, user: models.User,
@@ -1029,10 +1000,7 @@ def delete_node_data(*, db: Session, user: models.User,
         user_path = f"./user/{user.username}/"
         workflow_path = f"{user_path}workflow_{node_file_info.id}"
         if not os.path.exists(workflow_path):
-            raise HTTPException(
-                status_code=400,
-                detail="this workflow not exists in your workflows",
-                )
+            raise ValidationFailedError("this workflow not exists in your workflows")
         # workflowNodeFileInfo.node_name이랑 workflowNodeFileInfo.node_id로 파일 삭제
         file_name = f"{node_file_info.node_name}_{node_file_info.node_id}.{node_file_info.file_extension}"
         os.remove(f"{workflow_path}/{file_name}")
@@ -1043,7 +1011,4 @@ def delete_node_data(*, db: Session, user: models.User,
             'file_extension': node_file_info.file_extension
         }
     else:
-        raise HTTPException(
-                status_code=400,
-                detail="this workflow not exists in your workflows",
-                )
+        raise ValidationFailedError("this workflow not exists in your workflows")

--- a/backend/tests/unit/test_admin_service.py
+++ b/backend/tests/unit/test_admin_service.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for the admin service layer (app/admin/service.py) extracted in PR-8.
+
+Scope: pin the admin-gate + listing/mutation business logic with the admin crud,
+Docker, and plugin-sync boundaries mocked. Asserts the domain-exception mapping:
+the superuser gate raises ``PermissionDeniedError`` (-> 403) and the "not found"
+guards raise ``NotFoundError`` (-> 404), which the global handler renders as the
+unchanged ``{"detail": ...}`` body.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.core.exceptions import (
+    NotFoundError, PermissionDeniedError, ExternalServiceError
+)
+from app.admin import service
+
+
+def _admin():
+    u = MagicMock()
+    u.is_superuser = True
+    return u
+
+
+def _nonadmin():
+    u = MagicMock()
+    u.is_superuser = False
+    return u
+
+
+_LIST_KW = dict(amount=10, page_num=1, sort="id", order="asc", searchTerm="")
+
+
+# ---------------------------------------------------------------------------
+# admin gate
+# ---------------------------------------------------------------------------
+
+class TestAdminGate:
+    def test_nonadmin_blocked_403(self):
+        with pytest.raises(PermissionDeniedError) as exc:
+            service.get_users_count(db=MagicMock(), current_user=_nonadmin())
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Access denied: Admins only"
+
+    def test_nonadmin_blocked_on_listing(self):
+        with pytest.raises(PermissionDeniedError):
+            service.get_filtered_users(db=MagicMock(), current_user=_nonadmin(), **_LIST_KW)
+
+
+# ---------------------------------------------------------------------------
+# listings + counts
+# ---------------------------------------------------------------------------
+
+class TestListings:
+    def test_users_empty_raises_404(self):
+        with patch("app.admin.service.crud_admin.get_filtered_users", return_value=([], 0)):
+            with pytest.raises(NotFoundError) as exc:
+                service.get_filtered_users(db=MagicMock(), current_user=_admin(), **_LIST_KW)
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Users not found"
+
+    def test_users_returns_rows(self):
+        rows = [MagicMock(), MagicMock()]
+        with patch("app.admin.service.crud_admin.get_filtered_users", return_value=(rows, 2)):
+            out = service.get_filtered_users(db=MagicMock(), current_user=_admin(), **_LIST_KW)
+        assert out is rows
+
+    def test_users_count_returns_value(self):
+        with patch("app.admin.service.crud_admin.get_users_count", return_value=42):
+            assert service.get_users_count(db=MagicMock(), current_user=_admin()) == 42
+
+    def test_files_formats_rows(self):
+        f = MagicMock()
+        f.id, f.file_name, f.file_path, f.file_size, f.folder, f.user_id = 1, "a.h5ad", "/p", 10, "fold", 5
+        with patch("app.admin.service.crud_admin.get_filtered_files", return_value=([(f, "bob")], 1)):
+            out = service.get_filtered_files(db=MagicMock(), current_user=_admin(), **_LIST_KW)
+        assert out["total_count"] == 1
+        assert out["data"][0]["username"] == "bob"
+        assert out["data"][0]["file_name"] == "a.h5ad"
+
+    def test_files_empty_raises_404(self):
+        with patch("app.admin.service.crud_admin.get_filtered_files", return_value=([], 0)):
+            with pytest.raises(NotFoundError) as exc:
+                service.get_filtered_files(db=MagicMock(), current_user=_admin(), **_LIST_KW)
+        assert exc.value.detail == "Files not found"
+
+
+# ---------------------------------------------------------------------------
+# mutations
+# ---------------------------------------------------------------------------
+
+class TestMutations:
+    def test_delete_user_missing_raises_404(self):
+        with patch("app.admin.service.crud_admin.delete_user", return_value=False):
+            with pytest.raises(NotFoundError) as exc:
+                service.delete_user(db=MagicMock(), current_user=_admin(), user_id=1)
+        assert exc.value.detail == "User not found"
+
+    def test_delete_user_success_message(self):
+        with patch("app.admin.service.crud_admin.delete_user", return_value=True):
+            out = service.delete_user(db=MagicMock(), current_user=_admin(), user_id=1)
+        assert out == {"message": "User deleted successfully"}
+
+    def test_update_user_missing_raises_404(self):
+        with patch("app.admin.service.crud_admin.update_user", return_value=None):
+            with pytest.raises(NotFoundError):
+                service.update_user(db=MagicMock(), current_user=_admin(), user_id=1, user_data={})
+
+    def test_cancel_task_missing_raises_404(self):
+        with patch("app.admin.service.crud_admin.cancel_task", return_value=False):
+            with pytest.raises(NotFoundError) as exc:
+                service.cancel_task(db=MagicMock(), current_user=_admin(), task_id=9)
+        assert exc.value.detail == "Task not found"
+
+
+# ---------------------------------------------------------------------------
+# plugin sync / container manager
+# ---------------------------------------------------------------------------
+
+class TestPluginSync:
+    def test_sync_status_success(self):
+        mgr = MagicMock()
+        mgr.get_sync_status.return_value = {"ok": True}
+        with patch("app.admin.service.PluginSyncManager", return_value=mgr):
+            out = service.get_plugin_sync_status(current_user=_admin())
+        assert out == {"ok": True}
+
+    def test_sync_status_failure_raises_external(self):
+        with patch("app.admin.service.PluginSyncManager", side_effect=RuntimeError("git down")):
+            with pytest.raises(ExternalServiceError) as exc:
+                service.get_plugin_sync_status(current_user=_admin())
+        assert exc.value.status_code == 500
+        assert "Failed to get sync status" in exc.value.detail
+
+    def test_container_status_success(self):
+        with patch("app.admin.service.container_manager") as cm:
+            cm.get_status.return_value = {"tracked_tasks": 0}
+            out = service.get_container_manager_status(current_user=_admin())
+        assert out == {"tracked_tasks": 0}
+
+
+# ---------------------------------------------------------------------------
+# system stats (Docker mocked)
+# ---------------------------------------------------------------------------
+
+class TestSystemStats:
+    def test_no_containers_returns_zeroed_stats(self):
+        client = MagicMock()
+        client.containers.list.return_value = []
+        with patch("app.admin.service.docker.DockerClient", return_value=client):
+            out = service.get_system_stats()
+        assert out["total_containers"] == 0
+        assert out["containers"] == []
+        client.close.assert_called_once()

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for the auth service layer (app/auth/service.py) extracted in PR-8.
+
+Scope: pin the login / token-issuance logic with the user crud + token boundary
+mocked. Credential failures raise ``ValidationFailedError`` (-> 400); the detail
+strings are frozen to match the auth characterization tests.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.core.exceptions import ValidationFailedError
+from app.auth import service
+
+
+def _form(username="a@b.com", password="pw"):
+    f = MagicMock()
+    f.username = username
+    f.password = password
+    return f
+
+
+class TestLogin:
+    def test_bad_credentials_raises_400(self):
+        with patch("app.auth.service.crud_user.authenticate", return_value=None):
+            with pytest.raises(ValidationFailedError) as exc:
+                service.login(db=MagicMock(), form_data=_form())
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Incorrect email or password"
+
+    def test_inactive_user_raises_400(self):
+        user = MagicMock()
+        with patch("app.auth.service.crud_user.authenticate", return_value=user), \
+                patch("app.auth.service.crud_user.is_active", return_value=False):
+            with pytest.raises(ValidationFailedError) as exc:
+                service.login(db=MagicMock(), form_data=_form())
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "please login to activate"
+
+    def test_success_returns_token_payload(self):
+        user = MagicMock()
+        user.id = 7
+        user.email = "a@b.com"
+        user.is_active = True
+        with patch("app.auth.service.crud_user.authenticate", return_value=user), \
+                patch("app.auth.service.crud_user.is_active", return_value=True), \
+                patch("app.auth.service.crud_user.is_superuser", return_value=False), \
+                patch("app.auth.service.create_access_token", return_value="tok"):
+            out = service.login(db=MagicMock(), form_data=_form())
+        assert set(out.keys()) == {"access_token", "token_type", "user_info"}
+        assert out["access_token"] == "tok"
+        assert out["token_type"] == "bearer"
+        assert out["user_info"] == {"is_superuser": False, "email": "a@b.com", "is_active": True}

--- a/backend/tests/unit/test_datatable_service.py
+++ b/backend/tests/unit/test_datatable_service.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for the datatable service layer (app/datatable/service.py) extracted
+in PR-8.
+
+Scope: pin the load/cache/format orchestration with the path resolver, cache,
+and ``RemoteDataTable`` engine mocked. The terminal catch-all raises
+``ValidationFailedError`` (-> 400) with ``str(e)`` as the detail — matching the
+router's previous ``HTTPException(400, str(e))`` behaviour exactly.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.core.exceptions import ValidationFailedError
+from app.datatable import service
+
+
+def _vgt(file_name="d.h5ad", source="local"):
+    v = MagicMock()
+    v.file_name = file_name
+    v.source = source
+    return v
+
+
+def _user(username="dtsvc"):
+    u = MagicMock()
+    u.username = username
+    return u
+
+
+class TestLoadData:
+    def test_resolver_failure_wraps_to_400(self):
+        with patch("app.file.path_resolver.resolve_data_file_path",
+                   side_effect=RuntimeError("bad source")):
+            with pytest.raises(ValidationFailedError) as exc:
+                service.load_data(vgt_info=_vgt(), current_user=_user())
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "bad source"
+
+    def test_success_returns_vgt_payload(self):
+        with patch("app.file.path_resolver.resolve_data_file_path", return_value="/p/f"), \
+                patch("app.datatable.cache.get_cached_dataframe", return_value=MagicMock()), \
+                patch("app.datatable.service.RemoteDataTable") as RT, \
+                patch("app.datatable.service.transform_df_to_vgt_format",
+                      return_value={"columns": ["c"], "rows": [{"c": 1}]}):
+            RT.return_value.get_filtered_sorted_paginated_data.return_value = {
+                "df": MagicMock(), "totalRecords": 5
+            }
+            out = service.load_data(vgt_info=_vgt(), current_user=_user())
+        assert out == {
+            "status": "success",
+            "columns": ["c"],
+            "rows": [{"c": 1}],
+            "totalRecords": 5,
+        }
+
+    def test_cache_miss_loads_and_caches(self):
+        with patch("app.file.path_resolver.resolve_data_file_path", return_value="/p/f"), \
+                patch("app.datatable.cache.get_cached_dataframe", return_value=None), \
+                patch("app.datatable.cache.set_cached_dataframe") as set_cache, \
+                patch("app.datatable.service.load_tab_file", return_value=MagicMock()), \
+                patch("app.datatable.service.RemoteDataTable") as RT, \
+                patch("app.datatable.service.transform_df_to_vgt_format",
+                      return_value={"columns": [], "rows": []}):
+            RT.return_value.get_filtered_sorted_paginated_data.return_value = {
+                "df": MagicMock(), "totalRecords": 0
+            }
+            service.load_data(vgt_info=_vgt(), current_user=_user())
+        set_cache.assert_called_once()

--- a/backend/tests/unit/test_file_service.py
+++ b/backend/tests/unit/test_file_service.py
@@ -1,0 +1,223 @@
+"""
+Unit tests for the file service layer (app/file/service.py) extracted in PR-8.
+
+Scope: pin the extracted business logic with the filesystem / crud / security
+boundaries mocked. The characterization + integration tests already pin the HTTP
+contract; these give the new service functions direct coverage and assert the
+domain-exception mapping (``ValidationFailedError`` -> 400, ``NotFoundError`` ->
+404) that the global handler renders as the unchanged ``{"detail": ...}`` body.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.core.exceptions import NotFoundError, ValidationFailedError
+from app.file import service
+
+
+def _user(username="filesvc", user_id=3):
+    u = MagicMock()
+    u.id = user_id
+    u.username = username
+    return u
+
+
+def _file_info(file_name="d.h5ad", source="local", anno_column="cell_type",
+               option_file_name="opt"):
+    fi = MagicMock()
+    fi.file_name = file_name
+    fi.source = source
+    fi.anno_column = anno_column
+    fi.option_file_name = option_file_name
+    return fi
+
+
+# ---------------------------------------------------------------------------
+# save_upload: validation branches (async)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSaveUpload:
+    async def test_too_many_files_raises_400(self):
+        db = MagicMock()
+        files = [MagicMock(), MagicMock(), MagicMock()]
+        with patch("app.core.config.MAX_FILES_PER_UPLOAD", 1):
+            with pytest.raises(ValidationFailedError) as exc:
+                await service.save_upload(db=db, files=files, current_user=_user())
+        assert exc.value.status_code == 400
+        assert "Too many files" in exc.value.detail
+
+    async def test_invalid_filename_format_raises_400(self):
+        db = MagicMock()
+        files = [MagicMock()]
+        with patch("app.core.config.MAX_FILES_PER_UPLOAD", 20), \
+                patch("app.file.service.os.makedirs"), \
+                patch("app.file.security.validate_file_upload", return_value="nounderscore.h5ad"):
+            with pytest.raises(ValidationFailedError) as exc:
+                await service.save_upload(db=db, files=files, current_user=_user())
+        assert exc.value.status_code == 400
+        assert "Invalid filename format" in exc.value.detail
+
+    async def test_duplicate_filename_raises_400(self):
+        db = MagicMock()
+        files = [MagicMock()]
+        with patch("app.core.config.MAX_FILES_PER_UPLOAD", 20), \
+                patch("app.file.service.os.makedirs"), \
+                patch("app.file.security.validate_file_upload", return_value="folder_dup.h5ad"), \
+                patch("app.file.service.crud_file.get_user_file", return_value=MagicMock()):
+            with pytest.raises(ValidationFailedError) as exc:
+                await service.save_upload(db=db, files=files, current_user=_user())
+        assert exc.value.status_code == 400
+        assert "already exists" in exc.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Simple lookup functions
+# ---------------------------------------------------------------------------
+
+class TestLookups:
+    def test_find_user_file_found(self):
+        db = MagicMock()
+        rec = MagicMock()
+        with patch("app.file.service.crud_file.get_user_file", return_value=rec):
+            assert service.find_user_file(db=db, current_user=_user(), file_info=_file_info()) is rec
+
+    def test_find_user_file_missing_raises_400(self):
+        db = MagicMock()
+        with patch("app.file.service.crud_file.get_user_file", return_value=None):
+            with pytest.raises(ValidationFailedError) as exc:
+                service.find_user_file(db=db, current_user=_user(), file_info=_file_info())
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "this file not exists in your files"
+
+    def test_find_user_folder_missing_raises_400(self):
+        db = MagicMock()
+        folder = MagicMock()
+        folder.folder_name = "nope"
+        with patch("app.file.service.crud_file.get_user_folder", return_value=None):
+            with pytest.raises(ValidationFailedError) as exc:
+                service.find_user_folder(db=db, current_user=_user(), folder=folder)
+        assert exc.value.detail == "this folder not exists in your folders"
+
+    def test_update_file_missing_raises_400(self):
+        db = MagicMock()
+        with patch("app.file.service.crud_file.get_user_file", return_value=None):
+            with pytest.raises(ValidationFailedError):
+                service.update_file(db=db, current_user=_user(), file_info=_file_info())
+
+    def test_read_user_folder_shapes_walk(self):
+        walk = [("./user/filesvc/data", [], ["a.h5ad", "b.csv"])]
+        with patch("app.file.service.os.walk", return_value=walk):
+            res = service.read_user_folder(current_user=_user())
+        assert res == [("data", ["a.h5ad", "b.csv"])]
+
+
+# ---------------------------------------------------------------------------
+# delete_file
+# ---------------------------------------------------------------------------
+
+class TestDeleteFile:
+    def test_missing_raises_400(self):
+        db = MagicMock()
+        with patch("app.file.service.crud_file.get_user_file", return_value=None):
+            with pytest.raises(ValidationFailedError) as exc:
+                service.delete_file(db=db, current_user=_user(), file_info=_file_info())
+        assert exc.value.detail == "this file not exists in your files"
+
+    def test_deletes_and_returns_crud_result(self):
+        db = MagicMock()
+        with patch("app.file.service.crud_file.get_user_file", return_value=MagicMock()), \
+                patch("app.file.security.validate_file_path"), \
+                patch("app.file.service.os.path.exists", return_value=False), \
+                patch("app.file.service.crud_file.delete_user_file", return_value="deleted"):
+            out = service.delete_file(db=db, current_user=_user(), file_info=_file_info())
+        assert out == "deleted"
+
+
+# ---------------------------------------------------------------------------
+# h5ad columns/clusters: ownership + not-found + cache
+# ---------------------------------------------------------------------------
+
+class TestH5adColumns:
+    def test_unowned_local_file_raises_400(self):
+        db = MagicMock()
+        with patch("app.file.service.crud_file.get_user_file", return_value=None):
+            with pytest.raises(ValidationFailedError):
+                service.get_h5ad_columns(db=db, current_user=_user(), file_info=_file_info(source="local"))
+
+    def test_missing_file_raises_404(self):
+        db = MagicMock()
+        with patch("app.file.path_resolver.resolve_data_file_path", return_value="/x/y.h5ad"), \
+                patch("app.file.service.os.path.isfile", return_value=False):
+            with pytest.raises(NotFoundError) as exc:
+                service.get_h5ad_columns(db=db, current_user=_user(), file_info=_file_info(source="shared"))
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "File not found"
+
+    def test_cache_hit_returns_cached(self):
+        db = MagicMock()
+        cached = {"anno_columns": ["a"], "pseudo_columns": []}
+        with patch("app.file.path_resolver.resolve_data_file_path", return_value="/x/y.h5ad"), \
+                patch("app.file.service.os.path.isfile", return_value=True), \
+                patch("app.file.service.get_cached_columns", return_value=cached):
+            out = service.get_h5ad_columns(db=db, current_user=_user(), file_info=_file_info(source="shared"))
+        assert out == cached
+
+    def test_clusters_cache_hit(self):
+        db = MagicMock()
+        with patch("app.file.path_resolver.resolve_data_file_path", return_value="/x/y.h5ad"), \
+                patch("app.file.service.os.path.isfile", return_value=True), \
+                patch("app.file.service.get_cached_clusters", return_value=["c1", "c2"]):
+            out = service.get_h5ad_clusters(db=db, current_user=_user(), file_info=_file_info(source="shared"))
+        assert out == {"clusters": ["c1", "c2"]}
+
+
+# ---------------------------------------------------------------------------
+# setup / result / shared / download helpers
+# ---------------------------------------------------------------------------
+
+class TestFileAccess:
+    def test_read_setup_missing_raises_404(self):
+        with patch("app.file.security.validate_file_path"), \
+                patch("app.file.service.os.path.exists", return_value=False):
+            with pytest.raises(NotFoundError) as exc:
+                service.read_setup_file(current_user=_user(), file_name="x.json")
+        assert exc.value.status_code == 404
+
+    def test_check_convert_missing_raises_400(self):
+        with patch("app.file.service.os.path.isfile", return_value=False):
+            with pytest.raises(ValidationFailedError):
+                service.check_convert(current_user=_user(), file_name="d.h5ad")
+
+    def test_download_result_missing_raises_404(self):
+        with patch("app.file.security.validate_file_path"), \
+                patch("app.file.service.os.path.exists", return_value=False):
+            with pytest.raises(NotFoundError):
+                service.download_result_file(current_user=_user(), filename="r.csv")
+
+    def test_download_tutorial_missing_raises_404(self):
+        with patch("app.file.security.validate_file_path"), \
+                patch("app.file.service.os.path.exists", return_value=False):
+            with pytest.raises(NotFoundError):
+                service.download_tutorial_file(current_user=_user(), filename="t.html")
+
+    def test_get_shared_files_no_dir_returns_empty(self):
+        with patch("app.file.service.os.path.isdir", return_value=False):
+            assert service.get_shared_files() == []
+
+    def test_find_shared_missing_raises_404(self):
+        with patch("app.file.security.validate_file_path"), \
+                patch("app.file.service.os.path.exists", return_value=False):
+            with pytest.raises(NotFoundError) as exc:
+                service.find_shared_file(file_info=_file_info())
+        assert exc.value.detail == "Shared file not found"
+
+
+@pytest.mark.asyncio
+class TestDownloadData:
+    async def test_missing_raises_400(self):
+        with patch("app.file.path_resolver.resolve_data_file_path", return_value="/x/y.csv"), \
+                patch("app.file.service.os.path.isfile", return_value=False):
+            with pytest.raises(ValidationFailedError) as exc:
+                await service.download_data_file(current_user=_user(), filename="y.csv", source=None)
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "this file not exists in your files"

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -18,6 +18,7 @@ from unittest.mock import patch, MagicMock
 
 from fastapi import HTTPException
 
+from app.core.exceptions import ValidationFailedError, ExternalServiceError
 from app.task import service
 from app.task import sse
 from app.task.schemas import TaskSubmission
@@ -188,7 +189,7 @@ class TestGetTaskStatusSimple:
         assert result == {"task_id": "abc", "status": "UNKNOWN"}
 
     def test_blank_task_id_raises_400(self):
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(ValidationFailedError) as exc:
             service.get_task_status_simple(task_id="   ")
         assert exc.value.status_code == 400
         assert exc.value.detail == "Invalid task_id"
@@ -205,7 +206,7 @@ class TestGetResources:
 
     def test_none_status_raises_503(self):
         with patch("app.shared.resources.get_resource_status", return_value=None):
-            with pytest.raises(HTTPException) as exc:
+            with pytest.raises(ExternalServiceError) as exc:
                 service.get_resources()
         assert exc.value.status_code == 503
         assert exc.value.detail == "Resource monitoring unavailable"

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for the user service layer (app/user/service.py) extracted in PR-8.
+
+Scope: pin the registration / profile-read / update logic with the user crud +
+filesystem boundary mocked. A duplicate-email signup raises
+``ValidationFailedError`` (-> 400) with the frozen detail string.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.core.exceptions import ValidationFailedError
+from app.user import service
+
+
+def _user_in(email="a@b.com", username="alice"):
+    u = MagicMock()
+    u.email = email
+    u.username = username
+    return u
+
+
+class TestRegister:
+    def test_duplicate_email_raises_400(self):
+        with patch("app.user.service.crud_user.get_user_by_email", return_value=MagicMock()):
+            with pytest.raises(ValidationFailedError) as exc:
+                service.register(db=MagicMock(), user_in=_user_in())
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Email already registered"
+
+    def test_success_creates_user_and_folder(self):
+        created = MagicMock()
+        with patch("app.user.service.crud_user.get_user_by_email", return_value=None), \
+                patch("app.user.service.crud_user.create_user", return_value=created), \
+                patch("app.user.service.os.makedirs") as mk:
+            out = service.register(db=MagicMock(), user_in=_user_in(username="bob"))
+        assert out is created
+        mk.assert_called_once_with("./user/bob/data", exist_ok=True)
+
+
+class TestProfile:
+    def test_read_me_shape(self):
+        cu = MagicMock()
+        cu.id, cu.email, cu.username, cu.is_superuser = 1, "a@b.com", "alice", False
+        out = service.read_me(current_user=cu)
+        assert out == {"id": 1, "email": "a@b.com", "username": "alice", "is_superuser": False}
+
+    def test_update_plugins_delegates_to_crud(self):
+        cu = MagicMock()
+        cu.id = 5
+        user_in = MagicMock()
+        with patch("app.user.service.crud_user.update_user", return_value="updated") as upd:
+            out = service.update_plugins(db=MagicMock(), current_user=cu, user_in=user_in)
+        assert out == "updated"
+        assert upd.call_args[1]["user_id"] == 5

--- a/backend/tests/unit/test_workflow_service.py
+++ b/backend/tests/unit/test_workflow_service.py
@@ -23,6 +23,7 @@ from unittest.mock import patch, MagicMock
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
+from app.core.exceptions import NotFoundError, PermissionDeniedError, ValidationFailedError
 from app.workflow import service
 from app.workflow.schemas import (
     WorkflowCreate, WorkflowResult, WorkflowVisualizationRequest,
@@ -448,7 +449,7 @@ class TestWorkflowCrud:
         user = _user()
         db = MagicMock()
         with patch("app.workflow.service.crud_workflow.get_user_workflow", return_value=None):
-            with pytest.raises(HTTPException) as exc:
+            with pytest.raises(ValidationFailedError) as exc:
                 service.find_workflow(db=db, user=user, workflow_id=42)
         assert exc.value.status_code == 400
         assert "not exists" in exc.value.detail
@@ -457,7 +458,7 @@ class TestWorkflowCrud:
         user = _user()
         db = MagicMock()
         with patch("app.workflow.service.crud_workflow.get_user_workflows", return_value=[]):
-            with pytest.raises(HTTPException) as exc:
+            with pytest.raises(ValidationFailedError) as exc:
                 service.list_workflows(db=db, user=user)
         assert exc.value.status_code == 400
 
@@ -465,7 +466,7 @@ class TestWorkflowCrud:
         user = _user()
         db = MagicMock()
         with patch("app.workflow.service.crud_workflow.get_user_workflow", return_value=None):
-            with pytest.raises(HTTPException) as exc:
+            with pytest.raises(ValidationFailedError) as exc:
                 service.delete_workflow(db=db, user=user, workflow_id=1)
         assert exc.value.status_code == 400
 
@@ -527,7 +528,7 @@ class TestNodeData:
         db = MagicMock()
         read = WorkflowNodeFileRead(id=9, node_id="n", node_name="x", file_extension="json")
         with patch("app.workflow.service.crud_workflow.get_user_workflow", return_value=None):
-            with pytest.raises(HTTPException) as exc:
+            with pytest.raises(ValidationFailedError) as exc:
                 service.read_node_data(db=db, user=user, node_file_info=read)
         assert exc.value.status_code == 400
 
@@ -539,7 +540,7 @@ class TestResultAccess:
         user = _user(username="resu")
         monkeypatch.chdir(tmp_path)
         wr = WorkflowResult(id=1, algorithm_id=1, filename=None)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(NotFoundError) as exc:
             service.get_results(user=user, workflow_result=wr)
         assert exc.value.status_code == 404
 
@@ -557,7 +558,7 @@ class TestResultAccess:
 
     def test_get_visualization_result_bad_file_raises_400(self):
         wr = WorkflowResult(id=1, algorithm_id=1, filename="/does/not/exist.json")
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(ValidationFailedError) as exc:
             service.get_visualization_result(workflow_result=wr)
         assert exc.value.status_code == 400
 
@@ -598,6 +599,6 @@ class TestResultAccess:
         wr = WorkflowResult(id=1, algorithm_id=1, filename="absent.json")
         # Avoid real sleeps during the retry loop.
         with patch("app.workflow.service.time.sleep"):
-            with pytest.raises(HTTPException) as exc:
+            with pytest.raises(ValidationFailedError) as exc:
                 service.check_visualization_result(user=user, workflow_result=wr)
         assert exc.value.status_code == 400

--- a/docs/refactoring/v1.0.7/phase-3-service-layer.md
+++ b/docs/refactoring/v1.0.7/phase-3-service-layer.md
@@ -112,42 +112,41 @@ def submit_task(*, db: Session, user: User, payload: ...) -> Task:
 ## PR-8: 나머지 도메인 + 전역 예외 처리 (`refactor/v107-08-remaining-services`)
 
 ### 1. 전역 예외 핸들러 (이 PR에서 도입 — 이후 전 도메인에 적용됨)
-- [ ] `core/exceptions.py`에 도메인 예외 계층 정의:
+- [x] `core/exceptions.py`에 도메인 예외 계층 정의 (기존 error_utils 유지, 계층만 추가):
 ```python
-class CellcraftError(Exception):
-    """도메인 예외 베이스"""
-class NotFoundError(CellcraftError): ...
-class PermissionDeniedError(CellcraftError): ...
-class ValidationFailedError(CellcraftError): ...
-class ExternalServiceError(CellcraftError): ...   # Docker/GitHub/Redis
+class CellcraftError(Exception):        # status_code=500, .detail 보유, status_code= 오버라이드 지원
+class NotFoundError(CellcraftError):        # 404
+class PermissionDeniedError(CellcraftError):  # 403
+class ValidationFailedError(CellcraftError):  # 400
+class ExternalServiceError(CellcraftError):   # 502 (Docker/GitHub/Redis), 500/503 오버라이드
 ```
-- [ ] `main.py`(create_app)에 `app.add_exception_handler(...)` 등록 — 기존 엔드포인트가 내던 상태코드·응답 형태와 동일하게 매핑
-- [ ] PR-5~7에서 추출한 서비스들의 HTTPException 잔재를 도메인 예외로 교체 (응답 불변 확인)
+- [x] `main.py`(create_app)에 `app.add_exception_handler(CellcraftError, ...)` 등록 — 핸들러가 `JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})`를 반환하여 FastAPI 기본 HTTPException 응답과 **바이트 단위 동일**. 422 RequestValidationError 등 기본 동작은 미변경 (CellcraftError 서브클래스에만 발동)
+- [x] PR-5~7 서비스 HTTPException → 도메인 예외 전환 (응답 불변 검증: characterization+contract 통과):
+  - **전환**: workflow(list/find/delete_workflow, get_results, save/read/delete_node_data, get_visualization_result, check_visualization_result), task(get_resources 503, get_task_status_simple 400). 모두 감싸는 swallow 가드가 없는 sentinel raise만 전환하고 관련 unit 테스트 예외 타입 갱신
+  - **유지(보고)**: `compile_workflow`/`_resolve_plugin_paths`(외곽 `except Exception→HTTPException(400,str(e))`가 상세를 재-문자열화 → 전환 시 본문 변형), `visualize_data`(CellCraftHTTPException 구조화 본문/`create_error_response`), plugin/service.py 전체(모든 raise가 `except HTTPException→raise / except Exception→500` 가드 체인 안 + 기존 unit이 HTTPException(500) 롤백을 단언), task/service.py의 로그/DAG/manifest 함수(`except HTTPException: raise` 가드 체인). 모두 "무리한 전환 금지"에 따라 HTTPException 유지 — 응답 불변 보장
 
 ### 2. file 서비스
-| 현재 | 이동 후 |
-|---|---|
-| `file/router.py` 598줄의 업로드/다운로드/삭제 인라인 로직 | `file/service.py` (`save_upload()`, `resolve_download()`, `delete_file()`) |
-| 경로 검증 산재 | `file/security.py` 호출을 service 경유로 일원화 |
+- [x] `file/router.py` 598줄 → 178줄 로직을 `file/service.py`로 (업로드/다운로드/삭제/컬럼/클러스터/setup/shared/tutorial). router 195줄 (≤300 목표 달성)
+- [x] `file/security.py`(validate_file_upload/validate_file_path) 호출을 service 경유로 일원화. path-traversal 거부는 security.py의 HTTPException 그대로 (FastAPI 기본 핸들러 처리, 응답 불변)
 
 ### 3. admin 서비스
-- [ ] `admin/router.py` 760줄 → 통계/사용자 관리/시스템 관리 로직을 `admin/service.py`로
-- [ ] 타 도메인 데이터 접근은 해당 도메인 service 경유 (admin이 crud 직접 접근하는 부분 정리)
+- [x] `admin/router.py` 760줄 → 314줄. 통계/사용자·파일·워크플로우·태스크·플러그인 관리, 시스템 통계(Docker), 플러그인 sync, 컨테이너 매니저 로직을 `admin/service.py`로. 반복되던 `is_superuser` 가드는 `_require_admin()`(PermissionDeniedError)로 일원화 (router 400 목표 달성)
+- [x] 타 도메인 데이터 접근 **보고**: `admin/crud.py`가 users/files/workflows/tasks/plugins 테이블을 직접 조회 (대시보드용). 이는 PR-8 이전부터 존재하며 도메인 경계 강화는 범위 밖 — 그대로 이동만 함 (계획의 "일단 그대로 옮기고 보고" 지침대로)
 
 ### 4. auth·user·datatable 서비스
-- [ ] `auth/service.py`: 로그인/토큰 발급 (`security.py` 활용), router는 OAuth2 폼 처리만
-- [ ] `user/service.py`: 가입/조회/수정
-- [ ] `datatable/service.py`: h5ad 조회·캐싱 오케스트레이션 (h5ad.py/cache.py 위임)
+- [x] `auth/service.py`: 로그인/토큰 발급. router는 OAuth2 폼 처리 + response_model만
+- [x] `user/service.py`: 가입/조회/수정. **보고**: register/me/plugins 3개 엔드포인트는 물리적으로 `auth/router.py`에 잔류 (다른 router로 이동 시 마운트 경로가 바뀌어 OpenAPI 스냅샷 계약 위반). 로직만 user/service.py로 추출
+- [x] `datatable/service.py`: h5ad 조회·캐싱 오케스트레이션. router 29줄 → 13줄 (utils 내부 미변경, service 경유로만 전환)
 
 ### 체크리스트
-- [ ] 전 도메인 router에서 `try/except + HTTPException` 반복 패턴 제거 (전역 핸들러로 대체)
-- [ ] 에러 응답 본문·상태코드 불변 (characterization + OpenAPI diff)
-- [ ] import-linter 계약 추가: `router는 crud를 직접 import하지 않는다` (가능한 도메인부터 단계 적용)
+- [x] 신규 5개 도메인(file/admin/auth/user/datatable) router의 `try/except + HTTPException` 반복 패턴 제거 (도메인 예외 + 전역 핸들러로 대체). PR-5~7 서비스는 위 §1 "유지" 항목대로 일부 잔존
+- [x] 에러 응답 본문·상태코드 불변 (characterization file/auth·task 통과 + contract OpenAPI diff 0)
+- [~] import-linter 계약 `router는 crud를 직접 import하지 않는다`: 신규 5개 router는 이미 crud 미import(service 경유). 단, plugin/workflow router는 아직 `crud`를 `# noqa: F401` 재-export(기존 테스트 patch 경로 호환용)로 보유 — 계약 활성화는 전 도메인 동시 충족이 필요하므로 후속 PR로 이관 (현 계약 2종 KEPT 유지, 신규 계약 미추가)
 
 ---
 
 ## Phase 3 완료 기준
-- [ ] 8개 router 파일 각각 500줄 이하
-- [ ] 모든 도메인에 `service.py` 존재, 신규 service 단위 테스트 커버리지 80%+
-- [ ] router에 남은 것: 파싱/deps/service 호출/응답 변환뿐
-- [ ] 공통 머지 게이트 4종 (PR별)
+- [x] 8개 router 파일 각각 500줄 이하 (file 195 · admin 314 · auth 53 · datatable 13 · plugin 301 · task 245 · workflow 177 · version 15)
+- [x] 모든 도메인에 `service.py` 존재 (plugin/workflow/task/file/admin/auth/user/datatable), 신규 service 단위 테스트 신규 작성 (test_{file,admin,auth,datatable,user}_service.py, 44건). 도메인 예외 매핑·검증 브랜치 커버
+- [x] router에 남은 것: 파싱/deps/service 호출/응답 변환뿐 (admin의 반복 superuser 가드는 service `_require_admin`로 이동)
+- [x] 공통 머지 게이트: 전체 테스트 실패 집합 baseline과 **완전 동일**(68 failed, 신규 regression 0·우발 수정 0), 신규 테스트 통과로 570 passed(=524+46), contract OpenAPI diff 0, import-linter 2 contracts KEPT


### PR DESCRIPTION
## refactor(v1.0.7): 나머지 도메인 서비스 + 전역 예외 핸들러 (PR-8)

**Phase**: 3d (Phase 3 완료) | **PR 번호**: PR-8 | **계획 문서**: docs/refactoring/v1.0.7/phase-3-service-layer.md
**선행 PR**: PR-7 (#117) — ⚠️ **스택 PR**: #111→#112→#113→#114→#115→#116→#117→PR-8 순차 머지.

### 범위
- **전역 예외 핸들러**: `core/exceptions.py`에 `CellcraftError` 도메인 예외 계층 (404/403/400/502) + create_app() 핸들러 등록 — `{"detail": ...}` 형태로 기존 HTTPException 응답과 동일, 422 등 FastAPI 기본 동작 미변경
- **file 서비스**: router 598줄 → 195줄, file/security.py 검증 경유 일원화
- **admin 서비스**: router 760줄 → 314줄, `_require_admin()` 가드 일원화
- **auth/user/datatable 서비스** 신설 (user 엔드포인트는 OpenAPI 계약 유지 위해 auth/router 물리 잔류, 로직만 추출)
- **PR-5~7 서비스 예외 부분 전환**: swallow 가드 없는 sentinel raise만 도메인 예외로 전환. 재-문자열화(`except Exception→HTTPException(400,str(e))`)·구조화 본문 케이스는 응답 불변 원칙에 따라 HTTPException 유지 — 전환/유지 상세 목록은 phase-3 문서 §PR-8-1 참조
- 신규 단위 테스트 46건

### Phase 3 완료 지표
전 router 500줄 이하: file 195 · admin 314 · auth 53 · datatable 13 · plugin 301 · task 245 · workflow 177 · version 15. 전 도메인 service.py 보유.

### 후속 이관 항목
- `router는 crud 직접 import 금지` linter 계약: plugin/workflow router의 테스트 호환용 re-export 잔존으로 미활성화 (후속 PR)

### 머지 게이트 결과
| 게이트 | 결과 |
|---|---|
| 1. pytest 전체 | ✅ **570 passed** / 68 failed — baseline과 실패 집합 완전 동일 (diff empty) |
| 2. OpenAPI 스냅샷 | ✅ diff 0 (30건 통과) |
| 3. alembic | ✅ 스키마 변경 없음 |
| 4. 워커 스모크 | ✅ 태스크 이름 불변 + app.main 미유입 |
| import-linter | ✅ 2 kept, 0 broken |

### 롤백
`git revert` (DB 변경 없음)