### PR TITLE
fix(task): revoke_task 소유권 검사 추가 (cross-user 작업 강제종료 차단)

### DIFF
--- a/backend/app/task/service.py
+++ b/backend/app/task/service.py
@@ -131,6 +131,14 @@ def get_task_monitoring(*, db: Session, current_user: models.User) -> List[TaskM
 
 def revoke_task(*, db: Session, current_user: models.User, task_id: str) -> dict:
     """Revoke a Celery task and clean up its containers + results folder."""
+    # 권한 확인: 본인 소유 task만 revoke 가능 (형제 엔드포인트 get_dag_structure/get_rule_status와 동일 패턴).
+    # 누락 시 인증된 사용자가 타인 task_id로 실행중 작업을 SIGTERM/컨테이너 강제종료 가능 (A01 BAC).
+    task_record = crud_task.get_task_by_task_id(db, task_id)
+    if not task_record:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if task_record.user_id != current_user.id:
+        logger.warning(f"Access denied for user {current_user.id} to revoke task {task_id}")
+        raise HTTPException(status_code=403, detail="Access denied")
     try:
         # 지연 import 유지 (사유): 테스트 patch 호환(`app.task.service.get_celery_app`가
         # 아닌 호출부 재바인딩 방식) + worker가 task.service를 import 해도 web 계층


### PR DESCRIPTION
## 요약
`revoke_task()`(`app/task/service.py:132`)는 `current_user`를 받지만 **소유권 검사에 사용하지 않아**, 인증된 사용자가 타인의 `task_id`를 알면 그 사람의 실행중 Celery 작업을 `SIGTERM`/컨테이너 강제종료할 수 있었습니다 (A01 Broken Access Control). 형제 엔드포인트(`get_dag_structure`/`get_rule_status`, `service.py:555-557`)와 동일한 404/403 가드를 추가합니다.

## 성격
- **기존 결함** — 리팩토링(#111~120)이 도입한 것이 아니며, baseline 68 실패 목록의 `test_revoke_unauthorized_user`(403 기대)로 이미 잡혀 있던 항목입니다.
- v1.0.7 홀리스틱 릴리즈 리뷰에서 baseline-68 분류 중 표면화 → 릴리즈 전 핫픽스.

## 변경
`backend/app/task/service.py` +8줄 — revoke 실행 전 소유권 가드:
```python
task_record = crud_task.get_task_by_task_id(db, task_id)
if not task_record:
    raise HTTPException(status_code=404, detail="Task not found")
if task_record.user_id != current_user.id:
    raise HTTPException(status_code=403, detail="Access denied")
```

## 검증 (TEST_DB_PORT=5544 격리 스택)
- ✅ 전체 pytest: **578 passed / 66 failed** — baseline(68) 대비 `test_revoke_unauthorized_user`(→403) + `test_revoke_nonexistent_task`(→404) 2건 해소, **신규 리그레션 0**
- ✅ contract: 1 passed — **OpenAPI 스냅샷 불변**(런타임 403/404 분기라 계약 영향 없음)
- ✅ 스코프: 1파일 8줄

## Test plan
- [x] `TestTaskRevocation::test_revoke_unauthorized_user` → 403
- [x] `TestTaskRevocation::test_revoke_nonexistent_task` → 404
- [x] 전체 스위트 실패집합 = baseline − 2, 신규 0
- [x] contract(OpenAPI) 불변
